### PR TITLE
feat(projects): add start and end date fields

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -7,6 +7,8 @@ export default defineSchema({
     name: v.string(),
     description: v.optional(v.string()),
     definitionOfDone: v.optional(v.string()),
+    startDate: v.optional(v.number()),
+    endDate: v.optional(v.number()),
     order: v.number(),
     isArchived: v.boolean(),
     createdAt: v.number(),

--- a/apps/web/src/components/projects/project-form-dialog.tsx
+++ b/apps/web/src/components/projects/project-form-dialog.tsx
@@ -1,6 +1,9 @@
 import type { Doc } from "@convex/_generated/dataModel";
+import { format } from "date-fns";
+import { Calendar as CalendarIcon, X } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
 import {
   Dialog,
   DialogContent,
@@ -10,6 +13,11 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
 
 interface ProjectFormDialogProps {
@@ -19,6 +27,8 @@ interface ProjectFormDialogProps {
     name: string;
     description?: string;
     definitionOfDone?: string;
+    startDate?: number;
+    endDate?: number;
   }) => void;
   project?: Doc<"projects">;
 }
@@ -34,6 +44,19 @@ export function ProjectFormDialog({
   const [definitionOfDone, setDefinitionOfDone] = useState(
     project?.definitionOfDone ?? "",
   );
+  const [startDate, setStartDate] = useState<Date | undefined>(
+    project?.startDate ? new Date(project.startDate) : undefined,
+  );
+  const [endDate, setEndDate] = useState<Date | undefined>(
+    project?.endDate ? new Date(project.endDate) : undefined,
+  );
+
+  const handleStartDateChange = (date: Date | undefined) => {
+    setStartDate(date);
+    if (!date || (endDate && date > endDate)) {
+      setEndDate(undefined);
+    }
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -44,12 +67,16 @@ export function ProjectFormDialog({
       name: trimmedName,
       description: description.trim() || undefined,
       definitionOfDone: definitionOfDone.trim() || undefined,
+      startDate: startDate?.getTime(),
+      endDate: endDate?.getTime(),
     });
 
     if (!project) {
       setName("");
       setDescription("");
       setDefinitionOfDone("");
+      setStartDate(undefined);
+      setEndDate(undefined);
     }
     onOpenChange(false);
   };
@@ -89,6 +116,80 @@ export function ProjectFormDialog({
               placeholder="When is this project considered done?"
               rows={3}
             />
+          </div>
+          <div className="space-y-2">
+            <Label>Dates</Label>
+            <div className="flex items-center gap-2">
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-8 gap-1.5 text-xs"
+                  >
+                    <CalendarIcon className="h-3.5 w-3.5" />
+                    {startDate
+                      ? format(startDate, "MMM d, yyyy")
+                      : "Start date"}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={startDate}
+                    onSelect={handleStartDateChange}
+                  />
+                </PopoverContent>
+              </Popover>
+              {startDate && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  onClick={() => handleStartDateChange(undefined)}
+                  aria-label="Clear start date"
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              )}
+              <span className="text-xs text-muted-foreground">&ndash;</span>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-8 gap-1.5 text-xs"
+                    disabled={!startDate}
+                  >
+                    <CalendarIcon className="h-3.5 w-3.5" />
+                    {endDate ? format(endDate, "MMM d, yyyy") : "End date"}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={endDate}
+                    onSelect={setEndDate}
+                    disabled={(date) => (startDate ? date < startDate : false)}
+                  />
+                </PopoverContent>
+              </Popover>
+              {endDate && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  onClick={() => setEndDate(undefined)}
+                  aria-label="Clear end date"
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              )}
+            </div>
           </div>
           <DialogFooter>
             <Button

--- a/apps/web/src/hooks/use-project-mutations.ts
+++ b/apps/web/src/hooks/use-project-mutations.ts
@@ -7,12 +7,22 @@ export function useProjectMutations() {
     (localStore, args) => {
       const { id, ...updates } = args;
 
+      // Handle date clearing in optimistic state
+      const resolved = { ...updates };
+      if (updates.clearStartDate) {
+        resolved.startDate = undefined;
+        resolved.endDate = undefined;
+      }
+      if (updates.clearEndDate) {
+        resolved.endDate = undefined;
+      }
+
       const projects = localStore.getQuery(api.projects.list, {});
       if (projects !== undefined) {
         localStore.setQuery(
           api.projects.list,
           {},
-          projects.map((p) => (p._id === id ? { ...p, ...updates } : p)),
+          projects.map((p) => (p._id === id ? { ...p, ...resolved } : p)),
         );
       }
 
@@ -21,7 +31,7 @@ export function useProjectMutations() {
         localStore.setQuery(
           api.projects.get,
           { id },
-          { ...project, ...updates },
+          { ...project, ...resolved },
         );
       }
     },
@@ -59,6 +69,8 @@ export function useProjectMutations() {
             name: args.name,
             description: args.description,
             definitionOfDone: args.definitionOfDone,
+            startDate: args.startDate,
+            endDate: args.endDate,
             order: maxOrder + 1,
             isArchived: false,
             createdAt: Date.now(),

--- a/apps/web/src/routes/_authenticated/projects/$projectId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId.tsx
@@ -2,7 +2,8 @@ import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "convex-helpers/react/cache/hooks";
-import { Pencil, Trash2 } from "lucide-react";
+import { format } from "date-fns";
+import { Calendar as CalendarIcon, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { PageHeader } from "@/components/layout/page-header";
 import { ProjectFormDialog } from "@/components/projects/project-form-dialog";
@@ -110,6 +111,19 @@ function ProjectDetailPage() {
         }
       />
 
+      {(project.startDate || project.endDate) && (
+        <div className="mb-4 flex items-center gap-1.5 text-sm text-muted-foreground">
+          <CalendarIcon className="h-4 w-4" />
+          <span>
+            {project.startDate &&
+              format(new Date(project.startDate), "MMM d, yyyy")}
+            {project.startDate && project.endDate && " \u2013 "}
+            {project.endDate &&
+              format(new Date(project.endDate), "MMM d, yyyy")}
+          </span>
+        </div>
+      )}
+
       {project.definitionOfDone && (
         <div className="mb-6 rounded-md border p-4">
           <h2 className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
@@ -146,6 +160,10 @@ function ProjectDetailPage() {
               clearDescription: !data.description,
               definitionOfDone: data.definitionOfDone,
               clearDefinitionOfDone: !data.definitionOfDone,
+              startDate: data.startDate,
+              clearStartDate: !data.startDate,
+              endDate: data.endDate,
+              clearEndDate: !data.endDate,
             })
           }
         />


### PR DESCRIPTION
## Summary

- Add optional `startDate` and `endDate` fields to projects schema, mutations, form dialog, and detail page
- Date pickers use Popover+Calendar pattern (consistent with task due dates)
- Server-side validation: end date requires start date and must be on/after it
- Clearing start date automatically clears end date (both in mutations and UI)
- Optimistic updates handle date clearing correctly

## Test plan

- [ ] Create a project with start date only — verify it displays on detail page
- [ ] Create a project with both dates — verify range displays (e.g. "Jan 15, 2026 – Mar 30, 2026")
- [ ] Edit a project to add/change dates — verify optimistic update
- [ ] Clear start date — verify end date is also cleared
- [ ] Verify end date picker is disabled when no start date is set
- [ ] Verify end date calendar prevents selecting dates before start date
- [ ] Verify existing projects without dates still work unchanged
- [ ] `bun run lint` and `bun run build` pass

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)