### PR TITLE
fix(ui): add optimistic updates for getBySlug queries

### DIFF
--- a/apps/web/src/routes/_authenticated/areas/$areaSlug.tsx
+++ b/apps/web/src/routes/_authenticated/areas/$areaSlug.tsx
@@ -82,6 +82,17 @@ function AreaDetailPage() {
           { ...single, ...fullUpdates },
         );
       }
+
+      const bySlug = localStore.getQuery(api.areas.getBySlug, {
+        slug: areaSlug,
+      });
+      if (bySlug !== undefined && bySlug !== null) {
+        localStore.setQuery(
+          api.areas.getBySlug,
+          { slug: areaSlug },
+          { ...bySlug, ...fullUpdates },
+        );
+      }
     },
   );
 
@@ -96,6 +107,7 @@ function AreaDetailPage() {
         );
       }
       localStore.setQuery(api.areas.get, { id: args.id }, null);
+      localStore.setQuery(api.areas.getBySlug, { slug: areaSlug }, null);
     },
   );
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -79,6 +79,17 @@ function ProjectDetailPage() {
           { ...single, ...fullUpdates },
         );
       }
+
+      const bySlug = localStore.getQuery(api.projects.getBySlug, {
+        slug: projectSlug,
+      });
+      if (bySlug !== undefined && bySlug !== null) {
+        localStore.setQuery(
+          api.projects.getBySlug,
+          { slug: projectSlug },
+          { ...bySlug, ...fullUpdates },
+        );
+      }
     },
   );
 
@@ -93,6 +104,7 @@ function ProjectDetailPage() {
         );
       }
       localStore.setQuery(api.projects.get, { id: args.id }, null);
+      localStore.setQuery(api.projects.getBySlug, { slug: projectSlug }, null);
     },
   );
   const [showEdit, setShowEdit] = useState(false);


### PR DESCRIPTION
## Summary
- Add `getBySlug` cache updates to project and area optimistic update handlers
- Detail pages now reflect edits instantly instead of waiting for the server round-trip
- Cover both `update` and `remove` mutations for projects and areas

## Test plan
- [ ] Edit a project from its detail page — changes show immediately
- [ ] Edit an area from its detail page — changes show immediately
- [ ] Change health status on area detail page — updates instantly
- [ ] Delete a project from its detail page — no stale data flash
- [ ] Delete an area from its detail page — no stale data flash

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)