### PR TITLE
fix(ui): make loading skeletons match real page layouts

### DIFF
--- a/apps/web/src/components/tasks/task-list-skeleton.tsx
+++ b/apps/web/src/components/tasks/task-list-skeleton.tsx
@@ -1,19 +1,24 @@
 import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export function TaskListSkeleton() {
   return (
     <div>
-      <div className="mb-4 h-8 w-20 animate-pulse rounded bg-muted" />
       {Array.from({ length: 3 }).map((_, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
         <div key={i}>
-          <div className="flex items-center gap-3 py-3">
-            <div className="h-4 w-4 animate-pulse rounded-full bg-muted" />
-            <div className="h-4 flex-1 animate-pulse rounded bg-muted" />
+          <div className="flex items-start gap-3 py-3">
+            <Skeleton className="mt-0.5 h-4 w-4 shrink-0 rounded-full" />
+            <Skeleton className="h-4 flex-1" />
           </div>
           <Separator />
         </div>
       ))}
+      <div className="flex items-center gap-3 py-3">
+        <Skeleton className="h-4 w-4 shrink-0" />
+        <Skeleton className="h-4 w-16" />
+      </div>
+      <Separator />
     </div>
   );
 }

--- a/apps/web/src/routes/_authenticated/areas/$areaSlug.tsx
+++ b/apps/web/src/routes/_authenticated/areas/$areaSlug.tsx
@@ -30,6 +30,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export const Route = createFileRoute("/_authenticated/areas/$areaSlug")({
   component: AreaDetailPage,
@@ -149,11 +150,7 @@ function AreaDetailPage() {
   const isLoading = area === undefined || projects === undefined;
 
   if (isLoading) {
-    return (
-      <div className="mx-auto max-w-3xl">
-        <div className="h-8 w-48 animate-pulse rounded bg-muted" />
-      </div>
-    );
+    return <AreaDetailSkeleton />;
   }
 
   if (area === null) {
@@ -361,6 +358,64 @@ function AreaDetailPage() {
           });
         }}
       />
+    </div>
+  );
+}
+
+function AreaDetailSkeleton() {
+  return (
+    <div className="mx-auto max-w-3xl">
+      <div className="mb-6">
+        <Skeleton className="mb-3 h-4 w-12" />
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-40" />
+          <div className="flex items-center gap-1">
+            <Skeleton className="h-8 w-8 rounded-md" />
+            <Skeleton className="h-8 w-8 rounded-md" />
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-4 flex items-center gap-2">
+        <Skeleton className="h-2.5 w-2.5 rounded-full" />
+        <Skeleton className="h-8 w-40 rounded-md" />
+      </div>
+
+      <div className="mb-6 rounded-md border p-4">
+        <Skeleton className="mb-2 h-3 w-16" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="mt-1 h-4 w-2/3" />
+      </div>
+
+      <Separator className="mb-4" />
+
+      <div className="overflow-hidden rounded-md border">
+        <div className="flex gap-4 border-b px-3 py-1.5">
+          <Skeleton className="h-3 w-8" />
+          <Skeleton className="h-3 w-8" />
+          <Skeleton className="h-3 w-8" />
+        </div>
+        <div className="space-y-1.5 px-3 py-2">
+          <Skeleton className="h-6 w-3/4" />
+          <Skeleton className="h-6 w-1/2" />
+        </div>
+      </div>
+
+      <div className="mt-4 mb-2 flex items-center justify-between">
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-7 w-24 rounded-md" />
+      </div>
+
+      {Array.from({ length: 2 }).map((_, i) => (
+        <div
+          // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
+          key={i}
+          className="border-b py-3 last:border-b-0"
+        >
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="mt-1.5 h-3 w-64" />
+        </div>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -14,6 +14,7 @@ import { CompletedSection } from "@/components/tasks/completed-section";
 import { TaskListSkeleton } from "@/components/tasks/task-list-skeleton";
 import { TaskRow } from "@/components/tasks/task-row";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export const Route = createFileRoute("/_authenticated/")({
   component: Inbox,
@@ -52,7 +53,7 @@ function Inbox() {
   const completedTasks = tasks?.filter((t) => t.isCompleted) ?? [];
 
   if (isLoading) {
-    return <TaskListSkeleton />;
+    return <InboxSkeleton />;
   }
 
   return (
@@ -118,6 +119,40 @@ function Inbox() {
         onOpenChange={setShowCreateArea}
         onSubmit={(data) => createArea(data)}
       />
+    </div>
+  );
+}
+
+function InboxSkeleton() {
+  return (
+    <div className="mx-auto max-w-3xl">
+      <div className="mb-6">
+        <div className="mb-3 flex items-center justify-between">
+          <Skeleton className="h-4 w-12" />
+          <Skeleton className="h-7 w-20 rounded-md" />
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
+              key={i}
+              className="flex items-center gap-3 rounded-lg border p-3"
+            >
+              <Skeleton className="h-2.5 w-2.5 shrink-0 rounded-full" />
+              <div className="min-w-0 flex-1 space-y-1.5">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mb-6">
+        <Skeleton className="h-8 w-20" />
+      </div>
+
+      <TaskListSkeleton />
     </div>
   );
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug")({
   component: ProjectDetailPage,
@@ -99,7 +100,7 @@ function ProjectDetailPage() {
   const isLoading = project === undefined || tasks === undefined;
 
   if (isLoading) {
-    return <TaskListSkeleton />;
+    return <ProjectDetailSkeleton />;
   }
 
   if (project === null) {
@@ -233,6 +234,38 @@ function ProjectDetailPage() {
           }}
         />
       )}
+    </div>
+  );
+}
+
+function ProjectDetailSkeleton() {
+  return (
+    <div className="mx-auto max-w-3xl">
+      <div className="mb-6">
+        <Skeleton className="mb-3 h-4 w-16" />
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48" />
+          <div className="flex items-center gap-1">
+            <Skeleton className="h-8 w-8 rounded-md" />
+            <Skeleton className="h-8 w-8 rounded-md" />
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-4 flex items-center gap-1.5">
+        <Skeleton className="h-4 w-4" />
+        <Skeleton className="h-4 w-40" />
+      </div>
+
+      <div className="mb-6 rounded-md border p-4">
+        <Skeleton className="mb-2 h-3 w-28" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="mt-1 h-4 w-3/4" />
+      </div>
+
+      <Separator className="mb-4" />
+
+      <TaskListSkeleton />
     </div>
   );
 }

--- a/apps/web/src/routes/_authenticated/projects/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/index.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export const Route = createFileRoute("/_authenticated/projects/")({
   component: ProjectsPage,
@@ -193,19 +194,34 @@ function ProjectsListSkeleton() {
   return (
     <div className="mx-auto max-w-3xl">
       <div className="mb-6 flex items-center justify-between">
-        <div className="h-8 w-24 animate-pulse rounded bg-muted" />
-        <div className="h-8 w-28 animate-pulse rounded bg-muted" />
+        <Skeleton className="h-8 w-28" />
+        <Skeleton className="h-8 w-28 rounded-md" />
       </div>
-      {Array.from({ length: 3 }).map((_, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
-        <div key={i}>
-          <div className="py-3">
-            <div className="h-5 w-40 animate-pulse rounded bg-muted" />
-            <div className="mt-1.5 h-3 w-64 animate-pulse rounded bg-muted" />
-          </div>
-          <Separator />
+
+      <div className="overflow-hidden rounded-md border">
+        <div className="flex gap-4 border-b px-3 py-1.5">
+          <Skeleton className="h-3 w-8" />
+          <Skeleton className="h-3 w-8" />
+          <Skeleton className="h-3 w-8" />
         </div>
-      ))}
+        <div className="space-y-1.5 px-3 py-2">
+          <Skeleton className="h-6 w-3/4" />
+          <Skeleton className="h-6 w-1/2" />
+        </div>
+      </div>
+
+      <div className="mt-6">
+        {Array.from({ length: 3 }).map((_, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
+          <div key={i}>
+            <div className="py-3">
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="mt-1.5 h-3 w-64" />
+            </div>
+            <Separator />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Rewrote `TaskListSkeleton` to use `<Skeleton>` component and added "Add task" row placeholder
- Added `InboxSkeleton` with areas grid, page header, and task list inside `max-w-3xl`
- Updated `ProjectsListSkeleton` with timeline placeholder section
- Added `ProjectDetailSkeleton` with back link, title, actions, date range, definition of done box, and task list
- Added `AreaDetailSkeleton` with back link, title, actions, health status, standard box, timeline, and project list

## Test plan
- [ ] Navigate to each page while data is loading (throttle network in DevTools)
- [ ] Verify all skeletons are constrained to `max-w-3xl` (no full-viewport expansion)
- [ ] Verify Inbox skeleton shows areas grid + page header + task list
- [ ] Verify Project detail skeleton shows back link, metadata sections, and task list
- [ ] Verify Area detail skeleton shows back link, health status, timeline, and project list
- [ ] Verify Projects list skeleton includes timeline placeholder
- [ ] Confirm no layout shift when real content replaces skeletons

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)