### PR TITLE
fix(projects): show only ungrouped projects on /projects page

### DIFF
--- a/apps/web/convex/projects.ts
+++ b/apps/web/convex/projects.ts
@@ -46,6 +46,20 @@ export const getBySlug = query({
   },
 });
 
+export const listUngrouped = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+    if (!user) return [];
+    const userId = String(user._id);
+    const projects = await ctx.db
+      .query("projects")
+      .withIndex("by_user_order", (q) => q.eq("userId", userId))
+      .collect();
+    return projects.filter((p) => !p.isArchived && !p.areaId);
+  },
+});
+
 export const listByArea = query({
   args: { areaId: v.id("areas") },
   handler: async (ctx, args) => {

--- a/apps/web/src/routes/_authenticated/projects/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/index.tsx
@@ -29,15 +29,15 @@ export const Route = createFileRoute("/_authenticated/projects/")({
 });
 
 function ProjectsPage() {
-  const projects = useQuery(api.projects.list);
+  const projects = useQuery(api.projects.listUngrouped);
   const areas = useQuery(api.areas.list);
 
   const createProject = useMutation(api.projects.create).withOptimisticUpdate(
     (localStore, args) => {
-      const current = localStore.getQuery(api.projects.list, {});
+      const current = localStore.getQuery(api.projects.listUngrouped, {});
       if (current !== undefined) {
         const maxOrder = current.reduce((max, p) => Math.max(max, p.order), -1);
-        localStore.setQuery(api.projects.list, {}, [
+        localStore.setQuery(api.projects.listUngrouped, {}, [
           ...current,
           {
             _id: crypto.randomUUID() as Id<"projects">,
@@ -61,10 +61,10 @@ function ProjectsPage() {
 
   const removeProject = useMutation(api.projects.remove).withOptimisticUpdate(
     (localStore, args) => {
-      const current = localStore.getQuery(api.projects.list, {});
+      const current = localStore.getQuery(api.projects.listUngrouped, {});
       if (current !== undefined) {
         localStore.setQuery(
-          api.projects.list,
+          api.projects.listUngrouped,
           {},
           current.filter((p) => p._id !== args.id),
         );
@@ -101,7 +101,8 @@ function ProjectsPage() {
           <div className="flex flex-col items-center justify-center py-16 text-center">
             <FolderOpen className="mb-3 h-10 w-10 text-muted-foreground" />
             <p className="text-sm text-muted-foreground">
-              No projects yet. Create one to organize your tasks.
+              No ungrouped projects. Projects not assigned to an area will
+              appear here.
             </p>
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- Add `listUngrouped` Convex query that returns only projects without an `areaId`
- Switch `/projects` page from `api.projects.list` to `api.projects.listUngrouped`
- Update empty state text to reflect ungrouped context

Closes #60

## Test plan
- [ ] `/projects` page only shows projects not assigned to any area
- [ ] Projects assigned to an area do not appear on the page
- [ ] Timeline only includes ungrouped projects
- [ ] Area detail pages still show their own projects correctly
- [ ] Creating a new project from the page works with optimistic updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)