### PR TITLE
fix(sidebar): highlight active page on navigation

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import { api } from "@convex/_generated/api";
-import { Link, useMatchRoute } from "@tanstack/react-router";
+import { Link, useLocation } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { FolderOpen, Inbox, LogOut, Plus } from "lucide-react";
 import { useState } from "react";
@@ -22,16 +22,10 @@ import { authClient } from "@/lib/auth-client";
 
 export function AppSidebar() {
   const { data: session } = authClient.useSession();
-  const matchRoute = useMatchRoute();
+  const { pathname } = useLocation();
   const projects = useQuery(api.projects.list);
   const createProject = useMutation(api.projects.create);
   const [showCreateProject, setShowCreateProject] = useState(false);
-
-  const isInboxActive = matchRoute({ to: "/" });
-  const isProjectsActive = matchRoute({
-    to: "/projects",
-    fuzzy: true,
-  });
 
   return (
     <>
@@ -53,7 +47,7 @@ export function AppSidebar() {
                 <SidebarMenuItem>
                   <SidebarMenuButton
                     asChild
-                    isActive={!!isInboxActive}
+                    isActive={pathname === "/"}
                     tooltip="Inbox"
                   >
                     <Link to="/">
@@ -77,15 +71,11 @@ export function AppSidebar() {
             <SidebarGroupContent>
               <SidebarMenu>
                 {projects?.map((project) => {
-                  const isActive = matchRoute({
-                    to: "/projects/$projectId",
-                    params: { projectId: project._id },
-                  });
                   return (
                     <SidebarMenuItem key={project._id}>
                       <SidebarMenuButton
                         asChild
-                        isActive={!!isActive}
+                        isActive={pathname === `/projects/${project._id}`}
                         tooltip={project.name}
                       >
                         <Link
@@ -99,16 +89,18 @@ export function AppSidebar() {
                     </SidebarMenuItem>
                   );
                 })}
-                {!isProjectsActive && (
-                  <SidebarMenuItem>
-                    <SidebarMenuButton asChild tooltip="All projects">
-                      <Link to="/projects">
-                        <FolderOpen />
-                        <span>All projects</span>
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                )}
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={pathname === "/projects"}
+                    tooltip="All projects"
+                  >
+                    <Link to="/projects">
+                      <FolderOpen />
+                      <span>All projects</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>


### PR DESCRIPTION
## Summary
- Replace `useMatchRoute` with `useLocation` so sidebar highlights update reactively on client-side navigation instead of only on page reload
- Always show the "All projects" link and add `isActive` state so `/projects` page highlights correctly
- Fixes #18

## Test plan
- [ ] Navigate to Inbox (`/`) — Inbox link highlights
- [ ] Navigate to a specific project (`/projects/$id`) — that project highlights
- [ ] Navigate to All projects (`/projects`) — "All projects" link highlights
- [ ] Verify highlights update immediately on click, not just on reload