### PR TITLE
chore(web): add Vercel SPA rewrite config

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `apps/web/vercel.json` with a catch-all rewrite rule (`/(.*) → /index.html`)
- Ensures TanStack Router client-side routes work on direct navigation and page refresh when deployed to Vercel

## Test plan
- [ ] Deploy to Vercel and verify the root route (`/`) loads correctly
- [ ] Navigate directly to a nested route (e.g., `/projects`) and confirm it renders instead of 404
- [ ] Refresh the page on a nested route and confirm it still works