### PR TITLE
feat(sidebar): navigate to project after creation

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import { api } from "@convex/_generated/api";
-import { Link, useLocation } from "@tanstack/react-router";
+import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { FolderOpen, Inbox, LogOut, Plus } from "lucide-react";
 import { useState } from "react";
@@ -23,6 +23,7 @@ import { authClient } from "@/lib/auth-client";
 export function AppSidebar() {
   const { data: session } = authClient.useSession();
   const { pathname } = useLocation();
+  const navigate = useNavigate();
   const projects = useQuery(api.projects.list);
   const createProject = useMutation(api.projects.create);
   const [showCreateProject, setShowCreateProject] = useState(false);
@@ -128,7 +129,10 @@ export function AppSidebar() {
       <ProjectFormDialog
         open={showCreateProject}
         onOpenChange={setShowCreateProject}
-        onSubmit={(data) => createProject(data)}
+        onSubmit={async (data) => {
+          const projectId = await createProject(data);
+          navigate({ to: "/projects/$projectId", params: { projectId } });
+        }}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- After creating a new project via the sidebar dialog, automatically navigate to the new project's detail page
- Awaits the `createProject` mutation to get the returned project ID, then uses `useNavigate` to redirect to `/projects/$projectId`

Closes #11

## Test plan
- [ ] Create a new project via the sidebar "+" button
- [ ] Verify the browser navigates to the new project's detail page
- [ ] Verify the sidebar shows the new project as the active item

🤖 Generated with [Claude Code](https://claude.com/claude-code)