### PR TITLE
feat(web): add ConvexQueryCacheProvider to eliminate loading flashes

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "convex": "^1.31.7",
+    "convex-helpers": "^0.1.112",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.564.0",
     "radix-ui": "^1.4.3",

--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -1,6 +1,7 @@
 import { api } from "@convex/_generated/api";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache/hooks";
 import {
   ChevronRight,
   ChevronsUpDown,

--- a/apps/web/src/components/tasks/edit-task-dialog.tsx
+++ b/apps/web/src/components/tasks/edit-task-dialog.tsx
@@ -1,6 +1,6 @@
 import { api } from "@convex/_generated/api";
 import type { Doc, Id } from "@convex/_generated/dataModel";
-import { useQuery } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache/hooks";
 import { format } from "date-fns";
 import { Calendar as CalendarIcon, X } from "lucide-react";
 import { useEffect, useState } from "react";

--- a/apps/web/src/components/tasks/quick-add-task-dialog.tsx
+++ b/apps/web/src/components/tasks/quick-add-task-dialog.tsx
@@ -1,6 +1,7 @@
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache/hooks";
 import { format } from "date-fns";
 import { Calendar as CalendarIcon } from "lucide-react";
 import { useState } from "react";

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,7 @@
 import { ConvexBetterAuthProvider } from "@convex-dev/better-auth/react";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { ConvexReactClient } from "convex/react";
+import { ConvexQueryCacheProvider } from "convex-helpers/react/cache";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { authClient } from "./lib/auth-client";
@@ -29,7 +30,9 @@ if (!root) throw new Error("Root element not found");
 createRoot(root).render(
   <StrictMode>
     <ConvexBetterAuthProvider client={convex} authClient={authClient}>
-      <RouterProvider router={router} />
+      <ConvexQueryCacheProvider expiration={300_000}>
+        <RouterProvider router={router} />
+      </ConvexQueryCacheProvider>
     </ConvexBetterAuthProvider>
   </StrictMode>,
 );

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -1,6 +1,6 @@
 import { api } from "@convex/_generated/api";
 import { createFileRoute } from "@tanstack/react-router";
-import { useQuery } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache/hooks";
 import { PageHeader } from "@/components/layout/page-header";
 import { AddTaskRow } from "@/components/tasks/add-task-row";
 import { CompletedSection } from "@/components/tasks/completed-section";

--- a/apps/web/src/routes/_authenticated/projects/$projectId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId.tsx
@@ -1,7 +1,8 @@
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache/hooks";
 import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { PageHeader } from "@/components/layout/page-header";

--- a/apps/web/src/routes/_authenticated/projects/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/index.tsx
@@ -1,6 +1,7 @@
 import { api } from "@convex/_generated/api";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache/hooks";
 import { FolderOpen, Plus, Search, X } from "lucide-react";
 import { useState } from "react";
 import { PageHeader } from "@/components/layout/page-header";

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "convex": "^1.31.7",
+        "convex-helpers": "^0.1.112",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.564.0",
         "radix-ui": "^1.4.3",


### PR DESCRIPTION
## Summary
- Install `convex-helpers` and wrap the app with `ConvexQueryCacheProvider` (5-min expiration)
- Switch all `useQuery` imports from `convex/react` to `convex-helpers/react/cache/hooks` so queries use the cache
- Navigating between pages now renders cached data instantly instead of showing loading spinners

## Test plan
- [ ] Navigate from project list to project detail and back — no loading spinner on return
- [ ] Navigate from Inbox to a project and back — tasks render instantly
- [ ] `bun run lint` passes
- [ ] `bun run build` passes

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)