### PR TITLE
feat(areas): add areas for organizing projects

### DIFF
--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -8,8 +8,10 @@
  * @module
  */
 
+import type * as areas from "../areas.js";
 import type * as auth from "../auth.js";
 import type * as http from "../http.js";
+import type * as lib_slugs from "../lib/slugs.js";
 import type * as projects from "../projects.js";
 import type * as tasks from "../tasks.js";
 
@@ -20,8 +22,10 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  areas: typeof areas;
   auth: typeof auth;
   http: typeof http;
+  "lib/slugs": typeof lib_slugs;
   projects: typeof projects;
   tasks: typeof tasks;
 }>;

--- a/apps/web/convex/areas.ts
+++ b/apps/web/convex/areas.ts
@@ -1,0 +1,162 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { authComponent } from "./auth";
+import { generateSlug } from "./lib/slugs";
+
+export const list = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+    if (!user) return [];
+    const userId = String(user._id);
+    return ctx.db
+      .query("areas")
+      .withIndex("by_user_order", (q) => q.eq("userId", userId))
+      .collect();
+  },
+});
+
+export const get = query({
+  args: { id: v.id("areas") },
+  handler: async (ctx, args) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+    if (!user) return null;
+    const area = await ctx.db.get(args.id);
+    if (!area || area.userId !== String(user._id)) return null;
+    return area;
+  },
+});
+
+export const getBySlug = query({
+  args: { slug: v.string() },
+  handler: async (ctx, args) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+    if (!user) return null;
+    const userId = String(user._id);
+    return ctx.db
+      .query("areas")
+      .withIndex("by_user_slug", (q) =>
+        q.eq("userId", userId).eq("slug", args.slug),
+      )
+      .unique();
+  },
+});
+
+const healthStatusValidator = v.union(
+  v.literal("healthy"),
+  v.literal("needs_attention"),
+  v.literal("critical"),
+);
+
+export const create = mutation({
+  args: {
+    name: v.string(),
+    standard: v.optional(v.string()),
+    healthStatus: healthStatusValidator,
+  },
+  handler: async (ctx, args) => {
+    const user = await authComponent.getAuthUser(ctx);
+    const userId = String(user._id);
+
+    const existing = await ctx.db
+      .query("areas")
+      .withIndex("by_user_order", (q) => q.eq("userId", userId))
+      .order("desc")
+      .first();
+
+    const nextOrder = existing ? existing.order + 1 : 0;
+    const slug = generateSlug(args.name);
+
+    const id = await ctx.db.insert("areas", {
+      userId,
+      name: args.name,
+      slug,
+      standard: args.standard,
+      healthStatus: args.healthStatus,
+      order: nextOrder,
+      createdAt: Date.now(),
+    });
+
+    return { id, slug };
+  },
+});
+
+export const update = mutation({
+  args: {
+    id: v.id("areas"),
+    name: v.optional(v.string()),
+    standard: v.optional(v.string()),
+    clearStandard: v.optional(v.boolean()),
+    healthStatus: v.optional(healthStatusValidator),
+  },
+  handler: async (ctx, args) => {
+    const user = await authComponent.getAuthUser(ctx);
+    const userId = String(user._id);
+
+    const area = await ctx.db.get(args.id);
+    if (!area || area.userId !== userId) {
+      throw new Error("Area not found");
+    }
+
+    const updates: Record<string, unknown> = {};
+    if (args.name !== undefined) {
+      updates.name = args.name;
+      updates.slug = generateSlug(args.name);
+    }
+    if (args.clearStandard) {
+      updates.standard = undefined;
+    } else if (args.standard !== undefined) {
+      updates.standard = args.standard;
+    }
+    if (args.healthStatus !== undefined) {
+      updates.healthStatus = args.healthStatus;
+    }
+
+    await ctx.db.patch(args.id, updates);
+
+    return { slug: (updates.slug as string) ?? area.slug };
+  },
+});
+
+export const remove = mutation({
+  args: { id: v.id("areas") },
+  handler: async (ctx, args) => {
+    const user = await authComponent.getAuthUser(ctx);
+    const userId = String(user._id);
+
+    const area = await ctx.db.get(args.id);
+    if (!area || area.userId !== userId) {
+      throw new Error("Area not found");
+    }
+
+    // Unassign all projects from this area
+    const projects = await ctx.db
+      .query("projects")
+      .withIndex("by_area", (q) => q.eq("areaId", args.id))
+      .collect();
+
+    for (const project of projects) {
+      await ctx.db.patch(project._id, { areaId: undefined });
+    }
+
+    await ctx.db.delete(args.id);
+  },
+});
+
+export const reorder = mutation({
+  args: {
+    items: v.array(v.object({ id: v.id("areas"), order: v.number() })),
+  },
+  handler: async (ctx, args) => {
+    const user = await authComponent.getAuthUser(ctx);
+    const userId = String(user._id);
+
+    for (const item of args.items) {
+      const area = await ctx.db.get(item.id);
+      if (!area || area.userId !== userId) {
+        throw new Error("Area not found");
+      }
+      await ctx.db.patch(item.id, { order: item.order });
+    }
+  },
+});

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -2,12 +2,30 @@ import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 export default defineSchema({
+  areas: defineTable({
+    userId: v.string(),
+    name: v.string(),
+    slug: v.optional(v.string()),
+    standard: v.optional(v.string()),
+    healthStatus: v.union(
+      v.literal("healthy"),
+      v.literal("needs_attention"),
+      v.literal("critical"),
+    ),
+    order: v.number(),
+    createdAt: v.number(),
+  })
+    .index("by_user", ["userId"])
+    .index("by_user_order", ["userId", "order"])
+    .index("by_user_slug", ["userId", "slug"]),
+
   projects: defineTable({
     userId: v.string(),
     name: v.string(),
     slug: v.optional(v.string()),
     description: v.optional(v.string()),
     definitionOfDone: v.optional(v.string()),
+    areaId: v.optional(v.id("areas")),
     startDate: v.optional(v.number()),
     endDate: v.optional(v.number()),
     order: v.number(),
@@ -16,7 +34,8 @@ export default defineSchema({
   })
     .index("by_user", ["userId"])
     .index("by_user_order", ["userId", "order"])
-    .index("by_user_slug", ["userId", "slug"]),
+    .index("by_user_slug", ["userId", "slug"])
+    .index("by_area", ["areaId"]),
 
   tasks: defineTable({
     userId: v.string(),

--- a/apps/web/src/components/areas/area-card.tsx
+++ b/apps/web/src/components/areas/area-card.tsx
@@ -1,0 +1,33 @@
+import type { Doc } from "@convex/_generated/dataModel";
+import { Link } from "@tanstack/react-router";
+
+const healthColors = {
+  healthy: "bg-green-500",
+  needs_attention: "bg-yellow-500",
+  critical: "bg-red-500",
+} as const;
+
+interface AreaCardProps {
+  area: Doc<"areas">;
+  projectCount: number;
+}
+
+export function AreaCard({ area, projectCount }: AreaCardProps) {
+  return (
+    <Link
+      to="/areas/$areaSlug"
+      params={{ areaSlug: area.slug ?? area._id }}
+      className="flex items-center gap-3 rounded-lg border p-3 transition-colors hover:bg-muted/50"
+    >
+      <span
+        className={`h-2.5 w-2.5 shrink-0 rounded-full ${healthColors[area.healthStatus]}`}
+      />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{area.name}</p>
+        <p className="text-xs text-muted-foreground">
+          {projectCount} {projectCount === 1 ? "project" : "projects"}
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/src/components/areas/area-form-dialog.tsx
+++ b/apps/web/src/components/areas/area-form-dialog.tsx
@@ -1,0 +1,125 @@
+import type { Doc } from "@convex/_generated/dataModel";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+type HealthStatus = "healthy" | "needs_attention" | "critical";
+
+interface AreaFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: {
+    name: string;
+    standard?: string;
+    healthStatus: HealthStatus;
+  }) => void;
+  area?: Doc<"areas">;
+}
+
+export function AreaFormDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  area,
+}: AreaFormDialogProps) {
+  const [name, setName] = useState(area?.name ?? "");
+  const [standard, setStandard] = useState(area?.standard ?? "");
+  const [healthStatus, setHealthStatus] = useState<HealthStatus>(
+    area?.healthStatus ?? "healthy",
+  );
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+
+    onSubmit({
+      name: trimmedName,
+      standard: standard.trim() || undefined,
+      healthStatus,
+    });
+
+    if (!area) {
+      setName("");
+      setStandard("");
+      setHealthStatus("healthy");
+    }
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{area ? "Edit area" : "New area"}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="area-name">Name</Label>
+            <Input
+              id="area-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Health, Career, Finances"
+              autoFocus
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="area-standard">Standard</Label>
+            <Textarea
+              id="area-standard"
+              value={standard}
+              onChange={(e) => setStandard(e.target.value)}
+              placeholder="What does 'good enough' look like?"
+              rows={3}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="area-health">Health status</Label>
+            <Select
+              value={healthStatus}
+              onValueChange={(v) => setHealthStatus(v as HealthStatus)}
+            >
+              <SelectTrigger id="area-health">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="healthy">Healthy</SelectItem>
+                <SelectItem value="needs_attention">Needs attention</SelectItem>
+                <SelectItem value="critical">Critical</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!name.trim()}>
+              {area ? "Save" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/areas/area-picker.tsx
+++ b/apps/web/src/components/areas/area-picker.tsx
@@ -1,0 +1,63 @@
+import type { Doc } from "@convex/_generated/dataModel";
+import { Compass, X } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+interface AreaPickerProps {
+  areas: Doc<"areas">[];
+  selectedAreaId: string | undefined;
+  onSelect: (id: string | undefined) => void;
+}
+
+export function AreaPicker({
+  areas,
+  selectedAreaId,
+  onSelect,
+}: AreaPickerProps) {
+  const [open, setOpen] = useState(false);
+  const selected = areas.find((a) => a._id === selectedAreaId);
+
+  return (
+    <div className="flex items-center gap-1">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs">
+            <Compass className="h-3 w-3" />
+            {selected ? selected.name : "Area"}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-48 p-1" align="start">
+          {areas.map((a) => (
+            <button
+              key={a._id}
+              type="button"
+              onClick={() => {
+                onSelect(a._id);
+                setOpen(false);
+              }}
+              className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-muted"
+            >
+              {a.name}
+            </button>
+          ))}
+        </PopoverContent>
+      </Popover>
+      {selected && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={() => onSelect(undefined)}
+          aria-label="Clear area"
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/projects/project-form-dialog.tsx
+++ b/apps/web/src/components/projects/project-form-dialog.tsx
@@ -2,6 +2,7 @@ import type { Doc } from "@convex/_generated/dataModel";
 import { format } from "date-fns";
 import { Calendar as CalendarIcon, X } from "lucide-react";
 import { useState } from "react";
+import { AreaPicker } from "@/components/areas/area-picker";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import {
@@ -27,10 +28,13 @@ interface ProjectFormDialogProps {
     name: string;
     description?: string;
     definitionOfDone?: string;
+    areaId?: string;
     startDate?: number;
     endDate?: number;
   }) => void;
   project?: Doc<"projects">;
+  areas?: Doc<"areas">[];
+  defaultAreaId?: string;
 }
 
 export function ProjectFormDialog({
@@ -38,11 +42,16 @@ export function ProjectFormDialog({
   onOpenChange,
   onSubmit,
   project,
+  areas,
+  defaultAreaId,
 }: ProjectFormDialogProps) {
   const [name, setName] = useState(project?.name ?? "");
   const [description, setDescription] = useState(project?.description ?? "");
   const [definitionOfDone, setDefinitionOfDone] = useState(
     project?.definitionOfDone ?? "",
+  );
+  const [areaId, setAreaId] = useState<string | undefined>(
+    project?.areaId ?? defaultAreaId,
   );
   const [startDate, setStartDate] = useState<Date | undefined>(
     project?.startDate ? new Date(project.startDate) : undefined,
@@ -67,6 +76,7 @@ export function ProjectFormDialog({
       name: trimmedName,
       description: description.trim() || undefined,
       definitionOfDone: definitionOfDone.trim() || undefined,
+      areaId,
       startDate: startDate?.getTime(),
       endDate: endDate?.getTime(),
     });
@@ -75,6 +85,7 @@ export function ProjectFormDialog({
       setName("");
       setDescription("");
       setDefinitionOfDone("");
+      setAreaId(defaultAreaId);
       setStartDate(undefined);
       setEndDate(undefined);
     }
@@ -191,6 +202,16 @@ export function ProjectFormDialog({
               )}
             </div>
           </div>
+          {areas && areas.length > 0 && (
+            <div className="space-y-2">
+              <Label>Area</Label>
+              <AreaPicker
+                areas={areas}
+                selectedAreaId={areaId}
+                onSelect={setAreaId}
+              />
+            </div>
+          )}
           <DialogFooter>
             <Button
               type="button"

--- a/apps/web/src/hooks/use-area-mutations.ts
+++ b/apps/web/src/hooks/use-area-mutations.ts
@@ -1,0 +1,104 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { generateSlug } from "@convex/lib/slugs";
+import { useMutation } from "convex/react";
+
+export function useAreaMutations() {
+  const createArea = useMutation(api.areas.create).withOptimisticUpdate(
+    (localStore, args) => {
+      const areas = localStore.getQuery(api.areas.list, {});
+      if (areas !== undefined) {
+        const maxOrder = areas.reduce((max, a) => Math.max(max, a.order), -1);
+        localStore.setQuery(api.areas.list, {}, [
+          ...areas,
+          {
+            _id: crypto.randomUUID() as Id<"areas">,
+            _creationTime: Date.now(),
+            userId: "",
+            name: args.name,
+            slug: generateSlug(args.name),
+            standard: args.standard,
+            healthStatus: args.healthStatus,
+            order: maxOrder + 1,
+            createdAt: Date.now(),
+          },
+        ]);
+      }
+    },
+  );
+
+  const updateArea = useMutation(api.areas.update).withOptimisticUpdate(
+    (localStore, args) => {
+      const { id, ...updates } = args;
+
+      const resolved = { ...updates };
+      if (updates.clearStandard) {
+        resolved.standard = undefined;
+      }
+
+      const slugUpdate =
+        updates.name !== undefined ? { slug: generateSlug(updates.name) } : {};
+      const fullUpdates = { ...resolved, ...slugUpdate };
+
+      const areas = localStore.getQuery(api.areas.list, {});
+      if (areas !== undefined) {
+        localStore.setQuery(
+          api.areas.list,
+          {},
+          areas.map((a) => (a._id === id ? { ...a, ...fullUpdates } : a)),
+        );
+      }
+
+      const area = localStore.getQuery(api.areas.get, { id });
+      if (area !== undefined && area !== null) {
+        localStore.setQuery(api.areas.get, { id }, { ...area, ...fullUpdates });
+      }
+    },
+  );
+
+  const removeArea = useMutation(api.areas.remove).withOptimisticUpdate(
+    (localStore, args) => {
+      const areas = localStore.getQuery(api.areas.list, {});
+      if (areas !== undefined) {
+        localStore.setQuery(
+          api.areas.list,
+          {},
+          areas.filter((a) => a._id !== args.id),
+        );
+      }
+
+      localStore.setQuery(api.areas.get, { id: args.id }, null);
+
+      // Unassign projects from this area
+      const projects = localStore.getQuery(api.projects.list, {});
+      if (projects !== undefined) {
+        localStore.setQuery(
+          api.projects.list,
+          {},
+          projects.map((p) =>
+            p.areaId === args.id ? { ...p, areaId: undefined } : p,
+          ),
+        );
+      }
+    },
+  );
+
+  const reorderAreas = useMutation(api.areas.reorder).withOptimisticUpdate(
+    (localStore, args) => {
+      const areas = localStore.getQuery(api.areas.list, {});
+      if (areas !== undefined) {
+        const orderMap = new Map(
+          args.items.map((item) => [item.id, item.order]),
+        );
+        const updated = areas.map((a) => {
+          const newOrder = orderMap.get(a._id);
+          return newOrder !== undefined ? { ...a, order: newOrder } : a;
+        });
+        updated.sort((a, b) => a.order - b.order);
+        localStore.setQuery(api.areas.list, {}, updated);
+      }
+    },
+  );
+
+  return { createArea, updateArea, removeArea, reorderAreas };
+}

--- a/apps/web/src/hooks/use-project-mutations.ts
+++ b/apps/web/src/hooks/use-project-mutations.ts
@@ -8,7 +8,7 @@ export function useProjectMutations() {
     (localStore, args) => {
       const { id, ...updates } = args;
 
-      // Handle date clearing in optimistic state
+      // Handle clearing in optimistic state
       const resolved = { ...updates };
       if (updates.clearStartDate) {
         resolved.startDate = undefined;
@@ -16,6 +16,9 @@ export function useProjectMutations() {
       }
       if (updates.clearEndDate) {
         resolved.endDate = undefined;
+      }
+      if (updates.clearAreaId) {
+        resolved.areaId = undefined;
       }
 
       const slugUpdate =
@@ -75,6 +78,7 @@ export function useProjectMutations() {
             slug: generateSlug(args.name),
             description: args.description,
             definitionOfDone: args.definitionOfDone,
+            areaId: args.areaId,
             startDate: args.startDate,
             endDate: args.endDate,
             order: maxOrder + 1,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as UnauthenticatedSignUpRouteImport } from './routes/_unauthentic
 import { Route as UnauthenticatedSignInRouteImport } from './routes/_unauthenticated/sign-in'
 import { Route as AuthenticatedProjectsIndexRouteImport } from './routes/_authenticated/projects/index'
 import { Route as AuthenticatedProjectsProjectSlugRouteImport } from './routes/_authenticated/projects/$projectSlug'
+import { Route as AuthenticatedAreasAreaSlugRouteImport } from './routes/_authenticated/areas/$areaSlug'
 
 const UnauthenticatedRouteRoute = UnauthenticatedRouteRouteImport.update({
   id: '/_unauthenticated',
@@ -52,11 +53,18 @@ const AuthenticatedProjectsProjectSlugRoute =
     path: '/projects/$projectSlug',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedAreasAreaSlugRoute =
+  AuthenticatedAreasAreaSlugRouteImport.update({
+    id: '/areas/$areaSlug',
+    path: '/areas/$areaSlug',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof AuthenticatedIndexRoute
   '/sign-in': typeof UnauthenticatedSignInRoute
   '/sign-up': typeof UnauthenticatedSignUpRoute
+  '/areas/$areaSlug': typeof AuthenticatedAreasAreaSlugRoute
   '/projects/$projectSlug': typeof AuthenticatedProjectsProjectSlugRoute
   '/projects/': typeof AuthenticatedProjectsIndexRoute
 }
@@ -64,6 +72,7 @@ export interface FileRoutesByTo {
   '/': typeof AuthenticatedIndexRoute
   '/sign-in': typeof UnauthenticatedSignInRoute
   '/sign-up': typeof UnauthenticatedSignUpRoute
+  '/areas/$areaSlug': typeof AuthenticatedAreasAreaSlugRoute
   '/projects/$projectSlug': typeof AuthenticatedProjectsProjectSlugRoute
   '/projects': typeof AuthenticatedProjectsIndexRoute
 }
@@ -74,6 +83,7 @@ export interface FileRoutesById {
   '/_unauthenticated/sign-in': typeof UnauthenticatedSignInRoute
   '/_unauthenticated/sign-up': typeof UnauthenticatedSignUpRoute
   '/_authenticated/': typeof AuthenticatedIndexRoute
+  '/_authenticated/areas/$areaSlug': typeof AuthenticatedAreasAreaSlugRoute
   '/_authenticated/projects/$projectSlug': typeof AuthenticatedProjectsProjectSlugRoute
   '/_authenticated/projects/': typeof AuthenticatedProjectsIndexRoute
 }
@@ -83,10 +93,17 @@ export interface FileRouteTypes {
     | '/'
     | '/sign-in'
     | '/sign-up'
+    | '/areas/$areaSlug'
     | '/projects/$projectSlug'
     | '/projects/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/sign-in' | '/sign-up' | '/projects/$projectSlug' | '/projects'
+  to:
+    | '/'
+    | '/sign-in'
+    | '/sign-up'
+    | '/areas/$areaSlug'
+    | '/projects/$projectSlug'
+    | '/projects'
   id:
     | '__root__'
     | '/_authenticated'
@@ -94,6 +111,7 @@ export interface FileRouteTypes {
     | '/_unauthenticated/sign-in'
     | '/_unauthenticated/sign-up'
     | '/_authenticated/'
+    | '/_authenticated/areas/$areaSlug'
     | '/_authenticated/projects/$projectSlug'
     | '/_authenticated/projects/'
   fileRoutesById: FileRoutesById
@@ -154,17 +172,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectsProjectSlugRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/areas/$areaSlug': {
+      id: '/_authenticated/areas/$areaSlug'
+      path: '/areas/$areaSlug'
+      fullPath: '/areas/$areaSlug'
+      preLoaderRoute: typeof AuthenticatedAreasAreaSlugRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
   }
 }
 
 interface AuthenticatedRouteRouteChildren {
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute
+  AuthenticatedAreasAreaSlugRoute: typeof AuthenticatedAreasAreaSlugRoute
   AuthenticatedProjectsProjectSlugRoute: typeof AuthenticatedProjectsProjectSlugRoute
   AuthenticatedProjectsIndexRoute: typeof AuthenticatedProjectsIndexRoute
 }
 
 const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedIndexRoute: AuthenticatedIndexRoute,
+  AuthenticatedAreasAreaSlugRoute: AuthenticatedAreasAreaSlugRoute,
   AuthenticatedProjectsProjectSlugRoute: AuthenticatedProjectsProjectSlugRoute,
   AuthenticatedProjectsIndexRoute: AuthenticatedProjectsIndexRoute,
 }

--- a/apps/web/src/routes/_authenticated/areas/$areaSlug.tsx
+++ b/apps/web/src/routes/_authenticated/areas/$areaSlug.tsx
@@ -1,0 +1,241 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useQuery } from "convex-helpers/react/cache/hooks";
+import { Pencil, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { AreaFormDialog } from "@/components/areas/area-form-dialog";
+import { PageHeader } from "@/components/layout/page-header";
+import { ProjectFormDialog } from "@/components/projects/project-form-dialog";
+import { ProjectTimeline } from "@/components/projects/project-timeline";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { useAreaMutations } from "@/hooks/use-area-mutations";
+import { useProjectMutations } from "@/hooks/use-project-mutations";
+
+export const Route = createFileRoute("/_authenticated/areas/$areaSlug")({
+  component: AreaDetailPage,
+});
+
+const healthColors = {
+  healthy: "bg-green-500",
+  needs_attention: "bg-yellow-500",
+  critical: "bg-red-500",
+} as const;
+
+function AreaDetailPage() {
+  const { areaSlug } = Route.useParams();
+  const area = useQuery(api.areas.getBySlug, { slug: areaSlug });
+  const areas = useQuery(api.areas.list);
+  const projects = useQuery(
+    api.projects.listByArea,
+    area ? { areaId: area._id } : "skip",
+  );
+  const { updateArea, removeArea } = useAreaMutations();
+  const { createProject } = useProjectMutations();
+  const navigate = useNavigate();
+  const [showEdit, setShowEdit] = useState(false);
+  const [showCreateProject, setShowCreateProject] = useState(false);
+
+  const isLoading = area === undefined || projects === undefined;
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-3xl">
+        <div className="h-8 w-48 animate-pulse rounded bg-muted" />
+      </div>
+    );
+  }
+
+  if (area === null) {
+    return (
+      <div className="py-16 text-center">
+        <p className="text-sm text-muted-foreground">Area not found.</p>
+        <Link to="/" className="mt-2 inline-block text-sm underline">
+          Back to home
+        </Link>
+      </div>
+    );
+  }
+
+  const handleDelete = async () => {
+    await removeArea({ id: area._id });
+    navigate({ to: "/" });
+  };
+
+  const handleHealthChange = (
+    value: "healthy" | "needs_attention" | "critical",
+  ) => {
+    updateArea({ id: area._id, healthStatus: value });
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <PageHeader
+        title={area.name}
+        backLink={{ label: "Home", to: "/" }}
+        actions={
+          <>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setShowEdit(true)}
+              aria-label="Edit area"
+            >
+              <Pencil className="h-4 w-4" />
+            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="ghost" size="icon" aria-label="Delete area">
+                  <Trash2 className="h-4 w-4 text-muted-foreground" />
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete area?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Projects in &ldquo;{area.name}&rdquo; will be unassigned but
+                    not deleted.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleDelete}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </>
+        }
+      />
+
+      <div className="mb-4 flex items-center gap-2">
+        <span
+          className={`h-2.5 w-2.5 rounded-full ${healthColors[area.healthStatus]}`}
+        />
+        <Select value={area.healthStatus} onValueChange={handleHealthChange}>
+          <SelectTrigger className="h-8 w-40 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="healthy">Healthy</SelectItem>
+            <SelectItem value="needs_attention">Needs attention</SelectItem>
+            <SelectItem value="critical">Critical</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {area.standard && (
+        <div className="mb-6 rounded-md border p-4">
+          <h2 className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Standard
+          </h2>
+          <p className="whitespace-pre-wrap text-sm">{area.standard}</p>
+        </div>
+      )}
+
+      <Separator className="mb-4" />
+
+      <ProjectTimeline projects={projects} />
+
+      <div className="mt-4 mb-2 flex items-center justify-between">
+        <h2 className="text-sm font-medium">Projects</h2>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 text-xs"
+          onClick={() => setShowCreateProject(true)}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          New project
+        </Button>
+      </div>
+
+      {projects.length === 0 ? (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          No projects in this area yet.
+        </p>
+      ) : (
+        <div>
+          {projects.map((project) => {
+            const slug = project.slug ?? project._id;
+            return (
+              <Link
+                key={project._id}
+                to="/projects/$projectSlug"
+                params={{ projectSlug: slug }}
+                className="flex items-center gap-3 border-b py-3 transition-colors last:border-b-0 hover:bg-muted/50"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium">{project.name}</p>
+                  {project.description && (
+                    <p className="truncate text-xs text-muted-foreground">
+                      {project.description}
+                    </p>
+                  )}
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+
+      <AreaFormDialog
+        open={showEdit}
+        onOpenChange={setShowEdit}
+        area={area}
+        onSubmit={async (data) => {
+          const result = await updateArea({
+            id: area._id,
+            name: data.name,
+            standard: data.standard,
+            clearStandard: !data.standard,
+            healthStatus: data.healthStatus,
+          });
+          if (data.name !== area.name && result?.slug) {
+            navigate({
+              to: "/areas/$areaSlug",
+              params: { areaSlug: result.slug },
+              replace: true,
+            });
+          }
+        }}
+      />
+
+      <ProjectFormDialog
+        open={showCreateProject}
+        onOpenChange={setShowCreateProject}
+        areas={areas ?? []}
+        defaultAreaId={area._id}
+        onSubmit={async (data) => {
+          await createProject({
+            ...data,
+            areaId: (data.areaId ?? area._id) as Id<"areas">,
+          });
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -1,11 +1,17 @@
 import { api } from "@convex/_generated/api";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "convex-helpers/react/cache/hooks";
+import { Compass, Plus } from "lucide-react";
+import { useState } from "react";
+import { AreaCard } from "@/components/areas/area-card";
+import { AreaFormDialog } from "@/components/areas/area-form-dialog";
 import { PageHeader } from "@/components/layout/page-header";
 import { AddTaskRow } from "@/components/tasks/add-task-row";
 import { CompletedSection } from "@/components/tasks/completed-section";
 import { TaskListSkeleton } from "@/components/tasks/task-list-skeleton";
 import { TaskRow } from "@/components/tasks/task-row";
+import { Button } from "@/components/ui/button";
+import { useAreaMutations } from "@/hooks/use-area-mutations";
 
 export const Route = createFileRoute("/_authenticated/")({
   component: Inbox,
@@ -14,6 +20,9 @@ export const Route = createFileRoute("/_authenticated/")({
 function Inbox() {
   const tasks = useQuery(api.tasks.list);
   const projects = useQuery(api.projects.list);
+  const areas = useQuery(api.areas.list);
+  const { createArea } = useAreaMutations();
+  const [showCreateArea, setShowCreateArea] = useState(false);
   const isLoading = tasks === undefined;
 
   const activeTasks = tasks?.filter((t) => !t.isCompleted) ?? [];
@@ -25,6 +34,51 @@ function Inbox() {
 
   return (
     <div className="mx-auto max-w-3xl">
+      <div className="mb-6">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-medium">Areas</h2>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 text-xs"
+            onClick={() => setShowCreateArea(true)}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New area
+          </Button>
+        </div>
+        {areas && areas.length > 0 ? (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {areas.map((area) => {
+              const projectCount = (projects ?? []).filter(
+                (p) => p.areaId === area._id,
+              ).length;
+              return (
+                <AreaCard
+                  key={area._id}
+                  area={area}
+                  projectCount={projectCount}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-8 text-center">
+            <Compass className="mb-3 h-8 w-8 text-muted-foreground" />
+            <p className="mb-3 text-sm text-muted-foreground">
+              Define your life areas to organize projects by responsibility.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowCreateArea(true)}
+            >
+              Create area
+            </Button>
+          </div>
+        )}
+      </div>
+
       <PageHeader title="Inbox" />
       <div>
         {activeTasks.map((task) => (
@@ -35,6 +89,12 @@ function Inbox() {
           <CompletedSection tasks={completedTasks} />
         )}
       </div>
+
+      <AreaFormDialog
+        open={showCreateArea}
+        onOpenChange={setShowCreateArea}
+        onSubmit={(data) => createArea(data)}
+      />
     </div>
   );
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -1,4 +1,5 @@
 import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { format } from "date-fns";
@@ -36,6 +37,7 @@ function ProjectDetailPage() {
     api.tasks.listByProject,
     project ? { projectId: project._id } : "skip",
   );
+  const areas = useQuery(api.areas.list);
   const { updateProject, removeProject } = useProjectMutations();
   const navigate = useNavigate();
   const [showEdit, setShowEdit] = useState(false);
@@ -151,6 +153,7 @@ function ProjectDetailPage() {
           open={showEdit}
           onOpenChange={setShowEdit}
           project={project}
+          areas={areas ?? []}
           onSubmit={async (data) => {
             const result = await updateProject({
               id: project._id,
@@ -159,6 +162,8 @@ function ProjectDetailPage() {
               clearDescription: !data.description,
               definitionOfDone: data.definitionOfDone,
               clearDefinitionOfDone: !data.definitionOfDone,
+              areaId: data.areaId ? (data.areaId as Id<"areas">) : undefined,
+              clearAreaId: !data.areaId,
               startDate: data.startDate,
               clearStartDate: !data.startDate,
               endDate: data.endDate,

--- a/apps/web/src/routes/_authenticated/projects/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/index.tsx
@@ -1,4 +1,5 @@
 import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { format } from "date-fns";
@@ -17,6 +18,7 @@ export const Route = createFileRoute("/_authenticated/projects/")({
 
 function ProjectsPage() {
   const projects = useQuery(api.projects.list);
+  const areas = useQuery(api.areas.list);
   const { createProject } = useProjectMutations();
   const [showCreate, setShowCreate] = useState(false);
   const isLoading = projects === undefined;
@@ -90,7 +92,13 @@ function ProjectsPage() {
       <ProjectFormDialog
         open={showCreate}
         onOpenChange={setShowCreate}
-        onSubmit={(data) => createProject(data)}
+        areas={areas ?? []}
+        onSubmit={(data) =>
+          createProject({
+            ...data,
+            areaId: data.areaId ? (data.areaId as Id<"areas">) : undefined,
+          })
+        }
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Add "areas" — persistent life responsibilities (e.g. Health, Career, Finances) that group projects and surface their health at a glance
- Full CRUD for areas with name, standard (what "good enough" looks like), health status (healthy/needs attention/critical), and reordering
- Home page shows area cards grid with health color indicators and active project counts above Inbox
- Sidebar groups projects under their areas, with ungrouped projects in a separate section
- Area detail page with editable health status, standard section, project timeline, and project list
- Projects can be assigned to an area from the project form (create and edit)
- Deleting an area unassigns its projects without losing any data

## Test plan
- [ ] Create an area from the home page (empty state and "New area" button)
- [ ] Verify area card shows on home page with health dot and project count
- [ ] Click area card to navigate to area detail page
- [ ] Edit area name, standard, and health status from detail page
- [ ] Create a project from the area detail page — verify it's auto-assigned to the area
- [ ] Verify sidebar groups projects under areas
- [x] Create a project from sidebar within an area group — verify area pre-selected
- [ ] Assign/change/clear area on existing projects via the project edit form
- [ ] Delete an area — verify projects are unassigned but not deleted
- [ ] Verify project timeline renders on the area detail page

Closes #36