### PR TITLE
feat(tasks): add optional description field

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -5,6 +5,7 @@ export default defineSchema({
   tasks: defineTable({
     userId: v.string(),
     title: v.string(),
+    description: v.optional(v.string()),
     isCompleted: v.boolean(),
     dueDate: v.optional(v.number()),
     order: v.number(),

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -18,6 +18,7 @@ export const list = query({
 export const create = mutation({
   args: {
     title: v.string(),
+    description: v.optional(v.string()),
     dueDate: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
@@ -35,6 +36,7 @@ export const create = mutation({
     return ctx.db.insert("tasks", {
       userId,
       title: args.title,
+      description: args.description,
       isCompleted: false,
       dueDate: args.dueDate,
       order: nextOrder,
@@ -47,6 +49,8 @@ export const update = mutation({
   args: {
     id: v.id("tasks"),
     title: v.optional(v.string()),
+    description: v.optional(v.string()),
+    clearDescription: v.optional(v.boolean()),
     isCompleted: v.optional(v.boolean()),
     dueDate: v.optional(v.number()),
     clearDueDate: v.optional(v.boolean()),
@@ -63,6 +67,11 @@ export const update = mutation({
     const updates: Record<string, unknown> = {};
     if (args.title !== undefined) updates.title = args.title;
     if (args.isCompleted !== undefined) updates.isCompleted = args.isCompleted;
+    if (args.clearDescription) {
+      updates.description = undefined;
+    } else if (args.description !== undefined) {
+      updates.description = args.description;
+    }
     if (args.clearDueDate) {
       updates.dueDate = undefined;
     } else if (args.dueDate !== undefined) {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "cursor-pointer inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/src/routes/_authenticated/index.tsx
+++ b/src/routes/_authenticated/index.tsx
@@ -97,6 +97,11 @@ function TaskRow({ task }: { task: Doc<"tasks"> }) {
           >
             {task.title}
           </span>
+          {task.description && (
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+              {task.description}
+            </p>
+          )}
           {task.dueDate && <DueDateLabel timestamp={task.dueDate} />}
         </div>
         <Button
@@ -143,6 +148,7 @@ function DueDateLabel({ timestamp }: { timestamp: number }) {
 function AddTaskRow() {
   const [isAdding, setIsAdding] = useState(false);
   const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
   const [dueDate, setDueDate] = useState<Date | undefined>();
   const createTask = useMutation(api.tasks.create).withOptimisticUpdate(
     (localStore, args) => {
@@ -156,6 +162,7 @@ function AddTaskRow() {
           _creationTime: Date.now(),
           userId: "",
           title: args.title,
+          description: args.description,
           isCompleted: false,
           dueDate: args.dueDate,
           order: maxOrder + 1,
@@ -169,14 +176,21 @@ function AddTaskRow() {
     const trimmed = title.trim();
     if (!trimmed) return;
 
-    createTask({ title: trimmed, dueDate: dueDate?.getTime() });
+    const trimmedDesc = description.trim();
+    createTask({
+      title: trimmed,
+      description: trimmedDesc || undefined,
+      dueDate: dueDate?.getTime(),
+    });
     setTitle("");
+    setDescription("");
     setDueDate(undefined);
     setIsAdding(false);
   };
 
   const handleCancel = () => {
     setTitle("");
+    setDescription("");
     setDueDate(undefined);
     setIsAdding(false);
   };
@@ -218,6 +232,13 @@ function AddTaskRow() {
           onChange={(e) => setTitle(e.target.value)}
           onKeyDown={handleKeyDown}
           className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+        />
+        <textarea
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={2}
+          className="w-full resize-none bg-transparent text-xs text-muted-foreground outline-none placeholder:text-muted-foreground"
         />
         <div className="flex items-center justify-between">
           <Popover>


### PR DESCRIPTION
## Summary
- Add optional `description` field to tasks schema and backend mutations (create/update with clear support)
- Display task descriptions as truncated single-line muted text below the title
- Add description textarea to the add-task form with optimistic update support

## Test plan
- [x] Create a task with a description — verify it appears truncated below the title
- [x] Create a task without a description — verify it works as before
- [x] Create a task with a long description — verify it truncates to one line with ellipsis
- [x] Verify `bun run lint` and `bun run build` pass