### PR TITLE
refactor(convex): extract pure logic and use null sentinel for field clearing

### DIFF
--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -11,7 +11,10 @@
 import type * as areas from "../areas.js";
 import type * as auth from "../auth.js";
 import type * as http from "../http.js";
+import type * as lib_dates from "../lib/dates.js";
+import type * as lib_patch from "../lib/patch.js";
 import type * as lib_slugs from "../lib/slugs.js";
+import type * as lib_validation from "../lib/validation.js";
 import type * as projects from "../projects.js";
 import type * as tasks from "../tasks.js";
 
@@ -25,7 +28,10 @@ declare const fullApi: ApiFromModules<{
   areas: typeof areas;
   auth: typeof auth;
   http: typeof http;
+  "lib/dates": typeof lib_dates;
+  "lib/patch": typeof lib_patch;
   "lib/slugs": typeof lib_slugs;
+  "lib/validation": typeof lib_validation;
   projects: typeof projects;
   tasks: typeof tasks;
 }>;

--- a/apps/web/convex/lib/dates.test.ts
+++ b/apps/web/convex/lib/dates.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { validateDateRange, validateEffectiveDates } from "./dates";
+
+describe("validateDateRange", () => {
+  it("accepts both undefined", () => {
+    expect(() => validateDateRange()).not.toThrow();
+  });
+
+  it("accepts startDate only", () => {
+    expect(() => validateDateRange(100)).not.toThrow();
+  });
+
+  it("accepts valid range", () => {
+    expect(() => validateDateRange(100, 200)).not.toThrow();
+  });
+
+  it("accepts equal dates", () => {
+    expect(() => validateDateRange(100, 100)).not.toThrow();
+  });
+
+  it("rejects endDate without startDate", () => {
+    expect(() => validateDateRange(undefined, 200)).toThrow(
+      "End date requires a start date",
+    );
+  });
+
+  it("rejects endDate before startDate", () => {
+    expect(() => validateDateRange(200, 100)).toThrow(
+      "End date must not be before start date",
+    );
+  });
+});
+
+describe("validateEffectiveDates", () => {
+  it("passes when no changes", () => {
+    expect(() => validateEffectiveDates({ startDate: 100 }, {})).not.toThrow();
+  });
+
+  it("passes when setting a valid startDate", () => {
+    expect(() => validateEffectiveDates({}, { startDate: 100 })).not.toThrow();
+  });
+
+  it("passes when setting endDate with existing startDate", () => {
+    expect(() =>
+      validateEffectiveDates({ startDate: 100 }, { endDate: 200 }),
+    ).not.toThrow();
+  });
+
+  it("passes when clearing startDate (null also clears endDate)", () => {
+    expect(() =>
+      validateEffectiveDates(
+        { startDate: 100, endDate: 200 },
+        { startDate: null },
+      ),
+    ).not.toThrow();
+  });
+
+  it("passes when clearing endDate only", () => {
+    expect(() =>
+      validateEffectiveDates(
+        { startDate: 100, endDate: 200 },
+        { endDate: null },
+      ),
+    ).not.toThrow();
+  });
+
+  it("passes when startDate=null overrides a new endDate", () => {
+    expect(() =>
+      validateEffectiveDates(
+        { startDate: 100, endDate: 200 },
+        { startDate: null, endDate: 300 },
+      ),
+    ).not.toThrow();
+  });
+
+  it("passes when setting both dates at once", () => {
+    expect(() =>
+      validateEffectiveDates({}, { startDate: 100, endDate: 200 }),
+    ).not.toThrow();
+  });
+
+  it("throws when setting endDate on a project with no startDate", () => {
+    expect(() => validateEffectiveDates({}, { endDate: 300 })).toThrow(
+      "End date requires a start date",
+    );
+  });
+
+  it("throws when new endDate is before existing startDate", () => {
+    expect(() =>
+      validateEffectiveDates({ startDate: 200 }, { endDate: 100 }),
+    ).toThrow("End date must not be before start date");
+  });
+
+  it("throws when new startDate is after existing endDate", () => {
+    expect(() =>
+      validateEffectiveDates({ endDate: 100 }, { startDate: 200 }),
+    ).toThrow("End date must not be before start date");
+  });
+});

