### PR TITLE
feat(tasks): add edit task dialog on row click

### DIFF
--- a/src/components/tasks/edit-task-dialog.tsx
+++ b/src/components/tasks/edit-task-dialog.tsx
@@ -1,0 +1,165 @@
+import { api } from "@convex/_generated/api";
+import type { Doc, Id } from "@convex/_generated/dataModel";
+import { useQuery } from "convex/react";
+import { format } from "date-fns";
+import { Calendar as CalendarIcon, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { ProjectPicker } from "@/components/tasks/project-picker";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
+import { useTaskMutations } from "@/hooks/use-task-mutations";
+
+interface EditTaskDialogProps {
+  task: Doc<"tasks">;
+  projectId?: Id<"projects">;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function EditTaskDialog({
+  task,
+  projectId,
+  open,
+  onOpenChange,
+}: EditTaskDialogProps) {
+  const [title, setTitle] = useState(task.title);
+  const [description, setDescription] = useState(task.description ?? "");
+  const [dueDate, setDueDate] = useState<Date | undefined>(
+    task.dueDate ? new Date(task.dueDate) : undefined,
+  );
+  const [selectedProjectId, setSelectedProjectId] = useState<
+    string | undefined
+  >(task.projectId);
+  const projects = useQuery(api.projects.list);
+  const { updateTask } = useTaskMutations(projectId);
+
+  useEffect(() => {
+    if (open) {
+      setTitle(task.title);
+      setDescription(task.description ?? "");
+      setDueDate(task.dueDate ? new Date(task.dueDate) : undefined);
+      setSelectedProjectId(task.projectId);
+    }
+  }, [open, task.title, task.description, task.dueDate, task.projectId]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = title.trim();
+    if (!trimmed) return;
+
+    const descTrimmed = description.trim();
+    await updateTask({
+      id: task._id,
+      title: trimmed,
+      description: descTrimmed || undefined,
+      clearDescription: !descTrimmed && !!task.description,
+      dueDate: dueDate?.getTime(),
+      clearDueDate: !dueDate && !!task.dueDate,
+      projectId: selectedProjectId
+        ? (selectedProjectId as Id<"projects">)
+        : undefined,
+      clearProjectId: !selectedProjectId && !!task.projectId,
+    });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit task</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="edit-task-title">Title</Label>
+            <Input
+              id="edit-task-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Task name"
+              autoFocus
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-task-description">Description</Label>
+            <Textarea
+              id="edit-task-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Add details..."
+              rows={3}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 gap-1.5 text-xs"
+                >
+                  <CalendarIcon className="h-3.5 w-3.5" />
+                  {dueDate ? format(dueDate, "MMM d") : "Due date"}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="start">
+                <Calendar
+                  mode="single"
+                  selected={dueDate}
+                  onSelect={setDueDate}
+                />
+              </PopoverContent>
+            </Popover>
+            {dueDate && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => setDueDate(undefined)}
+                aria-label="Clear due date"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            )}
+            {projects && projects.length > 0 && (
+              <ProjectPicker
+                projects={projects}
+                selectedProjectId={selectedProjectId}
+                onSelect={setSelectedProjectId}
+              />
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!title.trim()}>
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/tasks/task-row.tsx
+++ b/src/components/tasks/task-row.tsx
@@ -1,6 +1,8 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
 import { format, isToday, isTomorrow } from "date-fns";
 import { Calendar as CalendarIcon, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { EditTaskDialog } from "@/components/tasks/edit-task-dialog";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -25,6 +27,7 @@ export function TaskRow({
   projectId?: Id<"projects">;
 }) {
   const { updateTask, removeTask } = useTaskMutations(projectId);
+  const [editOpen, setEditOpen] = useState(false);
 
   return (
     <>
@@ -39,7 +42,11 @@ export function TaskRow({
           }
           className="mt-0.5 rounded-full"
         />
-        <div className="min-w-0 flex-1">
+        <button
+          type="button"
+          className="min-w-0 flex-1 cursor-pointer text-left"
+          onClick={() => setEditOpen(true)}
+        >
           <span
             className={
               task.isCompleted ? "line-through text-muted-foreground" : ""
@@ -53,7 +60,7 @@ export function TaskRow({
             </p>
           )}
           {task.dueDate && <DueDateLabel timestamp={task.dueDate} />}
-        </div>
+        </button>
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button
@@ -83,6 +90,12 @@ export function TaskRow({
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
+        <EditTaskDialog
+          task={task}
+          projectId={projectId}
+          open={editOpen}
+          onOpenChange={setEditOpen}
+        />
       </div>
       <Separator />
     </>


### PR DESCRIPTION
## Summary
- Add `EditTaskDialog` component with form fields for title, description, due date, and project assignment
- Make task row content area clickable (as a `<button>`) to open the edit dialog
- Pre-populates form from current task values; uses existing `update` mutation with `clear*` flags for optional fields

Closes #7

## Test plan
- [ ] Click task content area (title/description/due date) — edit dialog opens pre-filled
- [ ] Modify each field and save — changes persist with optimistic updates
- [ ] Clear optional fields (description, due date, project) and save — fields are removed
- [ ] Cancel or click outside — no changes saved
- [ ] Checkbox still toggles completion without opening dialog
- [ ] Delete button still opens delete confirmation without opening dialog
- [ ] Works on both Inbox and project pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)