### PR TITLE
feat(tasks): add Q keyboard shortcut for quick-add dialog

### DIFF
--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -1,5 +1,5 @@
 import { Plus } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { QuickAddTaskDialog } from "@/components/tasks/quick-add-task-dialog";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -7,6 +7,25 @@ import { SidebarTrigger } from "@/components/ui/sidebar";
 
 export function AppHeader() {
   const [showQuickAdd, setShowQuickAdd] = useState(false);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== "q" && e.key !== "Q") return;
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.tagName === "SELECT" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+      e.preventDefault();
+      setShowQuickAdd(true);
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   return (
     <header className="flex h-12 items-center gap-2 border-b px-4">


### PR DESCRIPTION
## Summary
- Press **Q** anywhere on authenticated pages to open the quick-add task dialog
- Shortcut is ignored when typing in inputs, textareas, selects, or contenteditable elements
- `preventDefault()` stops the keystroke from leaking into the dialog's auto-focused title input

Closes #13

## Test plan
- [ ] Press Q on inbox/project pages → dialog opens with empty title
- [ ] Press Q while focused on an input/textarea → nothing happens
- [ ] Press Escape → dialog closes
- [ ] Click "Add task" button → still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)