### PR TITLE
fix(ui): reset project form state when dialog opens

### DIFF
--- a/apps/web/src/components/projects/project-form-dialog.tsx
+++ b/apps/web/src/components/projects/project-form-dialog.tsx
@@ -1,7 +1,7 @@
 import type { Doc } from "@convex/_generated/dataModel";
 import { format } from "date-fns";
 import { Calendar as CalendarIcon, X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AreaPicker } from "@/components/areas/area-picker";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -59,6 +59,17 @@ export function ProjectFormDialog({
   const [endDate, setEndDate] = useState<Date | undefined>(
     project?.endDate ? new Date(project.endDate) : undefined,
   );
+
+  useEffect(() => {
+    if (open && !project) {
+      setName("");
+      setDescription("");
+      setDefinitionOfDone("");
+      setAreaId(defaultAreaId);
+      setStartDate(undefined);
+      setEndDate(undefined);
+    }
+  }, [open, project, defaultAreaId]);
 
   const handleStartDateChange = (date: Date | undefined) => {
     setStartDate(date);


### PR DESCRIPTION
## Summary
- Fix the "New project" button not pre-selecting the area it was clicked from in the sidebar
- Add a `useEffect` that resets all form fields when `ProjectFormDialog` opens in create mode, so `defaultAreaId` is always applied correctly

## Test plan
- [ ] Open sidebar → click "New project" on Area A → verify Area A is selected in the dropdown
- [ ] Close dialog → click "New project" on Area B → verify Area B is selected
- [ ] Click "New project" in the Ungrouped section → verify no area is selected
- [ ] Edit an existing project → verify form fields are populated from the project, not reset

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)