### PR TITLE
feat: add task inbox with Convex backend

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as auth from "../auth.js";
 import type * as http from "../http.js";
+import type * as tasks from "../tasks.js";
 
 import type {
   ApiFromModules,
@@ -20,6 +21,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   http: typeof http;
+  tasks: typeof tasks;
 }>;
 
 /**

--- a/convex/_generated/dataModel.d.ts
+++ b/convex/_generated/dataModel.d.ts
@@ -8,29 +8,29 @@
  * @module
  */
 
-import { AnyDataModel } from "convex/server";
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
 import type { GenericId } from "convex/values";
-
-/**
- * No `schema.ts` file found!
- *
- * This generated code has permissive types like `Doc = any` because
- * Convex doesn't know your schema. If you'd like more type safety, see
- * https://docs.convex.dev/using/schemas for instructions on how to add a
- * schema file.
- *
- * After you change a schema, rerun codegen with `npx convex dev`.
- */
+import schema from "../schema.js";
 
 /**
  * The names of all of your Convex tables.
  */
-export type TableNames = string;
+export type TableNames = TableNamesInDataModel<DataModel>;
 
 /**
  * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
  */
-export type Doc = any;
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
 
 /**
  * An identifier for a document in Convex.
@@ -42,8 +42,10 @@ export type Doc = any;
  *
  * IDs are just strings at runtime, but this type can be used to distinguish them from other
  * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
  */
-export type Id<TableName extends TableNames = TableNames> =
+export type Id<TableName extends TableNames | SystemTableNames> =
   GenericId<TableName>;
 
 /**
@@ -55,4 +57,4 @@ export type Id<TableName extends TableNames = TableNames> =
  * This type is used to parameterize methods like `queryGeneric` and
  * `mutationGeneric` to make them type-safe.
  */
