### PR TITLE
refactor(sidebar): use collapsible sub-menus with chevron toggles

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "convex": "^1.31.7",
     "convex-helpers": "^0.1.112",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.564.0",
+    "lucide-react": "^0.575.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",
     "react-day-picker": "^9.13.2",

--- a/apps/web/src/components/layout/app-header.tsx
+++ b/apps/web/src/components/layout/app-header.tsx
@@ -30,7 +30,7 @@ export function AppHeader() {
   return (
     <header className="flex h-12 items-center gap-2 border-b px-4">
       <SidebarTrigger className="-ml-1" />
-      <Separator orientation="vertical" className="mr-2 !h-4" />
+      <Separator orientation="vertical" className="mr-2 h-4!" />
       <div className="flex-1" />
       <Button
         size="sm"

--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -7,8 +7,6 @@ import { useQuery } from "convex-helpers/react/cache/hooks";
 import {
   ChevronRight,
   ChevronsUpDown,
-  Compass,
-  FolderOpen,
   Inbox,
   LogOut,
   Plus,
@@ -33,21 +31,18 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
-  SidebarGroupAction,
-  SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
+  SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
   SidebarRail,
 } from "@/components/ui/sidebar";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { authClient } from "@/lib/auth-client";
+import { Button } from "../ui/button";
 
 export function AppSidebar() {
   const { data: session } = authClient.useSession();
@@ -96,7 +91,10 @@ export function AppSidebar() {
         ungrouped.push(project);
       }
     }
-    return { areaProjects: grouped, ungroupedProjects: ungrouped };
+    return {
+      areaProjects: grouped,
+      ungroupedProjects: ungrouped,
+    };
   }, [projects]);
 
   const handleCreateProject = (forAreaId?: string) => {
@@ -106,12 +104,19 @@ export function AppSidebar() {
 
   return (
     <>
-      <Sidebar collapsible="icon">
+      <Sidebar>
         <SidebarHeader>
           <SidebarMenu>
             <SidebarMenuItem>
               <SidebarMenuButton size="lg" asChild>
-                <span className="font-semibold">vita-os</span>
+                <Link to="/">
+                  <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg font-semibold">
+                    V
+                  </div>
+                  <div className="flex flex-col gap-0.5 leading-none">
+                    <span className="font-medium">vita-os</span>
+                  </div>
+                </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>
@@ -119,151 +124,121 @@ export function AppSidebar() {
 
         <SidebarContent>
           <SidebarGroup>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                <SidebarMenuItem>
-                  <SidebarMenuButton
-                    asChild
-                    isActive={pathname === "/"}
-                    tooltip="Inbox"
-                  >
-                    <Link to="/">
-                      <Inbox />
-                      <span>Inbox</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  isActive={pathname === "/"}
+                  tooltip="Inbox"
+                >
+                  <Link to="/">
+                    <Inbox />
+                    <span>Inbox</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
 
-          {areas?.map((area) => {
-            const areaSlug = area.slug ?? area._id;
-            const areaProjectList = areaProjects.get(area._id) ?? [];
-            return (
-              <Collapsible
-                key={area._id}
-                defaultOpen
-                className="group/collapsible"
-              >
-                <SidebarGroup>
-                  <SidebarGroupLabel
-                    asChild
-                    className="hover:text-sidebar-foreground"
+              {areas?.map((area) => {
+                const areaSlug = area.slug ?? area._id;
+                const areaProjectList = areaProjects.get(area._id) ?? [];
+                return (
+                  <Collapsible
+                    key={area._id}
+                    defaultOpen
+                    className="group/collapsible"
                   >
-                    <Link to="/$areaSlug" params={{ areaSlug }}>
-                      <Compass className="mr-1 h-3 w-3" />
-                      {area.name}
-                    </Link>
-                  </SidebarGroupLabel>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        aria-label="New project"
+                    <SidebarMenuItem>
+                      <CollapsibleTrigger asChild>
+                        <SidebarMenuButton>
+                          <ChevronRight className="transition-transform group-data-[state=open]/collapsible:rotate-90" />
+                          {area.name}
+                        </SidebarMenuButton>
+                      </CollapsibleTrigger>
+                      <SidebarMenuAction
+                        showOnHover
                         onClick={() => handleCreateProject(area._id)}
-                        className="text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-9 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 after:absolute after:-inset-2 md:after:hidden group-data-[collapsible=icon]:hidden [&>svg]:size-4 [&>svg]:shrink-0"
+                        title="New project"
+                        asChild
                       >
-                        <Plus />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="top">New project</TooltipContent>
-                  </Tooltip>
-                  <CollapsibleTrigger asChild>
-                    <SidebarGroupAction>
-                      <ChevronRight className="transition-transform group-data-[state=open]/collapsible:rotate-90" />
-                      <span className="sr-only">Toggle {area.name}</span>
-                    </SidebarGroupAction>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <SidebarGroupContent>
-                      <SidebarMenu>
-                        {areaProjectList.map((project) => {
-                          const slug = project.slug ?? project._id;
-                          return (
-                            <SidebarMenuItem key={project._id}>
-                              <SidebarMenuButton
-                                asChild
-                                isActive={pathname === `/${areaSlug}/${slug}`}
-                                tooltip={project.name}
-                              >
-                                <Link
-                                  to="/$areaSlug/$projectSlug"
-                                  params={{
-                                    areaSlug,
-                                    projectSlug: slug,
-                                  }}
+                        <Button size="icon-xs" variant="ghost">
+                          <Plus />
+                        </Button>
+                      </SidebarMenuAction>
+                      <CollapsibleContent>
+                        <SidebarMenuSub>
+                          {areaProjectList.map((project) => {
+                            const slug = project.slug ?? project._id;
+                            return (
+                              <SidebarMenuSubItem key={project._id}>
+                                <SidebarMenuSubButton
+                                  asChild
+                                  isActive={pathname === `/${areaSlug}/${slug}`}
                                 >
-                                  <FolderOpen />
-                                  <span>{project.name}</span>
-                                </Link>
-                              </SidebarMenuButton>
-                            </SidebarMenuItem>
-                          );
-                        })}
-                      </SidebarMenu>
-                    </SidebarGroupContent>
-                  </CollapsibleContent>
-                </SidebarGroup>
-              </Collapsible>
-            );
-          })}
+                                  <Link
+                                    to="/$areaSlug/$projectSlug"
+                                    params={{
+                                      areaSlug,
+                                      projectSlug: slug,
+                                    }}
+                                  >
+                                    <span className="truncate">
+                                      {project.name}
+                                    </span>
+                                  </Link>
+                                </SidebarMenuSubButton>
+                              </SidebarMenuSubItem>
+                            );
+                          })}
+                        </SidebarMenuSub>
+                      </CollapsibleContent>
+                    </SidebarMenuItem>
+                  </Collapsible>
+                );
+              })}
 
-          <Collapsible defaultOpen className="group/collapsible">
-            <SidebarGroup>
-              <SidebarGroupLabel
-                asChild
-                className="hover:text-sidebar-foreground"
-              >
-                <Link to="/projects">Ungrouped</Link>
-              </SidebarGroupLabel>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label="New project"
+              <Collapsible defaultOpen className="group/collapsible">
+                <SidebarMenuItem>
+                  <CollapsibleTrigger asChild>
+                    <SidebarMenuButton>
+                      <ChevronRight className="transition-transform group-data-[state=open]/collapsible:rotate-90" />
+                      Ungrouped
+                    </SidebarMenuButton>
+                  </CollapsibleTrigger>
+                  <SidebarMenuAction
+                    showOnHover
                     onClick={() => handleCreateProject()}
-                    className="text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-9 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 after:absolute after:-inset-2 md:after:hidden group-data-[collapsible=icon]:hidden [&>svg]:size-4 [&>svg]:shrink-0"
+                    title="New project"
                   >
                     <Plus />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top">New project</TooltipContent>
-              </Tooltip>
-              <CollapsibleTrigger asChild>
-                <SidebarGroupAction>
-                  <ChevronRight className="transition-transform group-data-[state=open]/collapsible:rotate-90" />
-                  <span className="sr-only">Toggle ungrouped</span>
-                </SidebarGroupAction>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <SidebarGroupContent>
-                  <SidebarMenu>
-                    {ungroupedProjects.map((project) => {
-                      const slug = project.slug ?? project._id;
-                      return (
-                        <SidebarMenuItem key={project._id}>
-                          <SidebarMenuButton
-                            asChild
-                            isActive={pathname === `/projects/${slug}`}
-                            tooltip={project.name}
-                          >
-                            <Link
-                              to="/projects/$projectSlug"
-                              params={{ projectSlug: slug }}
+                  </SidebarMenuAction>
+                  <CollapsibleContent>
+                    <SidebarMenuSub>
+                      {ungroupedProjects.map((project) => {
+                        const slug = project.slug ?? project._id;
+                        return (
+                          <SidebarMenuSubItem key={project._id}>
+                            <SidebarMenuSubButton
+                              asChild
+                              isActive={pathname === `/projects/${slug}`}
                             >
-                              <FolderOpen />
-                              <span>{project.name}</span>
-                            </Link>
-                          </SidebarMenuButton>
-                        </SidebarMenuItem>
-                      );
-                    })}
-                  </SidebarMenu>
-                </SidebarGroupContent>
-              </CollapsibleContent>
-            </SidebarGroup>
-          </Collapsible>
+                              <Link
+                                to="/projects/$projectSlug"
+                                params={{
+                                  projectSlug: slug,
+                                }}
+                              >
+                                <span className="truncate">{project.name}</span>
+                              </Link>
+                            </SidebarMenuSubButton>
+                          </SidebarMenuSubItem>
+                        );
+                      })}
+                    </SidebarMenuSub>
+                  </CollapsibleContent>
+                </SidebarMenuItem>
+              </Collapsible>
+            </SidebarMenu>
+          </SidebarGroup>
         </SidebarContent>
 
         <SidebarFooter>

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "convex": "^1.31.7",
         "convex-helpers": "^0.1.112",
         "date-fns": "^4.1.0",
-        "lucide-react": "^0.564.0",
+        "lucide-react": "^0.575.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.0",
         "react-day-picker": "^9.13.2",
@@ -727,7 +727,7 @@
 
     "lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
-    "lucide-react": ["lucide-react@0.564.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-JJ8GVTQqFwuliifD48U6+h7DXEHdkhJ/E87kksGByII3qHxtPciVb8T8woQONHBQgHVOl7rSMrrip3SeVNy7Fg=="],
+    "lucide-react": ["lucide-react@0.575.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 


### PR DESCRIPTION
## Summary
- Replace per-area `SidebarGroup` layout with a single group using collapsible `SidebarMenuItem` + `SidebarMenuSub` for a flatter hierarchy
- Add chevron disclosure icon on the left of section titles with hover-visible "new project" `+` action on the right
- Truncate long project names in sub-menu items

## Test plan
- [ ] Verify areas and ungrouped sections expand/collapse via chevron click
- [ ] Hover over a section row and confirm the `+` button appears, opens the create project dialog
- [ ] Confirm long project names are truncated with ellipsis
- [ ] Check sidebar header links to home and displays branding
- [ ] Verify footer user dropdown and sign-out still work