### PR TITLE
fix(web): prevent layout shift on modal open

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -120,6 +120,10 @@
   html {
     scrollbar-gutter: stable;
   }
+  body[data-scroll-locked] {
+    /* biome-ignore lint/complexity/noImportantStyles: must override react-remove-scroll-bar's !important inline compensation */
+    margin-right: 0 !important;
+  }
   body {
     @apply bg-background text-foreground;
   }


### PR DESCRIPTION
## Summary

- Override `react-remove-scroll-bar`'s `margin-right` compensation on `body[data-scroll-locked]` since `scrollbar-gutter: stable` on `html` already reserves the scrollbar space

## Test plan

- [ ] Open a dialog (e.g. edit task) — background content should not shift horizontally
- [ ] Open a sheet or alert dialog — same, no shift
- [ ] Close the overlay — content stays stable

Closes #39