### PR TITLE
feat(projects): use slug-based URLs instead of doc IDs

### DIFF
--- a/apps/web/convex/lib/slugs.ts
+++ b/apps/web/convex/lib/slugs.ts
@@ -1,0 +1,25 @@
+/**
+ * Slugifies a string: lowercase, replace non-alphanumeric with hyphens,
+ * collapse consecutive hyphens, trim leading/trailing hyphens.
+ */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
+ * Generates a Notion-style slug: slugified-name-8charsuffix.
+ * The suffix is 8 hex characters from crypto.getRandomValues.
+ */
+export function generateSlug(name: string): string {
+  const base = slugify(name);
+  const bytes = new Uint8Array(4);
+  crypto.getRandomValues(bytes);
+  const suffix = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return base ? `${base}-${suffix}` : suffix;
+}

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -5,6 +5,7 @@ export default defineSchema({
   projects: defineTable({
     userId: v.string(),
     name: v.string(),
+    slug: v.optional(v.string()),
     description: v.optional(v.string()),
     definitionOfDone: v.optional(v.string()),
     startDate: v.optional(v.number()),
@@ -14,7 +15,8 @@ export default defineSchema({
     createdAt: v.number(),
   })
     .index("by_user", ["userId"])
-    .index("by_user_order", ["userId", "order"]),
+    .index("by_user_order", ["userId", "order"])
+    .index("by_user_slug", ["userId", "slug"]),
 
   tasks: defineTable({
     userId: v.string(),

--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -109,16 +109,17 @@ export function AppSidebar() {
                       </SidebarMenuButton>
                     </SidebarMenuItem>
                     {projects?.map((project) => {
+                      const slug = project.slug ?? project._id;
                       return (
                         <SidebarMenuItem key={project._id}>
                           <SidebarMenuButton
                             asChild
-                            isActive={pathname === `/projects/${project._id}`}
+                            isActive={pathname === `/projects/${slug}`}
                             tooltip={project.name}
                           >
                             <Link
-                              to="/projects/$projectId"
-                              params={{ projectId: project._id }}
+                              to="/projects/$projectSlug"
+                              params={{ projectSlug: slug }}
                             >
                               <FolderOpen />
                               <span>{project.name}</span>
@@ -203,8 +204,11 @@ export function AppSidebar() {
         open={showCreateProject}
         onOpenChange={setShowCreateProject}
         onSubmit={async (data) => {
-          const projectId = await createProject(data);
-          navigate({ to: "/projects/$projectId", params: { projectId } });
+          const { slug } = await createProject(data);
+          navigate({
+            to: "/projects/$projectSlug",
+            params: { projectSlug: slug },
+          });
         }}
       />
     </>

--- a/apps/web/src/hooks/use-project-mutations.ts
+++ b/apps/web/src/hooks/use-project-mutations.ts
@@ -1,5 +1,6 @@
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
+import { generateSlug } from "@convex/lib/slugs";
 import { useMutation } from "convex/react";
 
 export function useProjectMutations() {
@@ -17,12 +18,16 @@ export function useProjectMutations() {
         resolved.endDate = undefined;
       }
 
+      const slugUpdate =
+        updates.name !== undefined ? { slug: generateSlug(updates.name) } : {};
+      const fullUpdates = { ...resolved, ...slugUpdate };
+
       const projects = localStore.getQuery(api.projects.list, {});
       if (projects !== undefined) {
         localStore.setQuery(
           api.projects.list,
           {},
-          projects.map((p) => (p._id === id ? { ...p, ...resolved } : p)),
+          projects.map((p) => (p._id === id ? { ...p, ...fullUpdates } : p)),
         );
       }
 
@@ -31,7 +36,7 @@ export function useProjectMutations() {
         localStore.setQuery(
           api.projects.get,
           { id },
-          { ...project, ...resolved },
+          { ...project, ...fullUpdates },
         );
       }
     },
@@ -67,6 +72,7 @@ export function useProjectMutations() {
             _creationTime: Date.now(),
             userId: "",
             name: args.name,
+            slug: generateSlug(args.name),
             description: args.description,
             definitionOfDone: args.definitionOfDone,
             startDate: args.startDate,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -15,7 +15,7 @@ import { Route as AuthenticatedIndexRouteImport } from './routes/_authenticated/
 import { Route as UnauthenticatedSignUpRouteImport } from './routes/_unauthenticated/sign-up'
 import { Route as UnauthenticatedSignInRouteImport } from './routes/_unauthenticated/sign-in'
 import { Route as AuthenticatedProjectsIndexRouteImport } from './routes/_authenticated/projects/index'
-import { Route as AuthenticatedProjectsProjectIdRouteImport } from './routes/_authenticated/projects/$projectId'
+import { Route as AuthenticatedProjectsProjectSlugRouteImport } from './routes/_authenticated/projects/$projectSlug'
 
 const UnauthenticatedRouteRoute = UnauthenticatedRouteRouteImport.update({
   id: '/_unauthenticated',
@@ -46,10 +46,10 @@ const AuthenticatedProjectsIndexRoute =
     path: '/projects/',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
-const AuthenticatedProjectsProjectIdRoute =
-  AuthenticatedProjectsProjectIdRouteImport.update({
-    id: '/projects/$projectId',
-    path: '/projects/$projectId',
+const AuthenticatedProjectsProjectSlugRoute =
+  AuthenticatedProjectsProjectSlugRouteImport.update({
+    id: '/projects/$projectSlug',
+    path: '/projects/$projectSlug',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
 
@@ -57,14 +57,14 @@ export interface FileRoutesByFullPath {
   '/': typeof AuthenticatedIndexRoute
   '/sign-in': typeof UnauthenticatedSignInRoute
   '/sign-up': typeof UnauthenticatedSignUpRoute
-  '/projects/$projectId': typeof AuthenticatedProjectsProjectIdRoute
+  '/projects/$projectSlug': typeof AuthenticatedProjectsProjectSlugRoute
   '/projects/': typeof AuthenticatedProjectsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof AuthenticatedIndexRoute
   '/sign-in': typeof UnauthenticatedSignInRoute
   '/sign-up': typeof UnauthenticatedSignUpRoute
-  '/projects/$projectId': typeof AuthenticatedProjectsProjectIdRoute
+  '/projects/$projectSlug': typeof AuthenticatedProjectsProjectSlugRoute
   '/projects': typeof AuthenticatedProjectsIndexRoute
 }
 export interface FileRoutesById {
@@ -74,7 +74,7 @@ export interface FileRoutesById {
   '/_unauthenticated/sign-in': typeof UnauthenticatedSignInRoute
   '/_unauthenticated/sign-up': typeof UnauthenticatedSignUpRoute
   '/_authenticated/': typeof AuthenticatedIndexRoute
-  '/_authenticated/projects/$projectId': typeof AuthenticatedProjectsProjectIdRoute
+  '/_authenticated/projects/$projectSlug': typeof AuthenticatedProjectsProjectSlugRoute
   '/_authenticated/projects/': typeof AuthenticatedProjectsIndexRoute
 }
 export interface FileRouteTypes {
@@ -83,10 +83,10 @@ export interface FileRouteTypes {
     | '/'
     | '/sign-in'
     | '/sign-up'
-    | '/projects/$projectId'
+    | '/projects/$projectSlug'
     | '/projects/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/sign-in' | '/sign-up' | '/projects/$projectId' | '/projects'
+  to: '/' | '/sign-in' | '/sign-up' | '/projects/$projectSlug' | '/projects'
   id:
     | '__root__'
     | '/_authenticated'
@@ -94,7 +94,7 @@ export interface FileRouteTypes {
     | '/_unauthenticated/sign-in'
     | '/_unauthenticated/sign-up'
     | '/_authenticated/'
-    | '/_authenticated/projects/$projectId'
+    | '/_authenticated/projects/$projectSlug'
     | '/_authenticated/projects/'
   fileRoutesById: FileRoutesById
 }
@@ -147,11 +147,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
-    '/_authenticated/projects/$projectId': {
-      id: '/_authenticated/projects/$projectId'
-      path: '/projects/$projectId'
-      fullPath: '/projects/$projectId'
-      preLoaderRoute: typeof AuthenticatedProjectsProjectIdRouteImport
+    '/_authenticated/projects/$projectSlug': {
+      id: '/_authenticated/projects/$projectSlug'
+      path: '/projects/$projectSlug'
+      fullPath: '/projects/$projectSlug'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
   }
@@ -159,13 +159,13 @@ declare module '@tanstack/react-router' {
 
 interface AuthenticatedRouteRouteChildren {
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute
-  AuthenticatedProjectsProjectIdRoute: typeof AuthenticatedProjectsProjectIdRoute
+  AuthenticatedProjectsProjectSlugRoute: typeof AuthenticatedProjectsProjectSlugRoute
   AuthenticatedProjectsIndexRoute: typeof AuthenticatedProjectsIndexRoute
 }
 
 const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedIndexRoute: AuthenticatedIndexRoute,
-  AuthenticatedProjectsProjectIdRoute: AuthenticatedProjectsProjectIdRoute,
+  AuthenticatedProjectsProjectSlugRoute: AuthenticatedProjectsProjectSlugRoute,
   AuthenticatedProjectsIndexRoute: AuthenticatedProjectsIndexRoute,
 }
 

--- a/apps/web/src/routes/_authenticated/projects/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/index.tsx
@@ -90,8 +90,10 @@ function ProjectsPage() {
             filteredProjects.map((project) => (
               <div key={project._id}>
                 <Link
-                  to="/projects/$projectId"
-                  params={{ projectId: project._id }}
+                  to="/projects/$projectSlug"
+                  params={{
+                    projectSlug: project.slug ?? project._id,
+                  }}
                   className="-mx-2 flex items-center gap-3 rounded px-2 py-3 transition-colors hover:bg-muted/50"
                 >
                   <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Summary
- Replace Convex document IDs in project URLs with human-readable Notion-style slugs (`my-project-a1b2c3d4`)
- Slugs regenerate when a project is renamed, updating the browser URL in-place
- Includes a `backfillSlugs` mutation for existing projects (run post-deploy via `bunx convex run projects:backfillSlugs`)

## Test plan
- [ ] Create a new project — URL should be `/projects/<slugified-name>-<8chars>`
- [ ] Click project in sidebar and project list — navigates to slug URL
- [ ] Rename a project — URL updates in-place without page reload
- [ ] Refresh page on a slug URL — loads correctly
- [ ] Archive a project — slug URL shows "Project not found"
- [ ] Sidebar highlights correct project on slug URLs
- [ ] Run `bunx convex run projects:backfillSlugs` — existing projects get slugs

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)