### PR TITLE
feat(projects): add timeline view to projects page

### DIFF
--- a/apps/web/src/components/projects/project-timeline-bar.tsx
+++ b/apps/web/src/components/projects/project-timeline-bar.tsx
@@ -1,0 +1,55 @@
+import type { Doc } from "@convex/_generated/dataModel";
+import { Link } from "@tanstack/react-router";
+import { differenceInCalendarDays } from "date-fns";
+import { cn } from "@/lib/utils";
+
+const DAY_WIDTH = 24;
+
+interface ProjectTimelineBarProps {
+  project: Doc<"projects"> & { startDate: number };
+  rangeStart: Date;
+  today: Date;
+}
+
+export function ProjectTimelineBar({
+  project,
+  rangeStart,
+  today,
+}: ProjectTimelineBarProps) {
+  const startDate = new Date(project.startDate);
+  const endDate = project.endDate ? new Date(project.endDate) : today;
+  const hasEndDate = !!project.endDate;
+
+  const startOffset = differenceInCalendarDays(startDate, rangeStart);
+  const duration = differenceInCalendarDays(endDate, startDate) + 1;
+
+  return (
+    <div className="relative h-10 w-full">
+      <Link
+        to="/projects/$projectSlug"
+        params={{
+          projectSlug: project.slug ?? project._id,
+        }}
+        className={cn(
+          "absolute top-1 flex h-8 items-center px-2",
+          "bg-primary/15 text-foreground border border-primary/25",
+          "text-xs font-medium truncate transition-colors",
+          "hover:ring-2 hover:ring-ring/50",
+          hasEndDate ? "rounded-md" : "rounded-l-md border-r-0",
+        )}
+        style={{
+          left: startOffset * DAY_WIDTH,
+          width: duration * DAY_WIDTH,
+          minWidth: "3rem",
+          ...(!hasEndDate && {
+            maskImage: "linear-gradient(to right, black 60%, transparent)",
+            WebkitMaskImage:
+              "linear-gradient(to right, black 60%, transparent)",
+          }),
+        }}
+      >
+        <span className="truncate">{project.name}</span>
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/components/projects/project-timeline.tsx
+++ b/apps/web/src/components/projects/project-timeline.tsx
@@ -1,0 +1,160 @@
+import type { Doc } from "@convex/_generated/dataModel";
+import {
+  addMonths,
+  differenceInCalendarDays,
+  eachDayOfInterval,
+  eachMonthOfInterval,
+  endOfMonth,
+  format,
+  isToday,
+  startOfMonth,
+} from "date-fns";
+import { CalendarRange } from "lucide-react";
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { ProjectTimelineBar } from "./project-timeline-bar";
+
+const DAY_WIDTH = 24;
+
+type ProjectWithStartDate = Doc<"projects"> & {
+  startDate: number;
+};
+
+interface ProjectTimelineProps {
+  projects: Doc<"projects">[];
+}
+
+export function ProjectTimeline({ projects }: ProjectTimelineProps) {
+  const today = useMemo(() => new Date(), []);
+
+  const timelineProjects = useMemo(
+    () =>
+      projects.filter(
+        (p): p is ProjectWithStartDate => p.startDate !== undefined,
+      ),
+    [projects],
+  );
+
+  const { rangeStart, rangeEnd, totalWidth } = useMemo(() => {
+    if (timelineProjects.length === 0) {
+      return {
+        rangeStart: today,
+        rangeEnd: today,
+        totalWidth: 0,
+      };
+    }
+
+    const earliest = Math.min(...timelineProjects.map((p) => p.startDate));
+    const latestEnd = Math.max(
+      today.getTime(),
+      ...timelineProjects.map((p) => p.endDate ?? today.getTime()),
+    );
+
+    const start = startOfMonth(new Date(earliest));
+    const end = endOfMonth(addMonths(new Date(latestEnd), 1));
+    const days = differenceInCalendarDays(end, start) + 1;
+
+    return {
+      rangeStart: start,
+      rangeEnd: end,
+      totalWidth: days * DAY_WIDTH,
+    };
+  }, [timelineProjects, today]);
+
+  const months = useMemo(() => {
+    if (timelineProjects.length === 0) return [];
+    return eachMonthOfInterval({
+      start: rangeStart,
+      end: rangeEnd,
+    });
+  }, [timelineProjects.length, rangeStart, rangeEnd]);
+
+  const days = useMemo(() => {
+    if (timelineProjects.length === 0) return [];
+    return eachDayOfInterval({
+      start: rangeStart,
+      end: rangeEnd,
+    });
+  }, [timelineProjects.length, rangeStart, rangeEnd]);
+
+  if (timelineProjects.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <CalendarRange className="mb-3 h-10 w-10 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
+          Add dates to your projects to see them on the timeline.
+        </p>
+      </div>
+    );
+  }
+
+  const todayOffset = differenceInCalendarDays(today, rangeStart);
+  const todayLeft = todayOffset * DAY_WIDTH;
+
+  return (
+    <div className="overflow-x-auto rounded-md border">
+      <div style={{ width: totalWidth }}>
+        {/* Month labels */}
+        <div className="flex border-b bg-background">
+          {months.map((month, i) => {
+            const monthStart = i === 0 ? rangeStart : startOfMonth(month);
+            const monthEnd =
+              i === months.length - 1 ? rangeEnd : startOfMonth(months[i + 1]);
+            const spanDays =
+              differenceInCalendarDays(monthEnd, monthStart) +
+              (i === months.length - 1 ? 1 : 0);
+
+            return (
+              <div
+                key={month.getTime()}
+                className="border-r px-2 py-1 text-xs font-medium text-muted-foreground"
+                style={{ width: spanDays * DAY_WIDTH }}
+              >
+                {format(month, "MMM yyyy")}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Day numbers */}
+        <div className="flex border-b bg-background">
+          {days.map((day) => (
+            <div
+              key={day.getTime()}
+              className={cn(
+                "shrink-0 text-center text-[10px] leading-6",
+                isToday(day)
+                  ? "font-bold text-destructive"
+                  : day.getDay() === 0 || day.getDay() === 6
+                    ? "text-muted-foreground/50"
+                    : "text-muted-foreground",
+              )}
+              style={{ width: DAY_WIDTH }}
+            >
+              {day.getDate()}
+            </div>
+          ))}
+        </div>
+
+        {/* Timeline body */}
+        <div className="relative py-1">
+          {/* Today marker */}
+          <div
+            className="pointer-events-none absolute top-0 bottom-0 z-10 w-px bg-destructive/50"
+            style={{ left: todayLeft + DAY_WIDTH / 2 }}
+          />
+
+          {/* Project rows */}
+          {timelineProjects.map((project) => (
+            <ProjectTimelineBar
+              key={project._id}
+              project={project}
+              rangeStart={rangeStart}
+              today={today}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -24,7 +24,7 @@ function Inbox() {
   }
 
   return (
-    <div>
+    <div className="mx-auto max-w-3xl">
       <PageHeader title="Inbox" />
       <div>
         {activeTasks.map((task) => (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -66,7 +66,7 @@ function ProjectDetailPage() {
   };
 
   return (
-    <div>
+    <div className="mx-auto max-w-3xl">
       <PageHeader
         title={project.name}
         backLink={{ label: "Projects", to: "/projects" }}

--- a/apps/web/src/routes/_authenticated/projects/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/index.tsx
@@ -1,10 +1,12 @@
 import { api } from "@convex/_generated/api";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useQuery } from "convex-helpers/react/cache/hooks";
+import { format } from "date-fns";
 import { FolderOpen, Plus } from "lucide-react";
 import { useState } from "react";
 import { PageHeader } from "@/components/layout/page-header";
 import { ProjectFormDialog } from "@/components/projects/project-form-dialog";
+import { ProjectTimeline } from "@/components/projects/project-timeline";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { useProjectMutations } from "@/hooks/use-project-mutations";
@@ -25,52 +27,65 @@ function ProjectsPage() {
 
   return (
     <div>
-      <PageHeader
-        title="Projects"
-        actions={
-          <Button
-            size="sm"
-            className="gap-1.5"
-            onClick={() => setShowCreate(true)}
-          >
-            <Plus className="h-4 w-4" />
-            New project
-          </Button>
-        }
-      />
+      <div className="mx-auto max-w-3xl">
+        <PageHeader
+          title="Projects"
+          actions={
+            <Button
+              size="sm"
+              className="gap-1.5"
+              onClick={() => setShowCreate(true)}
+            >
+              <Plus className="h-4 w-4" />
+              New project
+            </Button>
+          }
+        />
+      </div>
 
-      {projects.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-16 text-center">
-          <FolderOpen className="mb-3 h-10 w-10 text-muted-foreground" />
-          <p className="text-sm text-muted-foreground">
-            No projects yet. Create one to organize your tasks.
-          </p>
-        </div>
-      ) : (
-        <div>
-          {projects.map((project) => (
-            <div key={project._id}>
-              <Link
-                to="/projects/$projectSlug"
-                params={{
-                  projectSlug: project.slug ?? project._id,
-                }}
-                className="-mx-2 flex items-center gap-3 rounded px-2 py-3 transition-colors hover:bg-muted/50"
-              >
-                <div className="min-w-0 flex-1">
-                  <span className="font-medium">{project.name}</span>
-                  {project.description && (
-                    <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                      {project.description}
-                    </p>
+      <ProjectTimeline projects={projects} />
+
+      <div className="mx-auto mt-6 max-w-3xl">
+        {projects.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <FolderOpen className="mb-3 h-10 w-10 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              No projects yet. Create one to organize your tasks.
+            </p>
+          </div>
+        ) : (
+          <div>
+            {projects.map((project) => (
+              <div key={project._id}>
+                <Link
+                  to="/projects/$projectSlug"
+                  params={{
+                    projectSlug: project.slug ?? project._id,
+                  }}
+                  className="-mx-2 flex items-center gap-3 rounded px-2 py-3 transition-colors hover:bg-muted/50"
+                >
+                  <div className="min-w-0 flex-1">
+                    <span className="font-medium">{project.name}</span>
+                    {project.description && (
+                      <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                        {project.description}
+                      </p>
+                    )}
+                  </div>
+                  {project.startDate && (
+                    <span className="shrink-0 text-xs text-muted-foreground">
+                      {format(new Date(project.startDate), "MMM d")}
+                      {project.endDate &&
+                        ` – ${format(new Date(project.endDate), "MMM d")}`}
+                    </span>
                   )}
-                </div>
-              </Link>
-              <Separator />
-            </div>
-          ))}
-        </div>
-      )}
+                </Link>
+                <Separator />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
 
       <ProjectFormDialog
         open={showCreate}
@@ -83,7 +98,7 @@ function ProjectsPage() {
 
 function ProjectsListSkeleton() {
   return (
-    <div>
+    <div className="mx-auto max-w-3xl">
       <div className="mb-6 flex items-center justify-between">
         <div className="h-8 w-24 animate-pulse rounded bg-muted" />
         <div className="h-8 w-28 animate-pulse rounded bg-muted" />

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -23,9 +23,9 @@ function AuthenticatedLayout() {
   return (
     <SidebarProvider>
       <AppSidebar />
-      <SidebarInset>
+      <SidebarInset className="overflow-x-hidden">
         <AppHeader />
-        <main className="mx-auto w-full max-w-3xl px-4 py-8">
+        <main className="w-full px-4 py-8">
           <Outlet />
         </main>
       </SidebarInset>


### PR DESCRIPTION
## Summary
- Add Gantt-style timeline to the projects page showing projects as horizontal bars on a day-level time axis
- Timeline always visible above the project list, with month/year headers and day numbers
- Projects with end dates show solid bars; open-ended projects fade out to the right
- Today marked with a vertical red line; weekends dimmed in the header
- Project list below shows date ranges alongside each project name
- Layout updated so timeline takes full content width while list stays at `max-w-3xl`

Closes #35

## Test plan
- [x] Verify timeline renders projects with start + end dates as solid bars
- [x] Verify projects with only a start date show a fading bar extending to today
- [x] Verify projects without dates are excluded from timeline but appear in the list
- [x] Verify clicking a timeline bar navigates to the project detail page
- [x] Verify today marker appears at the correct position
- [x] Verify horizontal scroll works when timeline extends beyond viewport
- [x] Verify empty state shown when no projects have dates
- [x] Verify inbox and project detail pages are unaffected by layout changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)