### PR TITLE
refactor(layout): unify page headers with shared PageHeader component

### DIFF
--- a/src/components/layout/page-header.tsx
+++ b/src/components/layout/page-header.tsx
@@ -1,0 +1,47 @@
+import type { LinkProps } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
+import { ArrowLeft } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface PageHeaderBackLink {
+  label: string;
+  to: LinkProps["to"];
+}
+
+interface PageHeaderProps {
+  title: string;
+  backLink?: PageHeaderBackLink;
+  description?: string;
+  actions?: ReactNode;
+  className?: string;
+}
+
+export function PageHeader({
+  title,
+  backLink,
+  description,
+  actions,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div className={cn("mb-6", className)}>
+      {backLink && (
+        <Link
+          to={backLink.to}
+          className="mb-3 inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="h-3 w-3" />
+          {backLink.label}
+        </Link>
+      )}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{title}</h1>
+        {actions && <div className="flex items-center gap-1">{actions}</div>}
+      </div>
+      {description && (
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+      )}
+    </div>
+  );
+}

--- a/src/routes/_authenticated/index.tsx
+++ b/src/routes/_authenticated/index.tsx
@@ -1,6 +1,7 @@
 import { api } from "@convex/_generated/api";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
+import { PageHeader } from "@/components/layout/page-header";
 import { AddTaskRow } from "@/components/tasks/add-task-row";
 import { CompletedSection } from "@/components/tasks/completed-section";
 import { TaskListSkeleton } from "@/components/tasks/task-list-skeleton";
@@ -24,7 +25,7 @@ function Inbox() {
 
   return (
     <div>
-      <h1 className="mb-4 text-2xl font-bold">Inbox</h1>
+      <PageHeader title="Inbox" />
       <div>
         {activeTasks.map((task) => (
           <TaskRow key={task._id} task={task} />

--- a/src/routes/_authenticated/projects/$projectId.tsx
+++ b/src/routes/_authenticated/projects/$projectId.tsx
@@ -2,8 +2,9 @@ import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
-import { ArrowLeft, Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
+import { PageHeader } from "@/components/layout/page-header";
 import { ProjectFormDialog } from "@/components/projects/project-form-dialog";
 import { AddTaskRow } from "@/components/tasks/add-task-row";
 import { CompletedSection } from "@/components/tasks/completed-section";
@@ -66,17 +67,12 @@ function ProjectDetailPage() {
 
   return (
     <div>
-      <div className="mb-6">
-        <Link
-          to="/projects"
-          className="mb-3 inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <ArrowLeft className="h-3 w-3" />
-          Projects
-        </Link>
-        <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-bold">{project.name}</h1>
-          <div className="flex items-center gap-1">
+      <PageHeader
+        title={project.name}
+        backLink={{ label: "Projects", to: "/projects" }}
+        description={project.description || undefined}
+        actions={
+          <>
             <Button
               variant="ghost"
               size="icon"
@@ -110,14 +106,9 @@ function ProjectDetailPage() {
                 </AlertDialogFooter>
               </AlertDialogContent>
             </AlertDialog>
-          </div>
-        </div>
-        {project.description && (
-          <p className="mt-1 text-sm text-muted-foreground">
-            {project.description}
-          </p>
-        )}
-      </div>
+          </>
+        }
+      />
 
       {project.definitionOfDone && (
         <div className="mb-6 rounded-md border p-4">

--- a/src/routes/_authenticated/projects/index.tsx
+++ b/src/routes/_authenticated/projects/index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { FolderOpen, Plus, Search, X } from "lucide-react";
 import { useState } from "react";
+import { PageHeader } from "@/components/layout/page-header";
 import { ProjectFormDialog } from "@/components/projects/project-form-dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -32,17 +33,19 @@ function ProjectsPage() {
 
   return (
     <div>
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Projects</h1>
-        <Button
-          size="sm"
-          className="gap-1.5"
-          onClick={() => setShowCreate(true)}
-        >
-          <Plus className="h-4 w-4" />
-          New project
-        </Button>
-      </div>
+      <PageHeader
+        title="Projects"
+        actions={
+          <Button
+            size="sm"
+            className="gap-1.5"
+            onClick={() => setShowCreate(true)}
+          >
+            <Plus className="h-4 w-4" />
+            New project
+          </Button>
+        }
+      />
 
       {projects.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-center">
@@ -118,7 +121,7 @@ function ProjectsPage() {
 function ProjectsListSkeleton() {
   return (
     <div>
-      <div className="mb-4 flex items-center justify-between">
+      <div className="mb-6 flex items-center justify-between">
         <div className="h-8 w-24 animate-pulse rounded bg-muted" />
         <div className="h-8 w-28 animate-pulse rounded bg-muted" />
       </div>

--- a/src/routes/_authenticated/route.tsx
+++ b/src/routes/_authenticated/route.tsx
@@ -25,7 +25,7 @@ function AuthenticatedLayout() {
       <AppSidebar />
       <SidebarInset>
         <AppHeader />
-        <main className="mx-auto max-w-3xl px-4 py-8">
+        <main className="mx-auto w-full max-w-3xl px-4 py-8">
           <Outlet />
         </main>
       </SidebarInset>


### PR DESCRIPTION
## Summary
- Extract a shared `PageHeader` component (`src/components/layout/page-header.tsx`) with support for title, back link, description, and action buttons
- Apply it to inbox, projects list, and project detail pages for consistent heading structure and spacing
- Fix content width not stretching by adding `w-full` to the authenticated layout's `<main>` container

Closes #12

## Test plan
- [ ] Verify inbox page heading renders with correct spacing
- [ ] Verify projects list page shows heading + "New project" button aligned
- [ ] Verify project detail page shows back link, title, edit/delete buttons, and description
- [ ] Verify content fills the full container width on all pages
- [ ] Confirm no functional behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)