### PR TITLE
feat(projects): add projects with task grouping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,16 +33,23 @@ Convex: `bunx convex dev` to start the Convex dev server (syncs functions and sc
 
 ## Architecture
 
-**Frontend** (Vite + React 19 + TypeScript 5.9):
+**Frontend** (Vite 7 + React 19 + TypeScript 5.9):
 - `src/main.tsx` — Entry point. `ConvexBetterAuthProvider` wraps `RouterProvider`.
-- `src/routes/` — TanStack Router file-based routing. `__root.tsx` is the root layout; add pages by creating new files here. The route tree is auto-generated at `src/routeTree.gen.ts` (gitignored).
+- `src/routes/` — TanStack Router file-based routing with layout-based route groups:
+  - `__root.tsx` — Root layout with devtools.
+  - `_authenticated/` — Protected routes (redirects to `/sign-in` if not authenticated). Contains `route.tsx` (layout with header) and `index.tsx` (Inbox/tasks page).
+  - `_unauthenticated/` — Public routes. Contains `route.tsx` (layout), `sign-in.tsx`, `sign-up.tsx`.
+  - Route tree auto-generated at `src/routeTree.gen.ts` (gitignored).
 - `src/components/ui/` — shadcn/ui components (added via CLI, not hand-written).
+- `src/components/auth/` — Auth-related components (e.g. loading spinner).
 - `src/lib/utils.ts` — `cn()` helper for Tailwind class merging.
 - `src/lib/auth-client.ts` — Better Auth client (signIn, signUp, signOut, useSession).
 - `src/index.css` — Tailwind v4 imports + shadcn CSS variables (light/dark themes).
+- React Compiler enabled via `babel-plugin-react-compiler` in `vite.config.ts`.
 
 **Backend** (Convex):
-- `convex/` — Convex functions (queries, mutations, actions). Files here deploy as serverless functions.
+- `convex/schema.ts` — Database schema. Currently defines `tasks` table (title, description, isCompleted, dueDate, order, createdAt, userId).
+- `convex/tasks.ts` — Task CRUD: `list` query, `create`/`update`/`remove` mutations with auth checks and optimistic update support on the frontend.
 - `convex/auth.ts` — Better Auth server config. Exports `authComponent`, `createAuth`, `getCurrentUser`.
 - `convex/http.ts` — HTTP router with auth routes.
 - `convex/convex.config.ts` — Convex app config registering the Better Auth component.
@@ -52,14 +59,15 @@ Convex: `bunx convex dev` to start the Convex dev server (syncs functions and sc
 ## Code Style
 
 Biome handles all linting and formatting. Key settings:
-- **Tabs** for indentation, **double quotes**, line width **80**
+- **Spaces** for indentation, **double quotes**, line width **80**
 - Organize imports enabled
-- `routeTree.gen.ts` is excluded from linting
+- `routeTree.gen.ts` and `convex/_generated` are excluded from linting
 
 ## Vite Plugin Order
 
 In `vite.config.ts`, the TanStack Router plugin **must** come before the React plugin.
 
-## Path Alias
+## Path Aliases
 
-`@` maps to `./src` — use `@/components/...`, `@/lib/...`, etc.
+- `@` maps to `./src` — use `@/components/...`, `@/lib/...`, etc.
+- `@convex` maps to `./convex` — use `@convex/_generated/...`, etc.

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as auth from "../auth.js";
 import type * as http from "../http.js";
+import type * as projects from "../projects.js";
 import type * as tasks from "../tasks.js";
 
 import type {
@@ -21,6 +22,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   http: typeof http;
+  projects: typeof projects;
   tasks: typeof tasks;
 }>;
 

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -1,0 +1,120 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { authComponent } from "./auth";
+
+export const list = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+    if (!user) return [];
+    const userId = String(user._id);
+    const projects = await ctx.db
+      .query("projects")
+      .withIndex("by_user_order", (q) => q.eq("userId", userId))
+      .collect();
+    return projects.filter((p) => !p.isArchived);
+  },
+});
+
+export const get = query({
+  args: { id: v.id("projects") },
+  handler: async (ctx, args) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+    if (!user) return null;
+    const project = await ctx.db.get(args.id);
+    if (!project || project.userId !== String(user._id)) return null;
+    if (project.isArchived) return null;
+    return project;
+  },
+});
+
+export const create = mutation({
+  args: {
+    name: v.string(),
+    description: v.optional(v.string()),
+    definitionOfDone: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const user = await authComponent.getAuthUser(ctx);
+    const userId = String(user._id);
+
+    const existing = await ctx.db
+      .query("projects")
+      .withIndex("by_user_order", (q) => q.eq("userId", userId))
+      .order("desc")
+      .first();
+
+    const nextOrder = existing ? existing.order + 1 : 0;
+
+    return ctx.db.insert("projects", {
+      userId,
+      name: args.name,
+      description: args.description,
+      definitionOfDone: args.definitionOfDone,
+      order: nextOrder,
+      isArchived: false,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+export const update = mutation({
+  args: {
+    id: v.id("projects"),
+    name: v.optional(v.string()),
+    description: v.optional(v.string()),
+    clearDescription: v.optional(v.boolean()),
+    definitionOfDone: v.optional(v.string()),
+    clearDefinitionOfDone: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const user = await authComponent.getAuthUser(ctx);
+    const userId = String(user._id);
+
+    const project = await ctx.db.get(args.id);
+    if (!project || project.userId !== userId) {
+      throw new Error("Project not found");
+    }
+
+    const updates: Record<string, unknown> = {};
+    if (args.name !== undefined) updates.name = args.name;
+    if (args.clearDescription) {
+      updates.description = undefined;
+    } else if (args.description !== undefined) {
+      updates.description = args.description;
+    }
+    if (args.clearDefinitionOfDone) {
+      updates.definitionOfDone = undefined;
+    } else if (args.definitionOfDone !== undefined) {
+      updates.definitionOfDone = args.definitionOfDone;
+    }
+
+    await ctx.db.patch(args.id, updates);
+  },
+});
+
+export const remove = mutation({
+  args: { id: v.id("projects") },
+  handler: async (ctx, args) => {
+    const user = await authComponent.getAuthUser(ctx);
+    const userId = String(user._id);
+
+    const project = await ctx.db.get(args.id);
+    if (!project || project.userId !== userId) {
+      throw new Error("Project not found");
+    }
+
+    // Archive the project
+    await ctx.db.patch(args.id, { isArchived: true });
+
+    // Unassign all tasks from this project
+    const tasks = await ctx.db
+      .query("tasks")
+      .withIndex("by_project", (q) => q.eq("projectId", args.id))
+      .collect();
+
+    for (const task of tasks) {
+      await ctx.db.patch(task._id, { projectId: undefined });
+    }
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2,15 +2,29 @@ import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 export default defineSchema({
+  projects: defineTable({
+    userId: v.string(),
+    name: v.string(),
+    description: v.optional(v.string()),
+    definitionOfDone: v.optional(v.string()),
+    order: v.number(),
+    isArchived: v.boolean(),
+    createdAt: v.number(),
+  })
+    .index("by_user", ["userId"])
+    .index("by_user_order", ["userId", "order"]),
+
   tasks: defineTable({
     userId: v.string(),
     title: v.string(),
     description: v.optional(v.string()),
     isCompleted: v.boolean(),
     dueDate: v.optional(v.number()),
+    projectId: v.optional(v.id("projects")),
     order: v.number(),
     createdAt: v.number(),
   })
     .index("by_user", ["userId"])
-    .index("by_user_order", ["userId", "order"]),
+    .index("by_user_order", ["userId", "order"])
+    .index("by_project", ["projectId"]),
 });

--- a/src/components/tasks/add-task-row.tsx
+++ b/src/components/tasks/add-task-row.tsx
@@ -1,0 +1,203 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+import { format } from "date-fns";
+import { Calendar as CalendarIcon, FolderOpen, Plus, X } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
+import { useTaskMutations } from "@/hooks/use-task-mutations";
+
+interface AddTaskRowProps {
+  projectId?: Id<"projects">;
+  showProjectPicker?: boolean;
+  projects?: Doc<"projects">[];
+}
+
+export function AddTaskRow({
+  projectId,
+  showProjectPicker,
+  projects,
+}: AddTaskRowProps) {
+  const [isAdding, setIsAdding] = useState(false);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [dueDate, setDueDate] = useState<Date | undefined>();
+  const [selectedProjectId, setSelectedProjectId] = useState<
+    string | undefined
+  >();
+  const { createTask } = useTaskMutations(projectId);
+
+  const handleSubmit = () => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+
+    const trimmedDesc = description.trim();
+    const resolvedProjectId = projectId ?? selectedProjectId;
+    createTask({
+      title: trimmed,
+      description: trimmedDesc || undefined,
+      dueDate: dueDate?.getTime(),
+      projectId: resolvedProjectId
+        ? (resolvedProjectId as Id<"projects">)
+        : undefined,
+    });
+    setTitle("");
+    setDescription("");
+    setDueDate(undefined);
+    setSelectedProjectId(undefined);
+    setIsAdding(false);
+  };
+
+  const handleCancel = () => {
+    setTitle("");
+    setDescription("");
+    setDueDate(undefined);
+    setSelectedProjectId(undefined);
+    setIsAdding(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSubmit();
+    } else if (e.key === "Escape") {
+      handleCancel();
+    }
+  };
+
+  if (!isAdding) {
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => setIsAdding(true)}
+          className="flex w-full items-center gap-3 py-3 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <Plus className="h-4 w-4" />
+          <span>Add task</span>
+        </button>
+        <Separator />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-3 py-3">
+        <input
+          // biome-ignore lint/a11y/noAutofocus: intentional for inline task form
+          autoFocus
+          type="text"
+          placeholder="Task name"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+        />
+        <textarea
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={2}
+          className="w-full resize-none bg-transparent text-xs text-muted-foreground outline-none placeholder:text-muted-foreground"
+        />
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 gap-1.5 text-xs"
+                >
+                  <CalendarIcon className="h-3 w-3" />
+                  {dueDate ? format(dueDate, "MMM d") : "Due date"}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="start">
+                <Calendar
+                  mode="single"
+                  selected={dueDate}
+                  onSelect={setDueDate}
+                />
+              </PopoverContent>
+            </Popover>
+            {showProjectPicker && projects && projects.length > 0 && (
+              <ProjectPicker
+                projects={projects}
+                selectedProjectId={selectedProjectId}
+                onSelect={setSelectedProjectId}
+              />
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button variant="ghost" size="sm" onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button size="sm" onClick={handleSubmit} disabled={!title.trim()}>
+              Add task
+            </Button>
+          </div>
+        </div>
+      </div>
+      <Separator />
+    </>
+  );
+}
+
+function ProjectPicker({
+  projects,
+  selectedProjectId,
+  onSelect,
+}: {
+  projects: Doc<"projects">[];
+  selectedProjectId: string | undefined;
+  onSelect: (id: string | undefined) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = projects.find((p) => p._id === selectedProjectId);
+
+  return (
+    <div className="flex items-center gap-1">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs">
+            <FolderOpen className="h-3 w-3" />
+            {selected ? selected.name : "Project"}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-48 p-1" align="start">
+          {projects.map((p) => (
+            <button
+              key={p._id}
+              type="button"
+              onClick={() => {
+                onSelect(p._id);
+                setOpen(false);
+              }}
+              className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-muted"
+            >
+              {p.name}
+            </button>
+          ))}
+        </PopoverContent>
+      </Popover>
+      {selected && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={() => onSelect(undefined)}
+          aria-label="Clear project"
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/tasks/completed-section.tsx
+++ b/src/components/tasks/completed-section.tsx
@@ -1,0 +1,40 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+import { useState } from "react";
+import { TaskRow } from "./task-row";
+
+export function CompletedSection({
+  tasks,
+  projectId,
+}: {
+  tasks: Doc<"tasks">[];
+  projectId?: Id<"projects">;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="mt-4">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <span
+          className="inline-block transition-transform"
+          style={{
+            transform: isOpen ? "rotate(90deg)" : "rotate(0deg)",
+          }}
+        >
+          &#9656;
+        </span>
+        Completed ({tasks.length})
+      </button>
+      {isOpen && (
+        <div className="mt-2">
+          {tasks.map((task) => (
+            <TaskRow key={task._id} task={task} projectId={projectId} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/tasks/task-list-skeleton.tsx
+++ b/src/components/tasks/task-list-skeleton.tsx
@@ -1,0 +1,19 @@
+import { Separator } from "@/components/ui/separator";
+
+export function TaskListSkeleton() {
+  return (
+    <div>
+      <div className="mb-4 h-8 w-20 animate-pulse rounded bg-muted" />
+      {Array.from({ length: 3 }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
+        <div key={i}>
+          <div className="flex items-center gap-3 py-3">
+            <div className="h-4 w-4 animate-pulse rounded-full bg-muted" />
+            <div className="h-4 flex-1 animate-pulse rounded bg-muted" />
+          </div>
+          <Separator />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/tasks/task-row.tsx
+++ b/src/components/tasks/task-row.tsx
@@ -1,0 +1,85 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+import { format, isToday, isTomorrow } from "date-fns";
+import { Calendar as CalendarIcon, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Separator } from "@/components/ui/separator";
+import { useTaskMutations } from "@/hooks/use-task-mutations";
+
+export function TaskRow({
+  task,
+  projectId,
+}: {
+  task: Doc<"tasks">;
+  projectId?: Id<"projects">;
+}) {
+  const { updateTask, removeTask } = useTaskMutations(projectId);
+
+  return (
+    <>
+      <div className="group flex items-start gap-3 py-3">
+        <Checkbox
+          checked={task.isCompleted}
+          onCheckedChange={(checked) =>
+            updateTask({
+              id: task._id,
+              isCompleted: checked === true,
+            })
+          }
+          className="mt-0.5 rounded-full"
+        />
+        <div className="min-w-0 flex-1">
+          <span
+            className={
+              task.isCompleted ? "line-through text-muted-foreground" : ""
+            }
+          >
+            {task.title}
+          </span>
+          {task.description && (
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+              {task.description}
+            </p>
+          )}
+          {task.dueDate && <DueDateLabel timestamp={task.dueDate} />}
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 opacity-0 transition-opacity group-hover:opacity-100"
+          onClick={() => removeTask({ id: task._id })}
+          aria-label="Delete task"
+        >
+          <Trash2 className="h-4 w-4 text-muted-foreground" />
+        </Button>
+      </div>
+      <Separator />
+    </>
+  );
+}
+
+function DueDateLabel({ timestamp }: { timestamp: number }) {
+  const date = new Date(timestamp);
+  let label: string;
+  let className = "text-xs text-muted-foreground";
+
+  if (isToday(date)) {
+    label = "Today";
+    className = "text-xs text-green-600";
+  } else if (isTomorrow(date)) {
+    label = "Tomorrow";
+    className = "text-xs text-orange-600";
+  } else if (date < new Date()) {
+    label = format(date, "MMM d");
+    className = "text-xs text-red-600";
+  } else {
+    label = format(date, "MMM d");
+  }
+
+  return (
+    <div className="mt-0.5 flex items-center gap-1">
+      <CalendarIcon className="h-3 w-3" />
+      <span className={className}>{label}</span>
+    </div>
+  );
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,155 @@
+import { XIcon } from "lucide-react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import type * as React from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { Select as SelectPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1",
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/src/hooks/use-task-mutations.ts
+++ b/src/hooks/use-task-mutations.ts
@@ -1,0 +1,115 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { useMutation } from "convex/react";
+
+export function useTaskMutations(projectId?: Id<"projects">) {
+  const updateTask = useMutation(api.tasks.update).withOptimisticUpdate(
+    (localStore, args) => {
+      const { id, ...updates } = args;
+
+      if (projectId) {
+        const tasks = localStore.getQuery(api.tasks.listByProject, {
+          projectId,
+        });
+        if (tasks !== undefined) {
+          const task = tasks.find((t) => t._id === id);
+          if (task) {
+            localStore.setQuery(
+              api.tasks.listByProject,
+              { projectId },
+              tasks.map((t) => (t._id === id ? { ...task, ...updates } : t)),
+            );
+          }
+        }
+      } else {
+        const tasks = localStore.getQuery(api.tasks.list, {});
+        if (tasks !== undefined) {
+          const task = tasks.find((t) => t._id === id);
+          if (task) {
+            localStore.setQuery(
+              api.tasks.list,
+              {},
+              tasks.map((t) => (t._id === id ? { ...task, ...updates } : t)),
+            );
+          }
+        }
+      }
+    },
+  );
+
+  const removeTask = useMutation(api.tasks.remove).withOptimisticUpdate(
+    (localStore, args) => {
+      if (projectId) {
+        const tasks = localStore.getQuery(api.tasks.listByProject, {
+          projectId,
+        });
+        if (tasks !== undefined) {
+          localStore.setQuery(
+            api.tasks.listByProject,
+            { projectId },
+            tasks.filter((t) => t._id !== args.id),
+          );
+        }
+      } else {
+        const tasks = localStore.getQuery(api.tasks.list, {});
+        if (tasks !== undefined) {
+          localStore.setQuery(
+            api.tasks.list,
+            {},
+            tasks.filter((t) => t._id !== args.id),
+          );
+        }
+      }
+    },
+  );
+
+  const createTask = useMutation(api.tasks.create).withOptimisticUpdate(
+    (localStore, args) => {
+      if (projectId) {
+        const tasks = localStore.getQuery(api.tasks.listByProject, {
+          projectId,
+        });
+        if (tasks !== undefined) {
+          const maxOrder = tasks.reduce((max, t) => Math.max(max, t.order), -1);
+          localStore.setQuery(api.tasks.listByProject, { projectId }, [
+            ...tasks,
+            {
+              _id: crypto.randomUUID() as Id<"tasks">,
+              _creationTime: Date.now(),
+              userId: "",
+              title: args.title,
+              description: args.description,
+              isCompleted: false,
+              dueDate: args.dueDate,
+              projectId,
+              order: maxOrder + 1,
+              createdAt: Date.now(),
+            },
+          ]);
+        }
+      } else {
+        const tasks = localStore.getQuery(api.tasks.list, {});
+        if (tasks !== undefined) {
+          const maxOrder = tasks.reduce((max, t) => Math.max(max, t.order), -1);
+          localStore.setQuery(api.tasks.list, {}, [
+            ...tasks,
+            {
+              _id: crypto.randomUUID() as Id<"tasks">,
+              _creationTime: Date.now(),
+              userId: "",
+              title: args.title,
+              description: args.description,
+              isCompleted: false,
+              dueDate: args.dueDate,
+              projectId: args.projectId,
+              order: maxOrder + 1,
+              createdAt: Date.now(),
+            },
+          ]);
+        }
+      }
+    },
+  );
+
+  return { createTask, updateTask, removeTask };
+}

--- a/src/routes/_authenticated/index.tsx
+++ b/src/routes/_authenticated/index.tsx
@@ -1,19 +1,10 @@
 import { api } from "@convex/_generated/api";
-import type { Doc, Id } from "@convex/_generated/dataModel";
 import { createFileRoute } from "@tanstack/react-router";
-import { useMutation, useQuery } from "convex/react";
-import { format, isToday, isTomorrow } from "date-fns";
-import { Calendar as CalendarIcon, Plus, Trash2 } from "lucide-react";
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Calendar } from "@/components/ui/calendar";
-import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { Separator } from "@/components/ui/separator";
+import { useQuery } from "convex/react";
+import { AddTaskRow } from "@/components/tasks/add-task-row";
+import { CompletedSection } from "@/components/tasks/completed-section";
+import { TaskListSkeleton } from "@/components/tasks/task-list-skeleton";
+import { TaskRow } from "@/components/tasks/task-row";
 
 export const Route = createFileRoute("/_authenticated/")({
   component: Inbox,
@@ -21,13 +12,14 @@ export const Route = createFileRoute("/_authenticated/")({
 
 function Inbox() {
   const tasks = useQuery(api.tasks.list);
+  const projects = useQuery(api.projects.list);
   const isLoading = tasks === undefined;
 
   const activeTasks = tasks?.filter((t) => !t.isCompleted) ?? [];
   const completedTasks = tasks?.filter((t) => t.isCompleted) ?? [];
 
   if (isLoading) {
-    return <InboxSkeleton />;
+    return <TaskListSkeleton />;
   }
 
   return (
@@ -37,289 +29,11 @@ function Inbox() {
         {activeTasks.map((task) => (
           <TaskRow key={task._id} task={task} />
         ))}
-        <AddTaskRow />
+        <AddTaskRow showProjectPicker projects={projects ?? []} />
         {completedTasks.length > 0 && (
           <CompletedSection tasks={completedTasks} />
         )}
       </div>
-    </div>
-  );
-}
-
-function TaskRow({ task }: { task: Doc<"tasks"> }) {
-  const updateTask = useMutation(api.tasks.update).withOptimisticUpdate(
-    (localStore, args) => {
-      const tasks = localStore.getQuery(api.tasks.list, {});
-      if (tasks === undefined) return;
-      const { id, ...updates } = args;
-
-      const updatedTask = tasks.find((t) => t._id === id);
-
-      if (!updatedTask) return;
-
-      localStore.setQuery(
-        api.tasks.list,
-        {},
-        tasks.map((t) => (t._id === id ? { ...updatedTask, ...updates } : t)),
-      );
-    },
-  );
-  const removeTask = useMutation(api.tasks.remove).withOptimisticUpdate(
-    (localStore, args) => {
-      const tasks = localStore.getQuery(api.tasks.list, {});
-      if (tasks === undefined) return;
-      localStore.setQuery(
-        api.tasks.list,
-        {},
-        tasks.filter((t) => t._id !== args.id),
-      );
-    },
-  );
-
-  return (
-    <>
-      <div className="group flex items-start gap-3 py-3">
-        <Checkbox
-          checked={task.isCompleted}
-          onCheckedChange={(checked) =>
-            updateTask({
-              id: task._id,
-              isCompleted: checked === true,
-            })
-          }
-          className="mt-0.5 rounded-full"
-        />
-        <div className="min-w-0 flex-1">
-          <span
-            className={
-              task.isCompleted ? "line-through text-muted-foreground" : ""
-            }
-          >
-            {task.title}
-          </span>
-          {task.description && (
-            <p className="mt-0.5 truncate text-xs text-muted-foreground">
-              {task.description}
-            </p>
-          )}
-          {task.dueDate && <DueDateLabel timestamp={task.dueDate} />}
-        </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 opacity-0 transition-opacity group-hover:opacity-100"
-          onClick={() => removeTask({ id: task._id })}
-          aria-label="Delete task"
-        >
-          <Trash2 className="h-4 w-4 text-muted-foreground" />
-        </Button>
-      </div>
-      <Separator />
-    </>
-  );
-}
-
-function DueDateLabel({ timestamp }: { timestamp: number }) {
-  const date = new Date(timestamp);
-  let label: string;
-  let className = "text-xs text-muted-foreground";
-
-  if (isToday(date)) {
-    label = "Today";
-    className = "text-xs text-green-600";
-  } else if (isTomorrow(date)) {
-    label = "Tomorrow";
-    className = "text-xs text-orange-600";
-  } else if (date < new Date()) {
-    label = format(date, "MMM d");
-    className = "text-xs text-red-600";
-  } else {
-    label = format(date, "MMM d");
-  }
-
-  return (
-    <div className="mt-0.5 flex items-center gap-1">
-      <CalendarIcon className="h-3 w-3" />
-      <span className={className}>{label}</span>
-    </div>
-  );
-}
-
-function AddTaskRow() {
-  const [isAdding, setIsAdding] = useState(false);
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [dueDate, setDueDate] = useState<Date | undefined>();
-  const createTask = useMutation(api.tasks.create).withOptimisticUpdate(
-    (localStore, args) => {
-      const tasks = localStore.getQuery(api.tasks.list, {});
-      if (tasks === undefined) return;
-      const maxOrder = tasks.reduce((max, t) => Math.max(max, t.order), -1);
-      localStore.setQuery(api.tasks.list, {}, [
-        ...tasks,
-        {
-          _id: crypto.randomUUID() as Id<"tasks">,
-          _creationTime: Date.now(),
-          userId: "",
-          title: args.title,
-          description: args.description,
-          isCompleted: false,
-          dueDate: args.dueDate,
-          order: maxOrder + 1,
-          createdAt: Date.now(),
-        },
-      ]);
-    },
-  );
-
-  const handleSubmit = () => {
-    const trimmed = title.trim();
-    if (!trimmed) return;
-
-    const trimmedDesc = description.trim();
-    createTask({
-      title: trimmed,
-      description: trimmedDesc || undefined,
-      dueDate: dueDate?.getTime(),
-    });
-    setTitle("");
-    setDescription("");
-    setDueDate(undefined);
-    setIsAdding(false);
-  };
-
-  const handleCancel = () => {
-    setTitle("");
-    setDescription("");
-    setDueDate(undefined);
-    setIsAdding(false);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      handleSubmit();
-    } else if (e.key === "Escape") {
-      handleCancel();
-    }
-  };
-
-  if (!isAdding) {
-    return (
-      <>
-        <button
-          type="button"
-          onClick={() => setIsAdding(true)}
-          className="flex w-full items-center gap-3 py-3 text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <Plus className="h-4 w-4" />
-          <span>Add task</span>
-        </button>
-        <Separator />
-      </>
-    );
-  }
-
-  return (
-    <>
-      <div className="space-y-3 py-3">
-        <input
-          // biome-ignore lint/a11y/noAutofocus: intentional for inline task form
-          autoFocus
-          type="text"
-          placeholder="Task name"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          onKeyDown={handleKeyDown}
-          className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-        />
-        <textarea
-          placeholder="Description"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          rows={2}
-          className="w-full resize-none bg-transparent text-xs text-muted-foreground outline-none placeholder:text-muted-foreground"
-        />
-        <div className="flex items-center justify-between">
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 gap-1.5 text-xs"
-              >
-                <CalendarIcon className="h-3 w-3" />
-                {dueDate ? format(dueDate, "MMM d") : "Due date"}
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-auto p-0" align="start">
-              <Calendar
-                mode="single"
-                selected={dueDate}
-                onSelect={setDueDate}
-              />
-            </PopoverContent>
-          </Popover>
-          <div className="flex gap-2">
-            <Button variant="ghost" size="sm" onClick={handleCancel}>
-              Cancel
-            </Button>
-            <Button size="sm" onClick={handleSubmit} disabled={!title.trim()}>
-              Add task
-            </Button>
-          </div>
-        </div>
-      </div>
-      <Separator />
-    </>
-  );
-}
-
-function CompletedSection({ tasks }: { tasks: Doc<"tasks">[] }) {
-  const [isOpen, setIsOpen] = useState(false);
-
-  return (
-    <div className="mt-4">
-      <button
-        type="button"
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <span
-          className="inline-block transition-transform"
-          style={{
-            transform: isOpen ? "rotate(90deg)" : "rotate(0deg)",
-          }}
-        >
-          &#9656;
-        </span>
-        Completed ({tasks.length})
-      </button>
-      {isOpen && (
-        <div className="mt-2">
-          {tasks.map((task) => (
-            <TaskRow key={task._id} task={task} />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function InboxSkeleton() {
-  return (
-    <div>
-      <div className="mb-4 h-8 w-20 animate-pulse rounded bg-muted" />
-      {Array.from({ length: 3 }).map((_, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
-        <div key={i}>
-          <div className="flex items-center gap-3 py-3">
-            <div className="h-4 w-4 animate-pulse rounded-full bg-muted" />
-            <div className="h-4 flex-1 animate-pulse rounded bg-muted" />
-          </div>
-          <Separator />
-        </div>
-      ))}
     </div>
   );
 }

--- a/src/routes/_authenticated/projects/$projectId.tsx
+++ b/src/routes/_authenticated/projects/$projectId.tsx
@@ -1,0 +1,136 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useMutation, useQuery } from "convex/react";
+import { ArrowLeft, Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { AddTaskRow } from "@/components/tasks/add-task-row";
+import { CompletedSection } from "@/components/tasks/completed-section";
+import { TaskListSkeleton } from "@/components/tasks/task-list-skeleton";
+import { TaskRow } from "@/components/tasks/task-row";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { ProjectFormDialog } from "./-project-form-dialog";
+
+export const Route = createFileRoute("/_authenticated/projects/$projectId")({
+  component: ProjectDetailPage,
+});
+
+function ProjectDetailPage() {
+  const { projectId } = Route.useParams();
+  const id = projectId as Id<"projects">;
+  const project = useQuery(api.projects.get, { id });
+  const tasks = useQuery(api.tasks.listByProject, {
+    projectId: id,
+  });
+  const updateProject = useMutation(api.projects.update);
+  const removeProject = useMutation(api.projects.remove);
+  const navigate = useNavigate();
+  const [showEdit, setShowEdit] = useState(false);
+
+  const isLoading = project === undefined || tasks === undefined;
+
+  if (isLoading) {
+    return <TaskListSkeleton />;
+  }
+
+  if (project === null) {
+    return (
+      <div className="py-16 text-center">
+        <p className="text-sm text-muted-foreground">Project not found.</p>
+        <Link to="/projects" className="mt-2 inline-block text-sm underline">
+          Back to projects
+        </Link>
+      </div>
+    );
+  }
+
+  const activeTasks = tasks.filter((t) => !t.isCompleted);
+  const completedTasks = tasks.filter((t) => t.isCompleted);
+
+  const handleDelete = async () => {
+    await removeProject({ id });
+    navigate({ to: "/projects" });
+  };
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          to="/projects"
+          className="mb-3 inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="h-3 w-3" />
+          Projects
+        </Link>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">{project.name}</h1>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setShowEdit(true)}
+              aria-label="Edit project"
+            >
+              <Pencil className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handleDelete}
+              aria-label="Delete project"
+            >
+              <Trash2 className="h-4 w-4 text-muted-foreground" />
+            </Button>
+          </div>
+        </div>
+        {project.description && (
+          <p className="mt-1 text-sm text-muted-foreground">
+            {project.description}
+          </p>
+        )}
+      </div>
+
+      {project.definitionOfDone && (
+        <div className="mb-6 rounded-md border p-4">
+          <h2 className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Definition of Done
+          </h2>
+          <p className="whitespace-pre-wrap text-sm">
+            {project.definitionOfDone}
+          </p>
+        </div>
+      )}
+
+      <Separator className="mb-4" />
+
+      <div>
+        {activeTasks.map((task) => (
+          <TaskRow key={task._id} task={task} projectId={id} />
+        ))}
+        <AddTaskRow projectId={id} />
+        {completedTasks.length > 0 && (
+          <CompletedSection tasks={completedTasks} projectId={id} />
+        )}
+      </div>
+
+      {project && (
+        <ProjectFormDialog
+          open={showEdit}
+          onOpenChange={setShowEdit}
+          project={project}
+          onSubmit={(data) =>
+            updateProject({
+              id,
+              name: data.name,
+              description: data.description,
+              clearDescription: !data.description,
+              definitionOfDone: data.definitionOfDone,
+              clearDefinitionOfDone: !data.definitionOfDone,
+            })
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/src/routes/_authenticated/projects/-project-form-dialog.tsx
+++ b/src/routes/_authenticated/projects/-project-form-dialog.tsx
@@ -1,0 +1,109 @@
+import type { Doc } from "@convex/_generated/dataModel";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+interface ProjectFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: {
+    name: string;
+    description?: string;
+    definitionOfDone?: string;
+  }) => void;
+  project?: Doc<"projects">;
+}
+
+export function ProjectFormDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  project,
+}: ProjectFormDialogProps) {
+  const [name, setName] = useState(project?.name ?? "");
+  const [description, setDescription] = useState(project?.description ?? "");
+  const [definitionOfDone, setDefinitionOfDone] = useState(
+    project?.definitionOfDone ?? "",
+  );
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+
+    onSubmit({
+      name: trimmedName,
+      description: description.trim() || undefined,
+      definitionOfDone: definitionOfDone.trim() || undefined,
+    });
+
+    if (!project) {
+      setName("");
+      setDescription("");
+      setDefinitionOfDone("");
+    }
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{project ? "Edit project" : "New project"}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="project-name">Name</Label>
+            <Input
+              id="project-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Project name"
+              autoFocus
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="project-description">Description</Label>
+            <Input
+              id="project-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What is this project about?"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="project-dod">Definition of Done</Label>
+            <Textarea
+              id="project-dod"
+              value={definitionOfDone}
+              onChange={(e) => setDefinitionOfDone(e.target.value)}
+              placeholder="When is this project considered done?"
+              rows={3}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!name.trim()}>
+              {project ? "Save" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/_authenticated/projects/index.tsx
+++ b/src/routes/_authenticated/projects/index.tsx
@@ -1,0 +1,97 @@
+import { api } from "@convex/_generated/api";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useMutation, useQuery } from "convex/react";
+import { FolderOpen, Plus } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { ProjectFormDialog } from "./-project-form-dialog";
+
+export const Route = createFileRoute("/_authenticated/projects/")({
+  component: ProjectsPage,
+});
+
+function ProjectsPage() {
+  const projects = useQuery(api.projects.list);
+  const createProject = useMutation(api.projects.create);
+  const [showCreate, setShowCreate] = useState(false);
+  const isLoading = projects === undefined;
+
+  if (isLoading) {
+    return <ProjectsListSkeleton />;
+  }
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Projects</h1>
+        <Button
+          size="sm"
+          className="gap-1.5"
+          onClick={() => setShowCreate(true)}
+        >
+          <Plus className="h-4 w-4" />
+          New project
+        </Button>
+      </div>
+
+      {projects.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <FolderOpen className="mb-3 h-10 w-10 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            No projects yet. Create one to organize your tasks.
+          </p>
+        </div>
+      ) : (
+        <div>
+          {projects.map((project) => (
+            <div key={project._id}>
+              <Link
+                to="/projects/$projectId"
+                params={{ projectId: project._id }}
+                className="-mx-2 flex items-center gap-3 rounded px-2 py-3 transition-colors hover:bg-muted/50"
+              >
+                <div className="min-w-0 flex-1">
+                  <span className="font-medium">{project.name}</span>
+                  {project.description && (
+                    <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                      {project.description}
+                    </p>
+                  )}
+                </div>
+              </Link>
+              <Separator />
+            </div>
+          ))}
+        </div>
+      )}
+
+      <ProjectFormDialog
+        open={showCreate}
+        onOpenChange={setShowCreate}
+        onSubmit={(data) => createProject(data)}
+      />
+    </div>
+  );
+}
+
+function ProjectsListSkeleton() {
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <div className="h-8 w-24 animate-pulse rounded bg-muted" />
+        <div className="h-8 w-28 animate-pulse rounded bg-muted" />
+      </div>
+      {Array.from({ length: 3 }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
+        <div key={i}>
+          <div className="py-3">
+            <div className="h-5 w-40 animate-pulse rounded bg-muted" />
+            <div className="mt-1.5 h-3 w-64 animate-pulse rounded bg-muted" />
+          </div>
+          <Separator />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/routes/_authenticated/route.tsx
+++ b/src/routes/_authenticated/route.tsx
@@ -1,4 +1,9 @@
-import { createFileRoute, Navigate, Outlet } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  Link,
+  Navigate,
+  Outlet,
+} from "@tanstack/react-router";
 import { useConvexAuth } from "convex/react";
 import { LogOut } from "lucide-react";
 import { AuthVerifyingLoader } from "@/components/auth/auth-verifying-loader";
@@ -40,7 +45,24 @@ function AppHeader() {
   return (
     <header className="border-b">
       <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-3">
-        <span className="text-lg font-semibold">vita-os</span>
+        <div className="flex items-center gap-6">
+          <span className="text-lg font-semibold">vita-os</span>
+          <nav className="flex items-center gap-4">
+            <Link
+              to="/"
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground [&.active]:font-medium [&.active]:text-foreground"
+            >
+              Inbox
+            </Link>
+            <Link
+              to="/projects"
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground [&.active]:font-medium [&.active]:text-foreground"
+              activeOptions={{ exact: false }}
+            >
+              Projects
+            </Link>
+          </nav>
+        </div>
         <div className="flex items-center gap-3">
           {session?.user?.email && (
             <span className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- Add `projects` table (name, description, definition of done, soft-delete via archive) with full CRUD backend
- Add `/projects` list page and `/projects/$projectId` detail page with task list, definition of done display, and edit/delete actions
- Inbox now only shows unassigned tasks; add-task form includes a project picker popover to assign tasks on creation
- Extract shared task components (TaskRow, AddTaskRow, CompletedSection, TaskListSkeleton) and centralize optimistic update logic in `useTaskMutations` hook

## Test plan
- [ ] Create a project with name + definition of done at `/projects` — verify it appears in the list
- [ ] Navigate to the project detail page — verify empty task list and DoD section render
- [ ] Add tasks to the project — verify they appear on the project page and NOT in Inbox
- [ ] Add a task in Inbox without selecting a project — verify it stays in Inbox only
- [ ] Add a task in Inbox with a project selected via the picker — verify it appears on the project page
- [ ] Complete and delete tasks on the project page — verify optimistic updates work
- [ ] Edit a project (name, description, DoD) — verify changes are reflected
- [ ] Delete a project — verify its tasks reappear in Inbox (unassigned)
- [ ] Verify nav links (Inbox / Projects) highlight correctly for the active route