### PR TITLE
feat(projects): add optimistic updates for mutations

### DIFF
--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -1,6 +1,5 @@
 import { api } from "@convex/_generated/api";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
-import { useMutation } from "convex/react";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import {
   ChevronRight,
@@ -39,6 +38,7 @@ import {
   SidebarMenuItem,
   SidebarRail,
 } from "@/components/ui/sidebar";
+import { useProjectMutations } from "@/hooks/use-project-mutations";
 import { authClient } from "@/lib/auth-client";
 
 export function AppSidebar() {
@@ -46,7 +46,7 @@ export function AppSidebar() {
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const projects = useQuery(api.projects.list);
-  const createProject = useMutation(api.projects.create);
+  const { createProject } = useProjectMutations();
   const [showCreateProject, setShowCreateProject] = useState(false);
 
   return (

--- a/apps/web/src/hooks/use-project-mutations.ts
+++ b/apps/web/src/hooks/use-project-mutations.ts
@@ -1,0 +1,72 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { useMutation } from "convex/react";
+
+export function useProjectMutations() {
+  const updateProject = useMutation(api.projects.update).withOptimisticUpdate(
+    (localStore, args) => {
+      const { id, ...updates } = args;
+
+      const projects = localStore.getQuery(api.projects.list, {});
+      if (projects !== undefined) {
+        localStore.setQuery(
+          api.projects.list,
+          {},
+          projects.map((p) => (p._id === id ? { ...p, ...updates } : p)),
+        );
+      }
+
+      const project = localStore.getQuery(api.projects.get, { id });
+      if (project !== undefined && project !== null) {
+        localStore.setQuery(
+          api.projects.get,
+          { id },
+          { ...project, ...updates },
+        );
+      }
+    },
+  );
+
+  const removeProject = useMutation(api.projects.remove).withOptimisticUpdate(
+    (localStore, args) => {
+      const projects = localStore.getQuery(api.projects.list, {});
+      if (projects !== undefined) {
+        localStore.setQuery(
+          api.projects.list,
+          {},
+          projects.filter((p) => p._id !== args.id),
+        );
+      }
+
+      localStore.setQuery(api.projects.get, { id: args.id }, null);
+    },
+  );
+
+  const createProject = useMutation(api.projects.create).withOptimisticUpdate(
+    (localStore, args) => {
+      const projects = localStore.getQuery(api.projects.list, {});
+      if (projects !== undefined) {
+        const maxOrder = projects.reduce(
+          (max, p) => Math.max(max, p.order),
+          -1,
+        );
+        localStore.setQuery(api.projects.list, {}, [
+          ...projects,
+          {
+            _id: crypto.randomUUID() as Id<"projects">,
+            _creationTime: Date.now(),
+            userId: "",
+            name: args.name,
+            description: args.description,
+            definitionOfDone: args.definitionOfDone,
+            order: maxOrder + 1,
+            isArchived: false,
+            createdAt: Date.now(),
+          },
+        ]);
+      }
+    },
+  );
+
+  return { createProject, updateProject, removeProject };
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId.tsx
@@ -1,7 +1,6 @@
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useMutation } from "convex/react";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
@@ -24,6 +23,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { useProjectMutations } from "@/hooks/use-project-mutations";
 
 export const Route = createFileRoute("/_authenticated/projects/$projectId")({
   component: ProjectDetailPage,
@@ -36,8 +36,7 @@ function ProjectDetailPage() {
   const tasks = useQuery(api.tasks.listByProject, {
     projectId: id,
   });
-  const updateProject = useMutation(api.projects.update);
-  const removeProject = useMutation(api.projects.remove);
+  const { updateProject, removeProject } = useProjectMutations();
   const navigate = useNavigate();
   const [showEdit, setShowEdit] = useState(false);
 

--- a/apps/web/src/routes/_authenticated/projects/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/index.tsx
@@ -1,6 +1,5 @@
 import { api } from "@convex/_generated/api";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useMutation } from "convex/react";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { FolderOpen, Plus, Search, X } from "lucide-react";
 import { useState } from "react";
@@ -9,6 +8,7 @@ import { ProjectFormDialog } from "@/components/projects/project-form-dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
+import { useProjectMutations } from "@/hooks/use-project-mutations";
 
 export const Route = createFileRoute("/_authenticated/projects/")({
   component: ProjectsPage,
@@ -16,7 +16,7 @@ export const Route = createFileRoute("/_authenticated/projects/")({
 
 function ProjectsPage() {
   const projects = useQuery(api.projects.list);
-  const createProject = useMutation(api.projects.create);
+  const { createProject } = useProjectMutations();
   const [showCreate, setShowCreate] = useState(false);
   const [search, setSearch] = useState("");
   const isLoading = projects === undefined;


### PR DESCRIPTION
## Summary
- Add `useProjectMutations` hook with optimistic updates for create, update, and remove project mutations
- Replace raw `useMutation` calls in project list, project detail, and sidebar with the new hook
- Follows the existing `useTaskMutations` pattern

Closes #31

## Test plan
- [ ] Create a project from the projects page — appears instantly in the list
- [ ] Create a project from the sidebar — appears instantly and navigates
- [ ] Edit a project name/description — updates instantly in both list and detail views
- [ ] Delete a project — disappears instantly from the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)