### PR TITLE
feat(dashboard): add attention logic and review tracking

### DIFF
--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as areas from "../areas.js";
 import type * as auth from "../auth.js";
 import type * as captures from "../captures.js";
+import type * as dashboard from "../dashboard.js";
 import type * as http from "../http.js";
 import type * as lib_patch from "../lib/patch.js";
 import type * as lib_slugs from "../lib/slugs.js";
@@ -28,6 +29,7 @@ declare const fullApi: ApiFromModules<{
   areas: typeof areas;
   auth: typeof auth;
   captures: typeof captures;
+  dashboard: typeof dashboard;
   http: typeof http;
   "lib/patch": typeof lib_patch;
   "lib/slugs": typeof lib_slugs;

--- a/apps/web/convex/dashboard.ts
+++ b/apps/web/convex/dashboard.ts
@@ -1,0 +1,119 @@
+import { mutation, query } from "./_generated/server";
+import { authComponent } from "./auth";
+
+export const attention = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+    if (!user) return { items: [], byArea: {} as Record<string, number> };
+    const userId = String(user._id);
+    const now = Date.now();
+
+    const projects = await ctx.db
+      .query("projects")
+      .withIndex("by_user_order", (q) => q.eq("userId", userId))
+      .collect();
+
+    const activeProjects = projects.filter((p) => p.state === "active");
+
+    const items: Array<{
+      projectId: string;
+      projectName: string;
+      projectSlug: string | undefined;
+      areaId: string;
+      reason: "no_next_action" | "review_overdue";
+      overdueBy?: number;
+    }> = [];
+
+    for (const project of activeProjects) {
+      if (!project.nextAction) {
+        items.push({
+          projectId: project._id,
+          projectName: project.name,
+          projectSlug: project.slug,
+          areaId: project.areaId,
+          reason: "no_next_action",
+        });
+      }
+      if (project.nextReviewDate && project.nextReviewDate < now) {
+        items.push({
+          projectId: project._id,
+          projectName: project.name,
+          projectSlug: project.slug,
+          areaId: project.areaId,
+          reason: "review_overdue",
+          overdueBy: now - project.nextReviewDate,
+        });
+      }
+    }
+
+    items.sort((a, b) => {
+      if (a.reason === "no_next_action" && b.reason !== "no_next_action")
+        return -1;
+      if (a.reason !== "no_next_action" && b.reason === "no_next_action")
+        return 1;
+      if (a.reason === "review_overdue" && b.reason === "review_overdue") {
+        return (b.overdueBy ?? 0) - (a.overdueBy ?? 0);
+      }
+      return 0;
+    });
+
+    const byArea: Record<string, number> = {};
+    const seenByArea = new Map<string, Set<string>>();
+    for (const item of items) {
+      if (!seenByArea.has(item.areaId)) {
+        seenByArea.set(item.areaId, new Set());
+      }
+      seenByArea.get(item.areaId)?.add(item.projectId);
+    }
+    for (const [areaId, projectSet] of seenByArea) {
+      byArea[areaId] = projectSet.size;
+    }
+
+    return { items, byArea };
+  },
+});
+
+export const lastReview = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+    if (!user) return null;
+    const userId = String(user._id);
+
+    const settings = await ctx.db
+      .query("userSettings")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .unique();
+
+    return settings?.lastReviewDate ?? null;
+  },
+});
+
+export const markReviewed = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const user = await authComponent.getAuthUser(ctx);
+    const userId = String(user._id);
+
+    const existing = await ctx.db
+      .query("userSettings")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .unique();
+
+    const now = Date.now();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        lastReviewDate: now,
+      });
+    } else {
+      await ctx.db.insert("userSettings", {
+        userId,
+        lastReviewDate: now,
+      });
+    }
+
+    return now;
+  },
+});

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -58,6 +58,11 @@ export default defineSchema({
     .index("by_user", ["userId"])
     .index("by_user_created", ["userId", "createdAt"]),
 
+  userSettings: defineTable({
+    userId: v.string(),
+    lastReviewDate: v.optional(v.number()),
+  }).index("by_user", ["userId"]),
+
   projectLogs: defineTable({
     userId: v.string(),
     projectId: v.id("projects"),

--- a/apps/web/src/components/areas/area-card.tsx
+++ b/apps/web/src/components/areas/area-card.tsx
@@ -1,5 +1,6 @@
 import type { Doc } from "@convex/_generated/dataModel";
 import { Link } from "@tanstack/react-router";
+import { AlertTriangle } from "lucide-react";
 
 const healthColors = {
   healthy: "bg-green-500",
@@ -10,9 +11,14 @@ const healthColors = {
 interface AreaCardProps {
   area: Doc<"areas">;
   projectCount: number;
+  attentionCount: number;
 }
 
-export function AreaCard({ area, projectCount }: AreaCardProps) {
+export function AreaCard({
+  area,
+  projectCount,
+  attentionCount,
+}: AreaCardProps) {
   return (
     <Link
       to="/$areaSlug"
@@ -27,6 +33,12 @@ export function AreaCard({ area, projectCount }: AreaCardProps) {
         <p className="text-xs text-muted-foreground">
           {projectCount} {projectCount === 1 ? "project" : "projects"}
         </p>
+        {attentionCount > 0 && (
+          <p className="mt-0.5 flex items-center gap-1 text-xs text-amber-600 dark:text-amber-500">
+            <AlertTriangle className="h-3 w-3" />
+            {attentionCount} needs attention
+          </p>
+        )}
       </div>
     </Link>
   );

--- a/apps/web/src/components/dashboard/attention-section.tsx
+++ b/apps/web/src/components/dashboard/attention-section.tsx
@@ -1,0 +1,81 @@
+import type { Doc } from "@convex/_generated/dataModel";
+import { Link } from "@tanstack/react-router";
+import { formatDistanceToNow } from "date-fns";
+import { AlertTriangle, CircleAlert } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+interface AttentionItem {
+  projectId: string;
+  projectName: string;
+  projectSlug: string | undefined;
+  areaId: string;
+  reason: "no_next_action" | "review_overdue";
+  overdueBy?: number;
+}
+
+interface AttentionSectionProps {
+  items: AttentionItem[];
+  areas: Doc<"areas">[];
+}
+
+export function AttentionSection({ items, areas }: AttentionSectionProps) {
+  const areaMap = new Map(areas.map((a) => [a._id as string, a]));
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center gap-2">
+        <h2 className="text-sm font-medium">Needs Attention</h2>
+        <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+          {items.length}
+        </Badge>
+      </div>
+      <div className="rounded-lg border">
+        {items.map((item, i) => {
+          const area = areaMap.get(item.areaId);
+          const areaSlug = area?.slug ?? area?._id ?? item.areaId;
+          const projectSlug = item.projectSlug ?? item.projectId;
+
+          return (
+            <Link
+              key={`${item.projectId}-${item.reason}`}
+              to="/$areaSlug/$projectSlug"
+              params={{ areaSlug, projectSlug }}
+              className={`flex items-center justify-between gap-3 px-3 py-2.5 transition-colors hover:bg-muted/50 ${
+                i < items.length - 1 ? "border-b" : ""
+              }`}
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium">
+                  {item.projectName}
+                </p>
+                {area && (
+                  <p className="text-xs text-muted-foreground">{area.name}</p>
+                )}
+              </div>
+              {item.reason === "no_next_action" ? (
+                <Badge
+                  variant="outline"
+                  className="shrink-0 gap-1 text-[10px] text-amber-600 dark:text-amber-500"
+                >
+                  <CircleAlert className="h-3 w-3" />
+                  No next action
+                </Badge>
+              ) : (
+                <Badge
+                  variant="outline"
+                  className="shrink-0 gap-1 text-[10px] text-amber-600 dark:text-amber-500"
+                >
+                  <AlertTriangle className="h-3 w-3" />
+                  Review overdue{" "}
+                  {item.overdueBy
+                    ? formatDistanceToNow(Date.now() - item.overdueBy)
+                    : ""}
+                </Badge>
+              )}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/review-status.tsx
+++ b/apps/web/src/components/dashboard/review-status.tsx
@@ -1,0 +1,42 @@
+import { formatDistanceToNow } from "date-fns";
+import { Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface ReviewStatusProps {
+  lastReviewDate: number | null;
+  onMarkReviewed: () => void;
+}
+
+export function ReviewStatus({
+  lastReviewDate,
+  onMarkReviewed,
+}: ReviewStatusProps) {
+  const isOverdue =
+    !lastReviewDate || Date.now() - lastReviewDate >= SEVEN_DAYS_MS;
+
+  return (
+    <div className="mb-6 flex items-center gap-2 text-xs">
+      <span
+        className={`h-2 w-2 shrink-0 rounded-full ${
+          isOverdue ? "bg-amber-500" : "bg-green-500"
+        }`}
+      />
+      <span className="text-muted-foreground">
+        {lastReviewDate
+          ? `Last reviewed ${formatDistanceToNow(new Date(lastReviewDate), { addSuffix: true })}`
+          : "Never reviewed"}
+      </span>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-6 gap-1 px-2 text-xs"
+        onClick={onMarkReviewed}
+      >
+        <Check className="h-3 w-3" />
+        Mark reviewed
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -8,6 +8,8 @@ import { Compass, Plus } from "lucide-react";
 import { useState } from "react";
 import { AreaCard } from "@/components/areas/area-card";
 import { AreaFormDialog } from "@/components/areas/area-form-dialog";
+import { AttentionSection } from "@/components/dashboard/attention-section";
+import { ReviewStatus } from "@/components/dashboard/review-status";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -21,6 +23,8 @@ export const Route = createFileRoute("/_authenticated/")({
 function Dashboard() {
   const projects = useQuery(api.projects.list);
   const areas = useQuery(api.areas.list);
+  const attention = useQuery(api.dashboard.attention);
+  const lastReviewDate = useQuery(api.dashboard.lastReview);
   const createArea = useMutation(api.areas.create).withOptimisticUpdate(
     (localStore, args) => {
       const current = localStore.getQuery(api.areas.list, {});
@@ -43,6 +47,7 @@ function Dashboard() {
       }
     },
   );
+  const markReviewed = useMutation(api.dashboard.markReviewed);
   const [showCreateArea, setShowCreateArea] = useState(false);
   const isLoading = areas === undefined;
 
@@ -52,6 +57,11 @@ function Dashboard() {
 
   return (
     <div className="mx-auto max-w-5xl">
+      <ReviewStatus
+        lastReviewDate={lastReviewDate ?? null}
+        onMarkReviewed={() => markReviewed()}
+      />
+
       <div className="mb-6">
         <div className="mb-3 flex items-center justify-between">
           <h2 className="text-sm font-medium">Areas</h2>
@@ -76,6 +86,7 @@ function Dashboard() {
                   key={area._id}
                   area={area}
                   projectCount={projectCount}
+                  attentionCount={attention?.byArea[area._id] ?? 0}
                 />
               );
             })}
@@ -97,6 +108,10 @@ function Dashboard() {
         )}
       </div>
 
+      {attention && attention.items.length > 0 && (
+        <AttentionSection items={attention.items} areas={areas ?? []} />
+      )}
+
       <AreaFormDialog
         open={showCreateArea}
         onOpenChange={setShowCreateArea}
@@ -109,6 +124,11 @@ function Dashboard() {
 function DashboardSkeleton() {
   return (
     <div className="mx-auto max-w-5xl">
+      <div className="mb-6 flex items-center gap-2">
+        <Skeleton className="h-2 w-2 rounded-full" />
+        <Skeleton className="h-3 w-32" />
+      </div>
+
       <div className="mb-6">
         <div className="mb-3 flex items-center justify-between">
           <Skeleton className="h-4 w-12" />


### PR DESCRIPTION
## Summary
- Add attention detection for projects missing a next action or with an overdue review date, surfaced as per-area counts on area cards and a dedicated "Needs Attention" section on the dashboard
- Add `userSettings` table and review status indicator with "Mark reviewed" button, showing overdue state when 7+ days since last review
- Inbox count already visible from all views via sidebar — no changes needed

## Test plan
- [ ] Verify area cards show attention count (amber indicator) for areas with projects needing attention
- [ ] Verify "Needs Attention" section lists projects sorted by urgency (no next action first, then overdue reviews)
- [ ] Verify each attention item links to the correct project detail page and shows area name + reason badge
- [ ] Verify review status shows "Never reviewed" initially with amber dot
- [ ] Verify clicking "Mark reviewed" updates timestamp and dot turns green
- [ ] Verify dot turns amber again after 7+ days
- [ ] Verify empty state: no attention section when all projects are on track
- [ ] Verify `bun run lint` and `bun run build` pass