--- a/apps/web/convex/lib/dates.ts
+++ b/apps/web/convex/lib/dates.ts
@@ -1,0 +1,51 @@
+/**
+ * Validates that a startDate/endDate pair is consistent:
+ * - endDate requires a startDate
+ * - endDate must not be before startDate
+ */
+export function validateDateRange(startDate?: number, endDate?: number): void {
+  if (endDate !== undefined && startDate === undefined) {
+    throw new Error("End date requires a start date");
+  }
+  if (startDate !== undefined && endDate !== undefined && endDate < startDate) {
+    throw new Error("End date must not be before start date");
+  }
+}
+
+interface CurrentDates {
+  startDate?: number;
+  endDate?: number;
+}
+
+interface DateChanges {
+  startDate?: number | null;
+  endDate?: number | null;
+}
+
+/**
+ * Given a project's current dates and the incoming update args,
+ * computes the effective startDate/endDate pair and validates it.
+ * Throws if the resulting state would be invalid.
+ *
+ * Convention: `null` means "clear", `undefined` means "no change".
+ */
+export function validateEffectiveDates(
+  current: CurrentDates,
+  changes: DateChanges,
+): void {
+  let effectiveStartDate = current.startDate;
+  if (changes.startDate === null) {
+    effectiveStartDate = undefined;
+  } else if (changes.startDate !== undefined) {
+    effectiveStartDate = changes.startDate;
+  }
+
+  let effectiveEndDate = current.endDate;
+  if (changes.endDate === null || changes.startDate === null) {
+    effectiveEndDate = undefined;
+  } else if (changes.endDate !== undefined) {
+    effectiveEndDate = changes.endDate;
+  }
+
+  validateDateRange(effectiveStartDate, effectiveEndDate);
+}

--- a/apps/web/convex/lib/patch.test.ts
+++ b/apps/web/convex/lib/patch.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { nullsToUndefined } from "./patch";
+
+describe("nullsToUndefined", () => {
+  it("converts null values to undefined", () => {
+    const result = nullsToUndefined({ a: null, b: "hello" });
+    expect(result).toEqual({ a: undefined, b: "hello" });
+  });
+
+  it("preserves non-null values", () => {
+    const result = nullsToUndefined({ a: 1, b: "two", c: true });
+    expect(result).toEqual({ a: 1, b: "two", c: true });
+  });
+
+  it("preserves undefined values (absent keys stay absent)", () => {
+    const obj: { a?: string | null } = {};
+    const result = nullsToUndefined(obj);
+    expect("a" in result).toBe(false);
+  });
+
+  it("returns empty object for empty input", () => {
+    expect(nullsToUndefined({})).toEqual({});
+  });
+
+  it("handles multiple null fields", () => {
+    const result = nullsToUndefined({ a: null, b: null, c: "keep" });
+    expect(result).toEqual({ a: undefined, b: undefined, c: "keep" });
+  });
+});

--- a/apps/web/convex/lib/patch.ts
+++ b/apps/web/convex/lib/patch.ts
@@ -1,0 +1,18 @@
+/**
+ * Converts all `null` values in an object to `undefined`.
+ *
+ * Convex strips `undefined` from function args (so clients can't send it),
+ * but `db.patch` treats `undefined` as "remove field". This bridges the gap:
+ * clients send `null` to mean "clear", and we convert before patching.
+ */
+export function nullsToUndefined<T extends Record<string, unknown>>(
+  obj: T,
+): { [K in keyof T]: Exclude<T[K], null> } {
+  const result = { ...obj };
+  for (const key of Object.keys(result)) {
+    if ((result as Record<string, unknown>)[key] === null) {
+      (result as Record<string, unknown>)[key] = undefined;
+    }
+  }
+  return result as { [K in keyof T]: Exclude<T[K], null> };
+}