-export type DataModel = AnyDataModel;
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -12,7 +12,6 @@ export const authComponent = createClient<DataModel>(components.betterAuth);
 
 export const createAuth = (ctx: GenericCtx<DataModel>) => {
   return betterAuth({
-    baseURL: siteUrl,
     trustedOrigins: [siteUrl],
     database: authComponent.adapter(ctx),
     emailAndPassword: {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,0 +1,15 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  tasks: defineTable({
+    userId: v.string(),
+    title: v.string(),
+    isCompleted: v.boolean(),
+    dueDate: v.optional(v.number()),
+    order: v.number(),
+    createdAt: v.number(),
+  })
+    .index("by_user", ["userId"])
+    .index("by_user_order", ["userId", "order"]),
+});

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -1,0 +1,89 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { authComponent } from "./auth";
+
+export const list = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+    if (!user) return [];
+    const userId = String(user._id);
+    return ctx.db
+      .query("tasks")
+      .withIndex("by_user_order", (q) => q.eq("userId", userId))
+      .collect();
+  },
+});
+
+export const create = mutation({
+  args: {
+    title: v.string(),
+    dueDate: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const user = await authComponent.getAuthUser(ctx);
+    const userId = String(user._id);
+
+    const existing = await ctx.db
+      .query("tasks")
+      .withIndex("by_user_order", (q) => q.eq("userId", userId))
+      .order("desc")
+      .first();
+
+    const nextOrder = existing ? existing.order + 1 : 0;
+
+    return ctx.db.insert("tasks", {
+      userId,
+      title: args.title,
+      isCompleted: false,
+      dueDate: args.dueDate,
+      order: nextOrder,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+export const update = mutation({
+  args: {
+    id: v.id("tasks"),
+    title: v.optional(v.string()),
+    isCompleted: v.optional(v.boolean()),
+    dueDate: v.optional(v.number()),
+    clearDueDate: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const user = await authComponent.getAuthUser(ctx);
+    const userId = String(user._id);
+
+    const task = await ctx.db.get(args.id);
+    if (!task || task.userId !== userId) {
+      throw new Error("Task not found");
+    }
+
+    const updates: Record<string, unknown> = {};
+    if (args.title !== undefined) updates.title = args.title;
+    if (args.isCompleted !== undefined) updates.isCompleted = args.isCompleted;
+    if (args.clearDueDate) {
+      updates.dueDate = undefined;
+    } else if (args.dueDate !== undefined) {
+      updates.dueDate = args.dueDate;
+    }
+
+    await ctx.db.patch(args.id, updates);
+  },
+});
+
+export const remove = mutation({
+  args: { id: v.id("tasks") },
+  handler: async (ctx, args) => {
+    const user = await authComponent.getAuthUser(ctx);
+    const userId = String(user._id);
+
+    const task = await ctx.db.get(args.id);
+    if (!task || task.userId !== userId) {
+      throw new Error("Task not found");
+    }
+
+    await ctx.db.delete(args.id);
+  },
+});

--- a/src/components/auth/auth-verifying-loader.tsx
+++ b/src/components/auth/auth-verifying-loader.tsx
@@ -3,7 +3,9 @@ export function AuthVerifyingLoader() {
     <div className="flex min-h-screen items-center justify-center">
       <div className="flex flex-col items-center gap-3">
         <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-foreground" />
-        <p className="text-sm text-muted-foreground">Checking your session...</p>
+        <p className="text-sm text-muted-foreground">
+          Checking your session...
+        </p>
       </div>
     </div>
   );

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,0 +1,217 @@
+import {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from "lucide-react";
+import * as React from "react";
+import {
+  type DayButton,
+  DayPicker,
+  getDefaultClassNames,
+} from "react-day-picker";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  captionLayout = "label",
+  buttonVariant = "ghost",
+  formatters,
+  components,
+  ...props
+}: React.ComponentProps<typeof DayPicker> & {
+  buttonVariant?: React.ComponentProps<typeof Button>["variant"];
+}) {
+  const defaultClassNames = getDefaultClassNames();
+
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn(
+        "bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
+        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
+        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+        className,
+      )}
+      captionLayout={captionLayout}
+      formatters={{
+        formatMonthDropdown: (date) =>
+          date.toLocaleString("default", { month: "short" }),
+        ...formatters,
+      }}
+      classNames={{
+        root: cn("w-fit", defaultClassNames.root),
+        months: cn(
+          "flex gap-4 flex-col md:flex-row relative",
+          defaultClassNames.months,
+        ),
+        month: cn("flex flex-col w-full gap-4", defaultClassNames.month),
+        nav: cn(
+          "flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between",
+          defaultClassNames.nav,
+        ),
+        button_previous: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
+          defaultClassNames.button_previous,
+        ),
+        button_next: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
+          defaultClassNames.button_next,
+        ),
+        month_caption: cn(
+          "flex items-center justify-center h-(--cell-size) w-full px-(--cell-size)",
+          defaultClassNames.month_caption,
+        ),
+        dropdowns: cn(
+          "w-full flex items-center text-sm font-medium justify-center h-(--cell-size) gap-1.5",
+          defaultClassNames.dropdowns,
+        ),
+        dropdown_root: cn(
+          "relative has-focus:border-ring border border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] rounded-md",
+          defaultClassNames.dropdown_root,
+        ),
+        dropdown: cn(
+          "absolute bg-popover inset-0 opacity-0",
+          defaultClassNames.dropdown,
+        ),
+        caption_label: cn(
+          "select-none font-medium",
+          captionLayout === "label"
+            ? "text-sm"
+            : "rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5",
+          defaultClassNames.caption_label,
+        ),
+        table: "w-full border-collapse",
+        weekdays: cn("flex", defaultClassNames.weekdays),
+        weekday: cn(
+          "text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none",
+          defaultClassNames.weekday,
+        ),
+        week: cn("flex w-full mt-2", defaultClassNames.week),
+        week_number_header: cn(
+          "select-none w-(--cell-size)",
+          defaultClassNames.week_number_header,
+        ),
+        week_number: cn(
+          "text-[0.8rem] select-none text-muted-foreground",
+          defaultClassNames.week_number,
+        ),
+        day: cn(
+          "relative w-full h-full p-0 text-center [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none",
+          props.showWeekNumber
+            ? "[&:nth-child(2)[data-selected=true]_button]:rounded-l-md"
+            : "[&:first-child[data-selected=true]_button]:rounded-l-md",
+          defaultClassNames.day,
+        ),
+        range_start: cn(
+          "rounded-l-md bg-accent",
+          defaultClassNames.range_start,
+        ),
+        range_middle: cn("rounded-none", defaultClassNames.range_middle),
+        range_end: cn("rounded-r-md bg-accent", defaultClassNames.range_end),
+        today: cn(
+          "bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none",
+          defaultClassNames.today,
+        ),
+        outside: cn(
+          "text-muted-foreground aria-selected:text-muted-foreground",
+          defaultClassNames.outside,
+        ),
+        disabled: cn(
+          "text-muted-foreground opacity-50",
+          defaultClassNames.disabled,
+        ),
+        hidden: cn("invisible", defaultClassNames.hidden),
+        ...classNames,
+      }}
+      components={{
+        Root: ({ className, rootRef, ...props }) => {
+          return (
+            <div
+              data-slot="calendar"
+              ref={rootRef}
+              className={cn(className)}
+              {...props}
+            />
+          );
+        },
+        Chevron: ({ className, orientation, ...props }) => {
+          if (orientation === "left") {
+            return (
+              <ChevronLeftIcon className={cn("size-4", className)} {...props} />
+            );
+          }
+
+          if (orientation === "right") {
+            return (
+              <ChevronRightIcon
+                className={cn("size-4", className)}
+                {...props}
+              />
+            );
+          }
+
+          return (
+            <ChevronDownIcon className={cn("size-4", className)} {...props} />
+          );
+        },
+        DayButton: CalendarDayButton,
+        WeekNumber: ({ children, ...props }) => {
+          return (
+            <td {...props}>
+              <div className="flex size-(--cell-size) items-center justify-center text-center">
+                {children}
+              </div>
+            </td>
+          );
+        },
+        ...components,
+      }}
+      {...props}
+    />
+  );
+}
+
+function CalendarDayButton({
+  className,
+  day,
+  modifiers,
+  ...props
+}: React.ComponentProps<typeof DayButton>) {
+  const defaultClassNames = getDefaultClassNames();
+
+  const ref = React.useRef<HTMLButtonElement>(null);
+  React.useEffect(() => {
+    if (modifiers.focused) ref.current?.focus();
+  }, [modifiers.focused]);
+
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon"
+      data-day={day.date.toLocaleDateString()}
+      data-selected-single={
+        modifiers.selected &&
+        !modifiers.range_start &&
+        !modifiers.range_end &&
+        !modifiers.range_middle
+      }
+      data-range-start={modifiers.range_start}
+      data-range-end={modifiers.range_end}
+      data-range-middle={modifiers.range_middle}
+      className={cn(
+        "data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-accent-foreground flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md [&>span]:text-xs [&>span]:opacity-70",
+        defaultClassNames.day,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Calendar, CalendarDayButton };

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import { CheckIcon } from "lucide-react";
+import { Checkbox as CheckboxPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Popover as PopoverPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+};

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,26 @@
+import { Separator as SeparatorPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/src/routes/_authenticated/index.tsx
+++ b/src/routes/_authenticated/index.tsx
@@ -1,40 +1,263 @@
+import { api } from "@convex/_generated/api";
+import type { Doc } from "@convex/_generated/dataModel";
 import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery } from "convex/react";
+import { format, isToday, isTomorrow } from "date-fns";
+import { Calendar as CalendarIcon, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { authClient } from "@/lib/auth-client";
+import { Calendar } from "@/components/ui/calendar";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
 
 export const Route = createFileRoute("/_authenticated/")({
-  component: Index,
+  component: Inbox,
 });
 
-function Index() {
-  const { data: session } = authClient.useSession();
+function Inbox() {
+  const tasks = useQuery(api.tasks.list);
+  const isLoading = tasks === undefined;
 
-  const handleSignOut = async () => {
-    await authClient.signOut();
-  };
+  const activeTasks = tasks?.filter((t) => !t.isCompleted) ?? [];
+  const completedTasks = tasks?.filter((t) => t.isCompleted) ?? [];
+
+  if (isLoading) {
+    return <InboxSkeleton />;
+  }
 
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <Card className="w-full max-w-md">
-        <CardHeader>
-          <CardTitle>Welcome to vita-os</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {session?.user && (
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground">Signed in as</p>
-              <p className="font-medium">{session.user.name}</p>
-              <p className="text-sm text-muted-foreground">
-                {session.user.email}
-              </p>
-            </div>
-          )}
-          <Button variant="outline" className="w-full" onClick={handleSignOut}>
-            Sign Out
-          </Button>
-        </CardContent>
-      </Card>
+    <div>
+      <h1 className="mb-4 text-2xl font-bold">Inbox</h1>
+      <div>
+        {activeTasks.map((task) => (
+          <TaskRow key={task._id} task={task} />
+        ))}
+        <AddTaskRow />
+        {completedTasks.length > 0 && (
+          <CompletedSection tasks={completedTasks} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TaskRow({ task }: { task: Doc<"tasks"> }) {
+  const updateTask = useMutation(api.tasks.update);
+  const removeTask = useMutation(api.tasks.remove);
+
+  return (
+    <>
+      <div className="group flex items-start gap-3 py-3">
+        <Checkbox
+          checked={task.isCompleted}
+          onCheckedChange={(checked) =>
+            updateTask({
+              id: task._id,
+              isCompleted: checked === true,
+            })
+          }
+          className="mt-0.5 rounded-full"
+        />
+        <div className="min-w-0 flex-1">
+          <span
+            className={
+              task.isCompleted ? "line-through text-muted-foreground" : ""
+            }
+          >
+            {task.title}
+          </span>
+          {task.dueDate && <DueDateLabel timestamp={task.dueDate} />}
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 opacity-0 transition-opacity group-hover:opacity-100"
+          onClick={() => removeTask({ id: task._id })}
+          aria-label="Delete task"
+        >
+          <Trash2 className="h-4 w-4 text-muted-foreground" />
+        </Button>
+      </div>
+      <Separator />
+    </>
+  );
+}
+
+function DueDateLabel({ timestamp }: { timestamp: number }) {
+  const date = new Date(timestamp);
+  let label: string;
+  let className = "text-xs text-muted-foreground";
+
+  if (isToday(date)) {
+    label = "Today";
+    className = "text-xs text-green-600";
+  } else if (isTomorrow(date)) {
+    label = "Tomorrow";
+    className = "text-xs text-orange-600";
+  } else if (date < new Date()) {
+    label = format(date, "MMM d");
+    className = "text-xs text-red-600";
+  } else {
+    label = format(date, "MMM d");
+  }
+
+  return (
+    <div className="mt-0.5 flex items-center gap-1">
+      <CalendarIcon className="h-3 w-3" />
+      <span className={className}>{label}</span>
+    </div>
+  );
+}
+
+function AddTaskRow() {
+  const [isAdding, setIsAdding] = useState(false);
+  const [title, setTitle] = useState("");
+  const [dueDate, setDueDate] = useState<Date | undefined>();
+  const createTask = useMutation(api.tasks.create);
+
+  const handleSubmit = async () => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+
+    await createTask({
+      title: trimmed,
+      dueDate: dueDate?.getTime(),
+    });
+
+    setTitle("");
+    setDueDate(undefined);
+    setIsAdding(false);
+  };
+
+  const handleCancel = () => {
+    setTitle("");
+    setDueDate(undefined);
+    setIsAdding(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSubmit();
+    } else if (e.key === "Escape") {
+      handleCancel();
+    }
+  };
+
+  if (!isAdding) {
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => setIsAdding(true)}
+          className="flex w-full items-center gap-3 py-3 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <Plus className="h-4 w-4" />
+          <span>Add task</span>
+        </button>
+        <Separator />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-3 py-3">
+        <input
+          // biome-ignore lint/a11y/noAutofocus: intentional for inline task form
+          autoFocus
+          type="text"
+          placeholder="Task name"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+        />
+        <div className="flex items-center justify-between">
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5 text-xs"
+              >
+                <CalendarIcon className="h-3 w-3" />
+                {dueDate ? format(dueDate, "MMM d") : "Due date"}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="start">
+              <Calendar
+                mode="single"
+                selected={dueDate}
+                onSelect={setDueDate}
+              />
+            </PopoverContent>
+          </Popover>
+          <div className="flex gap-2">
+            <Button variant="ghost" size="sm" onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button size="sm" onClick={handleSubmit} disabled={!title.trim()}>
+              Add task
+            </Button>
+          </div>
+        </div>
+      </div>
+      <Separator />
+    </>
+  );
+}
+
+function CompletedSection({ tasks }: { tasks: Doc<"tasks">[] }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="mt-4">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <span
+          className="inline-block transition-transform"
+          style={{
+            transform: isOpen ? "rotate(90deg)" : "rotate(0deg)",
+          }}
+        >
+          &#9656;
+        </span>
+        Completed ({tasks.length})
+      </button>
+      {isOpen && (
+        <div className="mt-2">
+          {tasks.map((task) => (
+            <TaskRow key={task._id} task={task} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InboxSkeleton() {
+  return (
+    <div>
+      <div className="mb-4 h-8 w-20 animate-pulse rounded bg-muted" />
+      {Array.from({ length: 3 }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
+        <div key={i}>
+          <div className="flex items-center gap-3 py-3">
+            <div className="h-4 w-4 animate-pulse rounded-full bg-muted" />
+            <div className="h-4 flex-1 animate-pulse rounded bg-muted" />
+          </div>
+          <Separator />
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/routes/_authenticated/route.tsx
+++ b/src/routes/_authenticated/route.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute, Navigate, Outlet } from "@tanstack/react-router";
 import { useConvexAuth } from "convex/react";
+import { LogOut } from "lucide-react";
 import { AuthVerifyingLoader } from "@/components/auth/auth-verifying-loader";
+import { Button } from "@/components/ui/button";
+import { authClient } from "@/lib/auth-client";
 
 export const Route = createFileRoute("/_authenticated")({
   component: AuthenticatedLayout,
@@ -17,5 +20,43 @@ function AuthenticatedLayout() {
     return <Navigate to="/sign-in" />;
   }
 
-  return <Outlet />;
+  return (
+    <div className="min-h-screen">
+      <AppHeader />
+      <main className="mx-auto max-w-3xl px-4 py-8">
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+
+function AppHeader() {
+  const { data: session } = authClient.useSession();
+
+  const handleSignOut = async () => {
+    await authClient.signOut();
+  };
+
+  return (
+    <header className="border-b">
+      <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-3">
+        <span className="text-lg font-semibold">vita-os</span>
+        <div className="flex items-center gap-3">
+          {session?.user?.email && (
+            <span className="text-sm text-muted-foreground">
+              {session.user.email}
+            </span>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleSignOut}
+            aria-label="Sign out"
+          >
+            <LogOut className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
 }

--- a/src/routes/_unauthenticated/sign-in.tsx
+++ b/src/routes/_unauthenticated/sign-in.tsx
@@ -45,7 +45,6 @@ function SignIn() {
   const handleGitHub = async () => {
     await authClient.signIn.social({
       provider: "github",
-      callbackURL: "/",
     });
   };
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "node"],
     "skipLibCheck": true,
 
     /* Bundler mode */
@@ -27,7 +27,8 @@
     /* Path aliases */
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@convex/*": ["./convex/*"]
     }
   },
   "include": ["src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@convex/*": ["./convex/*"]
     }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": "/src",
+      "@convex": "/convex",
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- Add tasks table schema and auth-gated CRUD functions (list, create, update, remove) in Convex
- Replace welcome card with inbox UI: inline task creation, due date picker, completion toggling, delete on hover, collapsible completed section
- Add app header with user email and sign-out to the authenticated layout
- Fix GitHub OAuth redirect_uri mismatch by removing explicit `baseURL` from Better Auth server config

## Test plan
- [ ] Sign in with email/password and verify inbox loads
- [ ] Sign in with GitHub OAuth and verify redirect works
- [ ] Create a task via the inline form
- [ ] Toggle a task as completed and verify it moves to completed section
- [ ] Add a due date to a task and verify label shows Today/Tomorrow/date
- [ ] Delete a task via the hover trash icon
- [ ] Sign out via the header button