### PR TITLE
feat(seo): add per-page meta tags and titles

### DIFF
--- a/apps/web/src/routes/_authenticated/areas/$areaSlug.tsx
+++ b/apps/web/src/routes/_authenticated/areas/$areaSlug.tsx
@@ -5,7 +5,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { Pencil, Plus, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AreaFormDialog } from "@/components/areas/area-form-dialog";
 import { PageHeader } from "@/components/layout/page-header";
 import { ProjectFormDialog } from "@/components/projects/project-form-dialog";
@@ -158,6 +158,14 @@ function AreaDetailPage() {
   );
   const [showEdit, setShowEdit] = useState(false);
   const [showCreateProject, setShowCreateProject] = useState(false);
+
+  useEffect(() => {
+    const title = area?.name ? `${area.name} | Vita OS` : "Area | Vita OS";
+    document.title = title;
+    return () => {
+      document.title = "Vita OS";
+    };
+  }, [area?.name]);
 
   const isLoading = area === undefined || projects === undefined;
 

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -17,6 +17,9 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export const Route = createFileRoute("/_authenticated/")({
+  head: () => ({
+    meta: [{ title: "Inbox | Vita OS" }],
+  }),
   component: Inbox,
 });
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -6,7 +6,7 @@ import { useMutation } from "convex/react";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { format } from "date-fns";
 import { Calendar as CalendarIcon, Pencil, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PageHeader } from "@/components/layout/page-header";
 import { ProjectFormDialog } from "@/components/projects/project-form-dialog";
 import { AddTaskRow } from "@/components/tasks/add-task-row";
@@ -108,6 +108,16 @@ function ProjectDetailPage() {
     },
   );
   const [showEdit, setShowEdit] = useState(false);
+
+  useEffect(() => {
+    const title = project?.name
+      ? `${project.name} | Vita OS`
+      : "Project | Vita OS";
+    document.title = title;
+    return () => {
+      document.title = "Vita OS";
+    };
+  }, [project?.name]);
 
   const isLoading = project === undefined || tasks === undefined;
 

--- a/apps/web/src/routes/_authenticated/projects/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/index.tsx
@@ -26,6 +26,9 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export const Route = createFileRoute("/_authenticated/projects/")({
+  head: () => ({
+    meta: [{ title: "Projects | Vita OS" }],
+  }),
   component: ProjectsPage,
 });
 

--- a/apps/web/src/routes/_unauthenticated/sign-in.tsx
+++ b/apps/web/src/routes/_unauthenticated/sign-in.tsx
@@ -14,6 +14,20 @@ import { Label } from "@/components/ui/label";
 import { authClient } from "@/lib/auth-client";
 
 export const Route = createFileRoute("/_unauthenticated/sign-in")({
+  head: () => ({
+    meta: [
+      { title: "Sign In | Vita OS" },
+      {
+        name: "description",
+        content: "Sign in to your Vita OS account.",
+      },
+      { property: "og:title", content: "Sign In | Vita OS" },
+      {
+        property: "og:description",
+        content: "Sign in to your Vita OS account.",
+      },
+    ],
+  }),
   component: SignIn,
 });
 

--- a/apps/web/src/routes/_unauthenticated/sign-up.tsx
+++ b/apps/web/src/routes/_unauthenticated/sign-up.tsx
@@ -14,6 +14,20 @@ import { Label } from "@/components/ui/label";
 import { authClient } from "@/lib/auth-client";
 
 export const Route = createFileRoute("/_unauthenticated/sign-up")({
+  head: () => ({
+    meta: [
+      { title: "Sign Up | Vita OS" },
+      {
+        name: "description",
+        content: "Create a Vita OS account to get started.",
+      },
+      { property: "og:title", content: "Sign Up | Vita OS" },
+      {
+        property: "og:description",
+        content: "Create a Vita OS account to get started.",
+      },
+    ],
+  }),
   component: SignUp,
 });
 


### PR DESCRIPTION
## Summary
- Add unique titles and meta descriptions to each route for browser tab clarity and SEO
- Public pages (sign-in, sign-up) get full OG meta tags since they're crawlable
- Authenticated static pages (Inbox, Projects) get title via TanStack Router `head` property
- Dynamic pages (project detail, area detail) use `useEffect` to set `document.title` reactively from Convex query data, with fallback titles while loading

## Test plan
- [ ] Navigate to each page and verify the browser tab shows the correct title
- [ ] Sign-in page: "Sign In | Vita OS"
- [ ] Sign-up page: "Sign Up | Vita OS"
- [ ] Inbox: "Inbox | Vita OS"
- [ ] Projects list: "Projects | Vita OS"
- [ ] Project detail: "<project name> | Vita OS" (and "Project | Vita OS" while loading)
- [ ] Area detail: "<area name> | Vita OS" (and "Area | Vita OS" while loading)
- [ ] Verify OG tags on sign-in/sign-up via view-source

Closes #52