--- a/apps/web/convex/lib/slugs.test.ts
+++ b/apps/web/convex/lib/slugs.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { generateSlug, slugify } from "./slugs";
+
+describe("slugify", () => {
+  it("lowercases text", () => {
+    expect(slugify("Hello World")).toBe("hello-world");
+  });
+
+  it("replaces non-alphanumeric chars with hyphens", () => {
+    expect(slugify("foo@bar!baz")).toBe("foo-bar-baz");
+  });
+
+  it("collapses consecutive hyphens", () => {
+    expect(slugify("foo---bar")).toBe("foo-bar");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(slugify("--hello--")).toBe("hello");
+  });
+
+  it("handles empty string", () => {
+    expect(slugify("")).toBe("");
+  });
+
+  it("handles all-special characters", () => {
+    expect(slugify("@#$%")).toBe("");
+  });
+});
+
+describe("generateSlug", () => {
+  it("produces a slug with an 8-char hex suffix", () => {
+    const slug = generateSlug("My Project");
+    expect(slug).toMatch(/^my-project-[0-9a-f]{8}$/);
+  });
+
+  it("returns only the suffix for empty names", () => {
+    const slug = generateSlug("");
+    expect(slug).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it("generates unique slugs for the same input", () => {
+    const a = generateSlug("test");
+    const b = generateSlug("test");
+    expect(a).not.toBe(b);
+  });
+});

--- a/apps/web/convex/lib/validation.test.ts
+++ b/apps/web/convex/lib/validation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { RESERVED_AREA_SLUGS, validateAreaName } from "./validation";
+
+describe("RESERVED_AREA_SLUGS", () => {
+  it("contains expected reserved slugs", () => {
+    expect(RESERVED_AREA_SLUGS.has("projects")).toBe(true);
+    expect(RESERVED_AREA_SLUGS.has("settings")).toBe(true);
+    expect(RESERVED_AREA_SLUGS.has("sign-in")).toBe(true);
+    expect(RESERVED_AREA_SLUGS.has("sign-up")).toBe(true);
+  });
+});
+
+describe("validateAreaName", () => {
+  it("accepts a normal area name", () => {
+    expect(() => validateAreaName("Work")).not.toThrow();
+  });
+
+  it("accepts names that slugify differently from reserved words", () => {
+    expect(() => validateAreaName("My Projects List")).not.toThrow();
+  });
+
+  it("rejects 'Projects' (case-insensitive via slugify)", () => {
+    expect(() => validateAreaName("Projects")).toThrow(
+      '"Projects" is reserved',
+    );
+  });
+
+  it("rejects 'Settings'", () => {
+    expect(() => validateAreaName("Settings")).toThrow(
+      '"Settings" is reserved',
+    );
+  });
+
+  it("rejects 'Sign In' (slugifies to sign-in)", () => {
+    expect(() => validateAreaName("Sign In")).toThrow('"Sign In" is reserved');
+  });
+
+  it("rejects 'Sign Up'", () => {
+    expect(() => validateAreaName("Sign Up")).toThrow('"Sign Up" is reserved');
+  });
+});

--- a/apps/web/convex/lib/validation.ts
+++ b/apps/web/convex/lib/validation.ts
@@ -1,0 +1,19 @@
+import { slugify } from "./slugs";
+
+export const RESERVED_AREA_SLUGS = new Set([
+  "projects",
+  "settings",
+  "sign-in",
+  "sign-up",
+]);
+
+/**
+ * Validates that an area name does not conflict with reserved slugs.
+ * Throws if the slugified name matches a reserved slug.
+ */
+export function validateAreaName(name: string): void {
+  const base = slugify(name);
+  if (RESERVED_AREA_SLUGS.has(base)) {
+    throw new Error(`"${name}" is reserved and cannot be used as an area name`);
+  }
+}

--- a/apps/web/src/components/tasks/add-task-row.tsx
+++ b/apps/web/src/components/tasks/add-task-row.tsx
@@ -29,7 +29,7 @@ export function AddTaskRow({
   const [description, setDescription] = useState("");
   const [dueDate, setDueDate] = useState<Date | undefined>();
   const [selectedProjectId, setSelectedProjectId] = useState<
-    string | undefined
+    Id<"projects"> | undefined
   >();
   const { createTask } = useTaskMutations(projectId);
 

--- a/apps/web/src/components/tasks/edit-task-dialog.tsx
+++ b/apps/web/src/components/tasks/edit-task-dialog.tsx
@@ -43,7 +43,7 @@ export function EditTaskDialog({
     task.dueDate ? new Date(task.dueDate) : undefined,
   );
   const [selectedProjectId, setSelectedProjectId] = useState<
-    string | undefined
+    Id<"projects"> | undefined
   >(task.projectId);
   const projects = useQuery(api.projects.list);
   const { updateTask } = useTaskMutations(projectId);
@@ -57,7 +57,7 @@ export function EditTaskDialog({
     }
   }, [open, task.title, task.description, task.dueDate, task.projectId]);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault();
     const trimmed = title.trim();
     if (!trimmed) return;
@@ -66,14 +66,9 @@ export function EditTaskDialog({
     await updateTask({
       id: task._id,
       title: trimmed,
-      description: descTrimmed || undefined,
-      clearDescription: !descTrimmed && !!task.description,
-      dueDate: dueDate?.getTime(),
-      clearDueDate: !dueDate && !!task.dueDate,
-      projectId: selectedProjectId
-        ? (selectedProjectId as Id<"projects">)
-        : undefined,
-      clearProjectId: !selectedProjectId && !!task.projectId,
+      description: descTrimmed || null,
+      dueDate: dueDate?.getTime() ?? null,
+      projectId: selectedProjectId ? selectedProjectId : null,
     });
     onOpenChange(false);
   };

--- a/apps/web/src/components/tasks/project-picker.tsx
+++ b/apps/web/src/components/tasks/project-picker.tsx
@@ -1,4 +1,4 @@
-import type { Doc } from "@convex/_generated/dataModel";
+import type { Doc, Id } from "@convex/_generated/dataModel";
 import { FolderOpen, X } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -10,8 +10,8 @@ import {
 
 interface ProjectPickerProps {
   projects: Doc<"projects">[];
-  selectedProjectId: string | undefined;
-  onSelect: (id: string | undefined) => void;
+  selectedProjectId: Id<"projects"> | undefined;
+  onSelect: (id: Id<"projects"> | undefined) => void;
 }
 
 export function ProjectPicker({

--- a/apps/web/src/components/tasks/quick-add-task-dialog.tsx
+++ b/apps/web/src/components/tasks/quick-add-task-dialog.tsx
@@ -37,7 +37,7 @@ export function QuickAddTaskDialog({
   const [description, setDescription] = useState("");
   const [dueDate, setDueDate] = useState<Date | undefined>();
   const [selectedProjectId, setSelectedProjectId] = useState<
-    string | undefined
+    Id<"projects"> | undefined
   >();
   const projects = useQuery(api.projects.list);
   const createTask = useMutation(api.tasks.create);
@@ -58,9 +58,7 @@ export function QuickAddTaskDialog({
       title: trimmed,
       description: description.trim() || undefined,
       dueDate: dueDate?.getTime(),
-      projectId: selectedProjectId
-        ? (selectedProjectId as Id<"projects">)
-        : undefined,
+      projectId: selectedProjectId ? selectedProjectId : undefined,
     });
     reset();
     onOpenChange(false);

--- a/apps/web/src/hooks/use-task-mutations.ts
+++ b/apps/web/src/hooks/use-task-mutations.ts
@@ -1,11 +1,13 @@
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
+import { nullsToUndefined } from "@convex/lib/patch";
 import { useMutation } from "convex/react";
 
 export function useTaskMutations(projectId?: Id<"projects">) {
   const updateTask = useMutation(api.tasks.update).withOptimisticUpdate(
     (localStore, args) => {
       const { id, ...updates } = args;
+      const resolved = nullsToUndefined(updates);
 
       if (projectId) {
         const tasks = localStore.getQuery(api.tasks.listByProject, {
@@ -17,7 +19,7 @@ export function useTaskMutations(projectId?: Id<"projects">) {
             localStore.setQuery(
               api.tasks.listByProject,
               { projectId },
-              tasks.map((t) => (t._id === id ? { ...task, ...updates } : t)),
+              tasks.map((t) => (t._id === id ? { ...task, ...resolved } : t)),
             );
           }
         }
@@ -29,7 +31,7 @@ export function useTaskMutations(projectId?: Id<"projects">) {
             localStore.setQuery(
               api.tasks.list,
               {},
-              tasks.map((t) => (t._id === id ? { ...task, ...updates } : t)),
+              tasks.map((t) => (t._id === id ? { ...task, ...resolved } : t)),
             );
           }
         }

--- a/apps/web/src/routes/_authenticated/$areaSlug/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/$projectSlug.tsx
@@ -1,5 +1,6 @@
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
+import { nullsToUndefined } from "@convex/lib/patch";
 import { generateSlug } from "@convex/lib/slugs";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
@@ -59,14 +60,9 @@ function AreaProjectDetailPage() {
     (localStore, args) => {
       const { id, ...updates } = args;
 
-      const resolved = { ...updates };
-      if (updates.clearStartDate) {
-        resolved.startDate = undefined;
-        resolved.endDate = undefined;
-      }
-      if (updates.clearEndDate) {
-        resolved.endDate = undefined;
-      }
+      // Clearing startDate must also clear endDate
+      if (updates.startDate === null) updates.endDate = null;
+      const resolved = nullsToUndefined(updates);
 
       const bySlug = localStore.getQuery(api.projects.getBySlug, {
         slug: projectSlug,
@@ -258,15 +254,11 @@ function AreaProjectDetailPage() {
             const result = await updateProject({
               id: project._id,
               name: data.name,
-              description: data.description,
-              clearDescription: !data.description,
-              definitionOfDone: data.definitionOfDone,
-              clearDefinitionOfDone: !data.definitionOfDone,
+              description: data.description || null,
+              definitionOfDone: data.definitionOfDone || null,
               areaId: data.areaId as Id<"areas">,
-              startDate: data.startDate,
-              clearStartDate: !data.startDate,
-              endDate: data.endDate,
-              clearEndDate: !data.endDate,
+              startDate: data.startDate ?? null,
+              endDate: data.endDate ?? null,
             });
 
             const newSlug =

--- a/apps/web/src/routes/_authenticated/$areaSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/index.tsx
@@ -1,5 +1,6 @@
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
+import { nullsToUndefined } from "@convex/lib/patch";
 import { generateSlug } from "@convex/lib/slugs";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
@@ -60,11 +61,7 @@ function AreaDetailPage() {
   const updateArea = useMutation(api.areas.update).withOptimisticUpdate(
     (localStore, args) => {
       const { id, ...updates } = args;
-
-      const resolved = { ...updates };
-      if (updates.clearStandard) {
-        resolved.standard = undefined;
-      }
+      const resolved = nullsToUndefined(updates);
 
       const bySlug = localStore.getQuery(api.areas.getBySlug, {
         slug: areaSlug,
@@ -361,8 +358,7 @@ function AreaDetailPage() {
           const result = await updateArea({
             id: area._id,
             name: data.name,
-            standard: data.standard,
-            clearStandard: !data.standard,
+            standard: data.standard || null,
             healthStatus: data.healthStatus,
           });
           if (data.name !== area.name && result?.slug) {


### PR DESCRIPTION
## Summary
- Extract business logic (date validation, area name validation) into pure functions in `convex/lib/` with full Vitest coverage (37 tests, zero mocks)
- Replace `clear*` boolean flags with nullable union types (`v.union(v.string(), v.null())`) — clients send `null` to clear a field instead of a separate flag
- Add `nullsToUndefined` helper to bridge the `null` sentinel clients send to the `undefined` that `db.patch` uses for field removal

## Test plan
- [x] `bunx vitest run convex/lib/` — 37 tests pass (dates, validation, slugs, patch)
- [x] `bun run lint` — clean
- [x] `bun run build` — type-check + production build passes
- [ ] Manual: edit a task, clear description/dueDate/project — verify fields are removed
- [ ] Manual: edit a project, clear start/end dates — verify both cleared together
- [ ] Manual: create an area named "Settings" — verify rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)