### PR TITLE
feat(home): add upcoming tasks section

### DIFF
--- a/apps/web/src/components/tasks/due-date-label.tsx
+++ b/apps/web/src/components/tasks/due-date-label.tsx
@@ -1,0 +1,28 @@
+import { format, isToday, isTomorrow } from "date-fns";
+import { Calendar as CalendarIcon } from "lucide-react";
+
+export function DueDateLabel({ timestamp }: { timestamp: number }) {
+  const date = new Date(timestamp);
+  let label: string;
+  let className = "text-xs text-muted-foreground";
+
+  if (isToday(date)) {
+    label = "Today";
+    className = "text-xs text-green-600";
+  } else if (isTomorrow(date)) {
+    label = "Tomorrow";
+    className = "text-xs text-orange-600";
+  } else if (date < new Date()) {
+    label = format(date, "MMM d");
+    className = "text-xs text-red-600";
+  } else {
+    label = format(date, "MMM d");
+  }
+
+  return (
+    <div className="mt-0.5 flex items-center gap-1">
+      <CalendarIcon className="h-3 w-3" />
+      <span className={className}>{label}</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/tasks/task-row.tsx
+++ b/apps/web/src/components/tasks/task-row.tsx
@@ -1,7 +1,7 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
-import { format, isToday, isTomorrow } from "date-fns";
-import { Calendar as CalendarIcon, Trash2 } from "lucide-react";
+import { Trash2 } from "lucide-react";
 import { useState } from "react";
+import { DueDateLabel } from "@/components/tasks/due-date-label";
 import { EditTaskDialog } from "@/components/tasks/edit-task-dialog";
 import {
   AlertDialog,
@@ -94,32 +94,6 @@ export function TaskRow({
         open={editOpen}
         onOpenChange={setEditOpen}
       />
-    </div>
-  );
-}
-
-function DueDateLabel({ timestamp }: { timestamp: number }) {
-  const date = new Date(timestamp);
-  let label: string;
-  let className = "text-xs text-muted-foreground";
-
-  if (isToday(date)) {
-    label = "Today";
-    className = "text-xs text-green-600";
-  } else if (isTomorrow(date)) {
-    label = "Tomorrow";
-    className = "text-xs text-orange-600";
-  } else if (date < new Date()) {
-    label = format(date, "MMM d");
-    className = "text-xs text-red-600";
-  } else {
-    label = format(date, "MMM d");
-  }
-
-  return (
-    <div className="mt-0.5 flex items-center gap-1">
-      <CalendarIcon className="h-3 w-3" />
-      <span className={className}>{label}</span>
     </div>
   );
 }

--- a/apps/web/src/components/tasks/upcoming-section.tsx
+++ b/apps/web/src/components/tasks/upcoming-section.tsx
@@ -1,0 +1,100 @@
+import type { Id } from "@convex/_generated/dataModel";
+import { Link } from "@tanstack/react-router";
+import { CalendarClock } from "lucide-react";
+import { useState } from "react";
+import { DueDateLabel } from "@/components/tasks/due-date-label";
+import { EditTaskDialog } from "@/components/tasks/edit-task-dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useTaskMutations } from "@/hooks/use-task-mutations";
+
+interface UpcomingTask {
+  _id: Id<"tasks">;
+  _creationTime: number;
+  userId: string;
+  title: string;
+  description?: string;
+  isCompleted: boolean;
+  dueDate?: number;
+  projectId?: Id<"projects">;
+  order: number;
+  createdAt: number;
+  projectName: string;
+  projectSlug: string;
+  areaName: string;
+  areaSlug: string;
+}
+
+export function UpcomingSection({ tasks }: { tasks: UpcomingTask[] }) {
+  if (tasks.length === 0) {
+    return (
+      <div className="mb-6">
+        <h2 className="mb-3 text-sm font-medium">Upcoming</h2>
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-8 text-center">
+          <CalendarClock className="mb-3 h-8 w-8 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            No upcoming tasks with due dates.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-6">
+      <h2 className="mb-3 text-sm font-medium">Upcoming ({tasks.length})</h2>
+      <div>
+        {tasks.map((task) => (
+          <UpcomingTaskRow key={task._id} task={task} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function UpcomingTaskRow({ task }: { task: UpcomingTask }) {
+  const [editOpen, setEditOpen] = useState(false);
+  const { updateTask } = useTaskMutations(task.projectId);
+
+  return (
+    <div className="group flex items-start gap-3 py-3">
+      <Checkbox
+        checked={task.isCompleted}
+        onCheckedChange={(checked) =>
+          updateTask({
+            id: task._id,
+            isCompleted: checked === true,
+          })
+        }
+        className="mt-0.5 rounded-full"
+      />
+      <button
+        type="button"
+        className="min-w-0 flex-1 cursor-pointer text-left"
+        onClick={() => setEditOpen(true)}
+      >
+        <span>{task.title}</span>
+        <div className="mt-0.5 flex items-center gap-1.5">
+          {task.dueDate && <DueDateLabel timestamp={task.dueDate} />}
+          <span className="text-xs text-muted-foreground">&middot;</span>
+          <Link
+            to="/$areaSlug/$projectSlug"
+            params={{
+              areaSlug: task.areaSlug,
+              projectSlug: task.projectSlug,
+            }}
+            className="truncate text-xs text-muted-foreground hover:underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {task.areaName} &rsaquo; {task.projectName}
+          </Link>
+        </div>
+      </button>
+      <EditTaskDialog
+        task={task}
+        projectId={task.projectId}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-task-mutations.ts
+++ b/apps/web/src/hooks/use-task-mutations.ts
@@ -36,6 +36,29 @@ export function useTaskMutations(projectId?: Id<"projects">) {
           }
         }
       }
+
+      // Also update listUpcoming cache
+      const upcoming = localStore.getQuery(api.tasks.listUpcoming, {});
+      if (upcoming !== undefined) {
+        const task = upcoming.find((t) => t._id === id);
+        if (task) {
+          if (resolved.isCompleted) {
+            localStore.setQuery(
+              api.tasks.listUpcoming,
+              {},
+              upcoming.filter((t) => t._id !== id),
+            );
+          } else {
+            localStore.setQuery(
+              api.tasks.listUpcoming,
+              {},
+              upcoming.map((t) =>
+                t._id === id ? { ...task, ...resolved } : t,
+              ),
+            );
+          }
+        }
+      }
     },
   );
 
@@ -61,6 +84,16 @@ export function useTaskMutations(projectId?: Id<"projects">) {
             tasks.filter((t) => t._id !== args.id),
           );
         }
+      }
+
+      // Also update listUpcoming cache
+      const upcoming = localStore.getQuery(api.tasks.listUpcoming, {});
+      if (upcoming !== undefined) {
+        localStore.setQuery(
+          api.tasks.listUpcoming,
+          {},
+          upcoming.filter((t) => t._id !== args.id),
+        );
       }
     },
   );

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -13,6 +13,7 @@ import { AddTaskRow } from "@/components/tasks/add-task-row";
 import { CompletedSection } from "@/components/tasks/completed-section";
 import { TaskListSkeleton } from "@/components/tasks/task-list-skeleton";
 import { TaskRow } from "@/components/tasks/task-row";
+import { UpcomingSection } from "@/components/tasks/upcoming-section";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -25,6 +26,7 @@ export const Route = createFileRoute("/_authenticated/")({
 
 function Inbox() {
   const tasks = useQuery(api.tasks.list);
+  const upcomingTasks = useQuery(api.tasks.listUpcoming, {});
   const projects = useQuery(api.projects.list);
   const areas = useQuery(api.areas.list);
   const createArea = useMutation(api.areas.create).withOptimisticUpdate(
@@ -106,6 +108,8 @@ function Inbox() {
         )}
       </div>
 
+      <UpcomingSection tasks={upcomingTasks ?? []} />
+
       <PageHeader title="Inbox" />
       <div>
         {activeTasks.map((task) => (
@@ -145,6 +149,25 @@ function InboxSkeleton() {
               <div className="min-w-0 flex-1 space-y-1.5">
                 <Skeleton className="h-4 w-24" />
                 <Skeleton className="h-3 w-16" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mb-6">
+        <Skeleton className="mb-3 h-4 w-20" />
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
+              key={i}
+              className="flex items-start gap-3 py-3"
+            >
+              <Skeleton className="mt-0.5 h-4 w-4 shrink-0 rounded-full" />
+              <div className="min-w-0 flex-1 space-y-1.5">
+                <Skeleton className="h-4 w-48" />
+                <Skeleton className="h-3 w-32" />
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Summary

- Add "Upcoming" section to the home page showing uncompleted tasks with due dates across all projects
- Tasks sorted by due date (overdue first), with color-coded labels (red/green/orange/gray)
- Each task shows "Area > Project" breadcrumb link for navigation context
- Extract `DueDateLabel` into shared component for reuse
- Add optimistic updates for checkbox toggling and task deletion in the upcoming list

## Test plan

- [ ] Create tasks with various due dates (past, today, tomorrow, future) across different projects
- [ ] Verify tasks appear sorted by due date, overdue tasks at the top
- [ ] Verify color coding: overdue=red, today=green, tomorrow=orange, future=gray
- [ ] Verify inbox tasks (no project) are excluded
- [ ] Verify completed tasks are excluded
- [ ] Click task title opens edit dialog
- [ ] Click "Area > Project" breadcrumb navigates to project page
- [ ] Checkbox marks task complete and removes it from the list (optimistic)
- [ ] Empty state shown when no upcoming tasks exist
- [ ] Loading skeleton renders correctly

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)