### PR TITLE
feat(home): split dashboard and inbox into separate routes

### DIFF
--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -154,10 +154,10 @@ export function AppSidebar() {
               <SidebarMenuItem>
                 <SidebarMenuButton
                   asChild
-                  isActive={pathname === "/"}
+                  isActive={pathname === "/inbox"}
                   tooltip="Inbox"
                 >
-                  <Link to="/">
+                  <Link to="/inbox">
                     <Inbox />
                     <span>Inbox</span>
                   </Link>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as AuthenticatedRouteRouteImport } from './routes/_authenticated/
 import { Route as AuthenticatedIndexRouteImport } from './routes/_authenticated/index'
 import { Route as UnauthenticatedSignUpRouteImport } from './routes/_unauthenticated/sign-up'
 import { Route as UnauthenticatedSignInRouteImport } from './routes/_unauthenticated/sign-in'
+import { Route as AuthenticatedInboxRouteImport } from './routes/_authenticated/inbox'
 import { Route as AuthenticatedAreaSlugIndexRouteImport } from './routes/_authenticated/$areaSlug/index'
 import { Route as AuthenticatedAreaSlugProjectSlugRouteImport } from './routes/_authenticated/$areaSlug/$projectSlug'
 
@@ -40,6 +41,11 @@ const UnauthenticatedSignInRoute = UnauthenticatedSignInRouteImport.update({
   path: '/sign-in',
   getParentRoute: () => UnauthenticatedRouteRoute,
 } as any)
