### PR TITLE
fix(routing): prevent skeleton flash on rename and non-name edits

### DIFF
--- a/apps/web/convex/areas.ts
+++ b/apps/web/convex/areas.ts
@@ -113,7 +113,9 @@ export const update = mutation({
     if (args.name !== undefined) {
       validateAreaSlug(args.name);
       updates.name = args.name;
-      updates.slug = generateSlug(args.name);
+      if (args.name !== area.name) {
+        updates.slug = generateSlug(args.name);
+      }
     }
     if (args.clearStandard) {
       updates.standard = undefined;

--- a/apps/web/convex/projects.ts
+++ b/apps/web/convex/projects.ts
@@ -163,7 +163,9 @@ export const update = mutation({
     const updates: Record<string, unknown> = {};
     if (args.name !== undefined) {
       updates.name = args.name;
-      updates.slug = generateSlug(args.name);
+      if (args.name !== project.name) {
+        updates.slug = generateSlug(args.name);
+      }
     }
     if (args.clearDescription) {
       updates.description = undefined;


### PR DESCRIPTION
## Summary

- Only regenerate area/project slugs on the server when the name actually changes, preventing edits to other fields (dates, description, health status) from invalidating the current URL and showing a permanent skeleton
- Fix client-side optimistic updates to match: compare `updates.name` against cached `bySlug.name` before generating a new slug
- Use `useRef` to hold the last valid query result across slug param transitions, so the page renders stale data instead of a loading skeleton during rename navigation

Closes #74

## Test plan

- [ ] Edit only dates/description on a project — page stays stable, no skeleton
- [ ] Edit only standard/health on an area — page stays stable, no skeleton
- [ ] Rename an area — title updates in-place, URL updates, no skeleton flash, sidebar reflects new name
- [ ] Rename a project — same behavior as area rename
- [ ] Back/forward browser navigation works after a rename
- [ ] Direct navigation to the new URL works
- [ ] Creating a new area/project still works and navigates correctly