### PR TITLE
fix(projects): rename "Projects" section to "Ungrouped"

### DIFF
--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -205,12 +205,12 @@ export function AppSidebar() {
                 asChild
                 className="hover:text-sidebar-foreground"
               >
-                <Link to="/projects">Projects</Link>
+                <Link to="/projects">Ungrouped</Link>
               </SidebarGroupLabel>
               <CollapsibleTrigger asChild>
                 <SidebarGroupAction>
                   <ChevronRight className="transition-transform group-data-[state=open]/collapsible:rotate-90" />
-                  <span className="sr-only">Toggle projects</span>
+                  <span className="sr-only">Toggle ungrouped</span>
                 </SidebarGroupAction>
               </CollapsibleTrigger>
               <CollapsibleContent>

--- a/apps/web/src/routes/_authenticated/projects/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/index.tsx
@@ -81,7 +81,7 @@ function ProjectsPage() {
   return (
     <div className="mx-auto max-w-3xl">
       <PageHeader
-        title="Projects"
+        title="Ungrouped"
         actions={
           <Button
             size="sm"


### PR DESCRIPTION
## Summary
- Rename sidebar section label from "Projects" to "Ungrouped" to accurately reflect it only shows unassigned projects
- Update screen-reader text to match
- Update `/projects` page header title to match

Closes #59

## Test plan
- [ ] Sidebar section reads "Ungrouped" instead of "Projects"
- [ ] `/projects` page heading reads "Ungrouped"
- [ ] Screen-reader text announces "Toggle ungrouped"

🤖 Generated with [Claude Code](https://claude.com/claude-code)