+const AuthenticatedInboxRoute = AuthenticatedInboxRouteImport.update({
+  id: '/inbox',
+  path: '/inbox',
+  getParentRoute: () => AuthenticatedRouteRoute,
+} as any)
 const AuthenticatedAreaSlugIndexRoute =
   AuthenticatedAreaSlugIndexRouteImport.update({
     id: '/$areaSlug/',
@@ -55,6 +61,7 @@ const AuthenticatedAreaSlugProjectSlugRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof AuthenticatedIndexRoute
+  '/inbox': typeof AuthenticatedInboxRoute
   '/sign-in': typeof UnauthenticatedSignInRoute
   '/sign-up': typeof UnauthenticatedSignUpRoute
   '/$areaSlug/$projectSlug': typeof AuthenticatedAreaSlugProjectSlugRoute
@@ -62,6 +69,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof AuthenticatedIndexRoute
+  '/inbox': typeof AuthenticatedInboxRoute
   '/sign-in': typeof UnauthenticatedSignInRoute
   '/sign-up': typeof UnauthenticatedSignUpRoute
   '/$areaSlug/$projectSlug': typeof AuthenticatedAreaSlugProjectSlugRoute
@@ -71,6 +79,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_authenticated': typeof AuthenticatedRouteRouteWithChildren
   '/_unauthenticated': typeof UnauthenticatedRouteRouteWithChildren
+  '/_authenticated/inbox': typeof AuthenticatedInboxRoute
   '/_unauthenticated/sign-in': typeof UnauthenticatedSignInRoute
   '/_unauthenticated/sign-up': typeof UnauthenticatedSignUpRoute
   '/_authenticated/': typeof AuthenticatedIndexRoute
@@ -81,16 +90,24 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/inbox'
     | '/sign-in'
     | '/sign-up'
     | '/$areaSlug/$projectSlug'
     | '/$areaSlug/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/sign-in' | '/sign-up' | '/$areaSlug/$projectSlug' | '/$areaSlug'
+  to:
+    | '/'
+    | '/inbox'
+    | '/sign-in'
+    | '/sign-up'
+    | '/$areaSlug/$projectSlug'
+    | '/$areaSlug'
   id:
     | '__root__'
     | '/_authenticated'
     | '/_unauthenticated'
+    | '/_authenticated/inbox'
     | '/_unauthenticated/sign-in'
     | '/_unauthenticated/sign-up'
     | '/_authenticated/'
@@ -140,6 +157,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UnauthenticatedSignInRouteImport
       parentRoute: typeof UnauthenticatedRouteRoute
     }
+    '/_authenticated/inbox': {
+      id: '/_authenticated/inbox'
+      path: '/inbox'
+      fullPath: '/inbox'
+      preLoaderRoute: typeof AuthenticatedInboxRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/$areaSlug/': {
       id: '/_authenticated/$areaSlug/'
       path: '/$areaSlug'
@@ -158,12 +182,14 @@ declare module '@tanstack/react-router' {
 }
 
 interface AuthenticatedRouteRouteChildren {
+  AuthenticatedInboxRoute: typeof AuthenticatedInboxRoute
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute
   AuthenticatedAreaSlugProjectSlugRoute: typeof AuthenticatedAreaSlugProjectSlugRoute
   AuthenticatedAreaSlugIndexRoute: typeof AuthenticatedAreaSlugIndexRoute
 }
 
 const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
+  AuthenticatedInboxRoute: AuthenticatedInboxRoute,
   AuthenticatedIndexRoute: AuthenticatedIndexRoute,
   AuthenticatedAreaSlugProjectSlugRoute: AuthenticatedAreaSlugProjectSlugRoute,
   AuthenticatedAreaSlugIndexRoute: AuthenticatedAreaSlugIndexRoute,

--- a/apps/web/src/routes/_authenticated/inbox.tsx
+++ b/apps/web/src/routes/_authenticated/inbox.tsx
@@ -1,0 +1,54 @@
+import { api } from "@convex/_generated/api";
+import { createFileRoute } from "@tanstack/react-router";
+import { useQuery } from "convex-helpers/react/cache/hooks";
+import { PageHeader } from "@/components/layout/page-header";
+import { AddTaskRow } from "@/components/tasks/add-task-row";
+import { CompletedSection } from "@/components/tasks/completed-section";
+import { TaskListSkeleton } from "@/components/tasks/task-list-skeleton";
+import { TaskRow } from "@/components/tasks/task-row";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export const Route = createFileRoute("/_authenticated/inbox")({
+  head: () => ({
+    meta: [{ title: "Inbox | Vita OS" }],
+  }),
+  component: InboxPage,
+});
+
+function InboxPage() {
+  const tasks = useQuery(api.tasks.list);
+  const projects = useQuery(api.projects.list);
+
+  if (tasks === undefined) {
+    return <InboxSkeleton />;
+  }
+
+  const activeTasks = tasks.filter((t) => !t.isCompleted);
+  const completedTasks = tasks.filter((t) => t.isCompleted);
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <PageHeader title="Inbox" />
+      <div>
+        {activeTasks.map((task) => (
+          <TaskRow key={task._id} task={task} />
+        ))}
+        <AddTaskRow showProjectPicker projects={projects ?? []} />
+        {completedTasks.length > 0 && (
+          <CompletedSection tasks={completedTasks} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function InboxSkeleton() {
+  return (
+    <div className="mx-auto max-w-3xl">
+      <div className="mb-6">
+        <Skeleton className="h-8 w-20" />
+      </div>
+      <TaskListSkeleton />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Make `/` a wider dashboard (`max-w-5xl`) with areas grid, upcoming tasks, and an inbox summary (first 5 tasks with "View all" link)
- Move the full inbox to `/inbox` with the add-task form and completed section
- Update sidebar "Inbox" link to point to `/inbox`; logo still links to `/` (dashboard)

Closes #85

## Test plan

- [ ] `/` shows the dashboard with wider layout, areas grid, upcoming tasks, and inbox summary (max 5 tasks)
- [ ] `/inbox` shows the full inbox with add-task form and completed section
- [ ] Sidebar "Inbox" link navigates to `/inbox` and shows active state
- [ ] Sidebar logo navigates to `/` (dashboard)
- [ ] "View all" link on dashboard inbox summary navigates to `/inbox`
- [ ] Task interactions (checkbox, edit, delete) work on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)