### PR TITLE
style: emerald/slate theme and surface scale

### DIFF
--- a/apps/web/src/components/areas/area-card.tsx
+++ b/apps/web/src/components/areas/area-card.tsx
@@ -18,7 +18,7 @@ export function AreaCard({
     <Link
       to="/$areaSlug"
       params={{ areaSlug: area.slug ?? area._id }}
-      className="group relative rounded-xl bg-card p-5 transition-colors hover:bg-accent/60"
+      className="group relative rounded-xl bg-surface-2 p-5 transition-colors hover:bg-surface-3/60"
     >
       <div className="flex items-center gap-2.5">
         <span

--- a/apps/web/src/components/areas/area-picker.tsx
+++ b/apps/web/src/components/areas/area-picker.tsx
@@ -39,7 +39,7 @@ export function AreaPicker({
               onSelect(a._id);
               setOpen(false);
             }}
-            className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-muted"
+            className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-surface-3"
           >
             {a.name}
           </button>

--- a/apps/web/src/components/captures/process-capture-dialog.tsx
+++ b/apps/web/src/components/captures/process-capture-dialog.tsx
@@ -14,7 +14,6 @@ import {
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Textarea } from "@/components/ui/textarea";
 
 type ProcessMode = "create_project" | "add_to_project" | "discard";
 
@@ -32,7 +31,6 @@ interface ProcessCaptureDialogProps {
           name: string;
           areaId: Id<"areas">;
           description?: string;
-          definitionOfDone?: string;
         }
       | { type: "add_to_project"; projectId: Id<"projects"> }
       | { type: "discard" },
@@ -50,7 +48,6 @@ export function ProcessCaptureDialog({
   const [mode, setMode] = useState<ProcessMode>("create_project");
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [definitionOfDone, setDefinitionOfDone] = useState("");
   const [areaId, setAreaId] = useState<string | undefined>(areas[0]?._id);
   const [projectId, setProjectId] = useState<string | undefined>(undefined);
 
@@ -65,7 +62,6 @@ export function ProcessCaptureDialog({
         name: trimmedName,
         areaId: areaId as Id<"areas">,
         description: description.trim() || undefined,
-        definitionOfDone: definitionOfDone.trim() || undefined,
       });
     } else if (mode === "add_to_project") {
       if (!projectId) return;
@@ -93,7 +89,7 @@ export function ProcessCaptureDialog({
         </ResponsiveDialogHeader>
 
         {/* Capture text reference */}
-        <div className="border-l-2 border-primary/30 bg-muted/30 py-2 pr-3 pl-3">
+        <div className="border-l-2 border-primary/30 bg-surface-3/30 py-2 pr-3 pl-3">
           <p className="line-clamp-3 whitespace-pre-wrap text-sm text-muted-foreground">
             {capture.text}
           </p>
@@ -159,21 +155,7 @@ export function ProcessCaptureDialog({
                     placeholder="Optional description"
                   />
                 </div>
-                <div className="space-y-1.5">
-                  <Label
-                    htmlFor="process-dod"
-                    className="text-xs text-muted-foreground"
-                  >
-                    Definition of Done
-                  </Label>
-                  <Textarea
-                    id="process-dod"
-                    value={definitionOfDone}
-                    onChange={(e) => setDefinitionOfDone(e.target.value)}
-                    placeholder="When is this project done?"
-                    rows={2}
-                  />
-                </div>
+                {/* definitionOfDone field hidden — pending removal from backend */}
               </div>
             </TabsContent>
 

--- a/apps/web/src/components/dashboard/attention-section.tsx
+++ b/apps/web/src/components/dashboard/attention-section.tsx
@@ -34,7 +34,7 @@ export function AttentionSection({ items, areas }: AttentionSectionProps) {
         <h2 className="text-sm font-medium">Needs Attention</h2>
         <span className="text-xs text-muted-foreground">{items.length}</span>
       </div>
-      <div className="divide-y divide-border/50 rounded-xl bg-card">
+      <div className="divide-y divide-border/50 rounded-xl bg-surface-2">
         {items.map((item) => {
           const area = areaMap.get(item.areaId);
           const areaSlug = area?.slug ?? area?._id ?? item.areaId;
@@ -45,7 +45,7 @@ export function AttentionSection({ items, areas }: AttentionSectionProps) {
               key={`${item.projectId}-${item.reason}`}
               to="/$areaSlug/$projectSlug"
               params={{ areaSlug, projectSlug }}
-              className="flex items-center justify-between gap-3 px-4 py-3.5 transition-colors first:rounded-t-xl last:rounded-b-xl hover:bg-accent/60"
+              className="flex items-center justify-between gap-3 px-4 py-3.5 transition-colors first:rounded-t-xl last:rounded-b-xl hover:bg-surface-3/60"
             >
               <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium">

--- a/apps/web/src/components/dashboard/recent-captures.tsx
+++ b/apps/web/src/components/dashboard/recent-captures.tsx
@@ -33,7 +33,6 @@ export function RecentCaptures() {
           name: string;
           areaId: Id<"areas">;
           description?: string;
-          definitionOfDone?: string;
         }
       | { type: "add_to_project"; projectId: Id<"projects"> }
       | { type: "discard" },
@@ -45,13 +44,13 @@ export function RecentCaptures() {
   return (
     <section>
       <div className="mb-4 flex items-center gap-2.5">
-        <div className="flex h-6 w-6 items-center justify-center rounded-md bg-muted">
+        <div className="flex h-6 w-6 items-center justify-center rounded-md bg-surface-3">
           <Inbox className="h-3.5 w-3.5 text-muted-foreground" />
         </div>
         <h2 className="text-sm font-medium">Recent Captures</h2>
         <span className="text-xs text-muted-foreground">{captures.length}</span>
       </div>
-      <div className="divide-y divide-border/50 rounded-xl bg-card">
+      <div className="divide-y divide-border/50 rounded-xl bg-surface-2">
         {visible.map((capture) => (
           <CaptureRow
             key={capture._id}

--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -72,7 +72,6 @@ export function AppSidebar() {
             name: args.name,
             slug: generateSlug(args.name),
             description: args.description,
-            definitionOfDone: args.definitionOfDone,
             areaId: args.areaId,
             order: maxOrder + 1,
             state: "active" as const,

--- a/apps/web/src/components/projects/project-form-dialog.tsx
+++ b/apps/web/src/components/projects/project-form-dialog.tsx
@@ -20,7 +20,6 @@ interface ProjectFormDialogProps {
   onSubmit: (data: {
     name: string;
     description?: string;
-    definitionOfDone?: string;
     areaId: string;
   }) => void;
   project?: Doc<"projects">;
@@ -38,9 +37,6 @@ export function ProjectFormDialog({
 }: ProjectFormDialogProps) {
   const [name, setName] = useState(project?.name ?? "");
   const [description, setDescription] = useState(project?.description ?? "");
-  const [definitionOfDone, setDefinitionOfDone] = useState(
-    project?.definitionOfDone ?? "",
-  );
   const [areaId, setAreaId] = useState<string | undefined>(
     project?.areaId ?? defaultAreaId,
   );
@@ -49,7 +45,6 @@ export function ProjectFormDialog({
     if (open && !project) {
       setName("");
       setDescription("");
-      setDefinitionOfDone("");
       setAreaId(defaultAreaId);
     }
   }, [open, project, defaultAreaId]);
@@ -62,14 +57,12 @@ export function ProjectFormDialog({
     onSubmit({
       name: trimmedName,
       description: description.trim() || undefined,
-      definitionOfDone: definitionOfDone.trim() || undefined,
       areaId,
     });
 
     if (!project) {
       setName("");
       setDescription("");
-      setDefinitionOfDone("");
       setAreaId(defaultAreaId);
     }
     onOpenChange(false);
@@ -114,24 +107,7 @@ export function ProjectFormDialog({
               rows={2}
             />
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="project-dod">
-              Definition of Done
-              <span className="ml-1 font-normal text-muted-foreground">
-                (optional)
-              </span>
-            </Label>
-            <Textarea
-              id="project-dod"
-              value={definitionOfDone}
-              onChange={(e) => setDefinitionOfDone(e.target.value)}
-              placeholder="A concrete, verifiable outcome..."
-              rows={2}
-            />
-            <p className="text-xs text-muted-foreground">
-              How will you know this is done?
-            </p>
-          </div>
+          {/* definitionOfDone field hidden — pending removal from backend */}
           {areas && (
             <div className="space-y-2">
               <Label>Area</Label>

--- a/apps/web/src/components/projects/project-picker.tsx
+++ b/apps/web/src/components/projects/project-picker.tsx
@@ -53,7 +53,7 @@ export function ProjectPicker({
                   onSelect(p._id);
                   setOpen(false);
                 }}
-                className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-muted"
+                className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-surface-3"
               >
                 {p.name}
               </button>

--- a/apps/web/src/components/projects/tag-input.tsx
+++ b/apps/web/src/components/projects/tag-input.tsx
@@ -127,7 +127,7 @@ export function TagInput({
               key={suggestion}
               type="button"
               onClick={() => handleAdd(suggestion)}
-              className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-muted"
+              className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-surface-3"
             >
               <span>{suggestion}</span>
               {PROBLEM_TYPE_TAGS.includes(suggestion) && (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4,38 +4,43 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(0.205 0.006 70);
-  --foreground: oklch(0.93 0.005 80);
-  --card: oklch(0.25 0.008 70);
-  --card-foreground: oklch(0.93 0.005 80);
-  --popover: oklch(0.23 0.007 70);
-  --popover-foreground: oklch(0.93 0.005 80);
-  --primary: oklch(0.7214 0.1337 49.9802);
-  --primary-foreground: oklch(0.16 0.006 70);
-  --secondary: oklch(0.594 0.0443 196.0233);
-  --secondary-foreground: oklch(0.16 0.006 70);
-  --muted: oklch(0.295 0.006 70);
-  --muted-foreground: oklch(0.7 0.008 70);
-  --accent: oklch(0.35 0.008 70);
-  --accent-foreground: oklch(0.93 0.005 80);
+  /* Surface scale */
+  --surface-1: oklch(0.205 0.006 250);
+  --surface-2: oklch(0.25 0.006 250);
+  --surface-3: oklch(0.3 0.006 250);
+
+  --background: var(--surface-1);
+  --foreground: oklch(0.93 0.005 250);
+  --card: var(--surface-2);
+  --card-foreground: oklch(0.93 0.005 250);
+  --popover: var(--surface-2);
+  --popover-foreground: oklch(0.93 0.005 250);
+  --primary: oklch(0.7 0.17 155);
+  --primary-foreground: oklch(0.16 0.006 155);
+  --secondary: oklch(0.6 0.06 170);
+  --secondary-foreground: oklch(0.16 0.006 170);
+  --muted: var(--surface-3);
+  --muted-foreground: oklch(0.7 0.008 250);
+  --accent: var(--surface-3);
+  --accent-foreground: oklch(0.93 0.005 250);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.93 0 0);
-  --border: oklch(0.34 0.006 70);
-  --input: oklch(0.295 0.006 70);
-  --ring: oklch(0.7214 0.1337 49.9802);
-  --chart-1: oklch(0.594 0.0443 196.0233);
-  --chart-2: oklch(0.7214 0.1337 49.9802);
-  --chart-3: oklch(0.8721 0.0864 68.5474);
-  --chart-4: oklch(0.72 0.005 70);
-  --chart-5: oklch(0.78 0.005 70);
-  --sidebar: oklch(0.19 0.008 70);
-  --sidebar-foreground: oklch(0.93 0.005 80);
-  --sidebar-primary: oklch(0.7214 0.1337 49.9802);
-  --sidebar-primary-foreground: oklch(0.16 0.006 70);
-  --sidebar-accent: oklch(0.35 0.008 70);
-  --sidebar-accent-foreground: oklch(0.93 0.005 80);
-  --sidebar-border: oklch(0.3 0.006 70);
-  --sidebar-ring: oklch(0.7214 0.1337 49.9802);
+  --border: oklch(0.34 0.006 250);
+  --input: var(--surface-3);
+  --ring: oklch(0.7 0.17 155);
+  --chart-1: oklch(0.7 0.17 155);
+  --chart-2: oklch(0.6 0.06 170);
+  --chart-3: oklch(0.75 0.1 130);
+  --chart-4: oklch(0.72 0.005 250);
+  --chart-5: oklch(0.78 0.005 250);
+  --sidebar: var(--surface-1);
+  --sidebar-foreground: oklch(0.93 0.005 250);
+  --sidebar-primary: oklch(0.7 0.17 155);
+  --sidebar-primary-foreground: oklch(0.16 0.006 155);
+  --sidebar-accent: var(--surface-3);
+  --sidebar-accent-foreground: oklch(0.93 0.005 250);
+  --sidebar-border: oklch(0.28 0.006 250);
+  --sidebar-ring: oklch(0.7 0.17 155);
   --font-sans: "Rubik Variable", ui-sans-serif, system-ui, sans-serif;
   --font-serif: serif;
   --font-mono: JetBrains Mono, monospace;
@@ -62,6 +67,10 @@
 }
 
 @theme inline {
+  --color-surface-1: var(--surface-1);
+  --color-surface-2: var(--surface-2);
+  --color-surface-3: var(--surface-3);
+
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);

--- a/apps/web/src/routes/_authenticated/$areaSlug/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/$projectSlug.tsx
@@ -195,7 +195,7 @@ function AreaProjectDetailPage() {
   };
 
   const handleFieldSave = (
-    field: "description" | "status" | "nextAction" | "definitionOfDone",
+    field: "description" | "status" | "nextAction",
     value: string,
   ) => {
     updateProject({
@@ -261,7 +261,7 @@ function AreaProjectDetailPage() {
 
       {/* Primary: Status & Next Action */}
       <div className="grid gap-3 sm:grid-cols-2">
-        <div className="rounded-xl bg-card p-4">
+        <div className="rounded-xl bg-surface-2 p-4">
           <div className="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
             <Target className="h-3.5 w-3.5" />
             Status
@@ -274,7 +274,7 @@ function AreaProjectDetailPage() {
           />
         </div>
 
-        <div className="rounded-xl bg-card p-4">
+        <div className="rounded-xl bg-surface-2 p-4">
           <div className="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
             <ArrowRight className="h-3.5 w-3.5" />
             Next Action
@@ -314,18 +314,7 @@ function AreaProjectDetailPage() {
           />
         </MetadataRow>
 
-        <MetadataRow
-          icon={<CheckCircle2 className="h-3.5 w-3.5" />}
-          label="Definition of Done"
-        >
-          <EditableField
-            value={project.definitionOfDone ?? ""}
-            onSave={(v) => handleFieldSave("definitionOfDone", v)}
-            variant="textarea"
-            placeholder="When is this done?"
-            className="text-sm"
-          />
-        </MetadataRow>
+        {/* definitionOfDone field hidden — pending removal from backend */}
       </div>
 
       {/* Actions */}
@@ -419,7 +408,7 @@ function AreaProjectDetailPage() {
       {/* Activity Log */}
       <section>
         <div className="mb-4 flex items-center gap-2.5">
-          <div className="flex h-6 w-6 items-center justify-center rounded-md bg-muted">
+          <div className="flex h-6 w-6 items-center justify-center rounded-md bg-surface-3">
             <MessageSquare className="h-3.5 w-3.5 text-muted-foreground" />
           </div>
           <h2 className="text-sm font-medium">Activity</h2>
@@ -433,7 +422,7 @@ function AreaProjectDetailPage() {
             value={noteText}
             onChange={(e) => setNoteText(e.target.value)}
             placeholder="Add a note..."
-            className="min-h-9 bg-card"
+            className="min-h-9 bg-surface-2"
             rows={1}
             onKeyDown={(e) => {
               if (e.key === "Enter" && !e.shiftKey) {
@@ -528,11 +517,11 @@ function ProjectDetailSkeleton() {
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2">
-        <div className="rounded-xl bg-card p-4">
+        <div className="rounded-xl bg-surface-2 p-4">
           <Skeleton className="mb-2 h-3 w-12" />
           <Skeleton className="h-5 w-3/4" />
         </div>
-        <div className="rounded-xl bg-card p-4">
+        <div className="rounded-xl bg-surface-2 p-4">
           <Skeleton className="mb-2 h-3 w-16" />
           <Skeleton className="h-5 w-3/4" />
         </div>

--- a/apps/web/src/routes/_authenticated/$areaSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/index.tsx
@@ -133,7 +133,6 @@ function AreaDetailPage() {
             name: args.name,
             slug: generateSlug(args.name),
             description: args.description,
-            definitionOfDone: args.definitionOfDone,
             areaId: args.areaId,
             order: maxOrder + 1,
             state: "active" as const,
@@ -259,7 +258,7 @@ function AreaDetailPage() {
 
         <div className="mt-3 flex items-center gap-3">
           <Select value={area.healthStatus} onValueChange={handleHealthChange}>
-            <SelectTrigger className="h-7 w-auto gap-2 border-none bg-muted/60 px-3 text-xs">
+            <SelectTrigger className="h-7 w-auto gap-2 border-none bg-surface-3/60 px-3 text-xs">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -276,7 +275,7 @@ function AreaDetailPage() {
 
       {/* Standard */}
       {area.standard && (
-        <div className="rounded-xl bg-card p-5">
+        <div className="rounded-xl bg-surface-2 p-5">
           <h2 className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
             Standard
           </h2>
@@ -290,7 +289,7 @@ function AreaDetailPage() {
       <section>
         <div className="mb-4 flex items-center justify-between">
           <div className="flex items-center gap-2.5">
-            <div className="flex h-6 w-6 items-center justify-center rounded-md bg-muted">
+            <div className="flex h-6 w-6 items-center justify-center rounded-md bg-surface-3">
               <FolderOpen className="h-3.5 w-3.5 text-muted-foreground" />
             </div>
             <h2 className="text-sm font-medium">Projects</h2>
@@ -321,7 +320,7 @@ function AreaDetailPage() {
             </Button>
           </div>
         ) : (
-          <div className="divide-y divide-border/50 rounded-xl bg-card">
+          <div className="divide-y divide-border/50 rounded-xl bg-surface-2">
             {projects.map((project) => {
               const slug = project.slug ?? project._id;
               return (
@@ -332,7 +331,7 @@ function AreaDetailPage() {
                   <Link
                     to="/$areaSlug/$projectSlug"
                     params={{ areaSlug, projectSlug: slug }}
-                    className="flex min-w-0 flex-1 items-start gap-4 px-4 py-4 transition-colors first:rounded-t-xl last:rounded-b-xl hover:bg-accent/60"
+                    className="flex min-w-0 flex-1 items-start gap-4 px-4 py-4 transition-colors first:rounded-t-xl last:rounded-b-xl hover:bg-surface-3/60"
                   >
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
@@ -472,7 +471,7 @@ function AreaDetailSkeleton() {
           <Skeleton className="h-6 w-6 rounded-md" />
           <Skeleton className="h-4 w-16" />
         </div>
-        <div className="divide-y divide-border/50 rounded-xl bg-card">
+        <div className="divide-y divide-border/50 rounded-xl bg-surface-2">
           {Array.from({ length: 2 }).map((_, i) => (
             <div
               // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id

--- a/apps/web/src/routes/_authenticated/inbox.tsx
+++ b/apps/web/src/routes/_authenticated/inbox.tsx
@@ -37,7 +37,6 @@ function InboxPage() {
           name: string;
           areaId: Id<"areas">;
           description?: string;
-          definitionOfDone?: string;
         }
       | { type: "add_to_project"; projectId: Id<"projects"> }
       | { type: "discard" },

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -146,7 +146,7 @@ function DashboardSkeleton() {
             <div
               // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
               key={i}
-              className="rounded-xl bg-card p-5"
+              className="rounded-xl bg-surface-2 p-5"
             >
               <div className="space-y-3">
                 <div className="flex items-center gap-2.5">

--- a/apps/web/src/routes/_unauthenticated/sign-in.tsx
+++ b/apps/web/src/routes/_unauthenticated/sign-in.tsx
@@ -110,7 +110,9 @@ function SignIn() {
               <div className="w-full border-t" />
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="bg-card px-2 text-muted-foreground">or</span>
+              <span className="bg-surface-2 px-2 text-muted-foreground">
+                or
+              </span>
             </div>
           </div>
           <Button variant="outline" className="w-full" onClick={handleGitHub}>

--- a/apps/web/src/routes/_unauthenticated/sign-up.tsx
+++ b/apps/web/src/routes/_unauthenticated/sign-up.tsx
@@ -123,7 +123,9 @@ function SignUp() {
               <div className="w-full border-t" />
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="bg-card px-2 text-muted-foreground">or</span>
+              <span className="bg-surface-2 px-2 text-muted-foreground">
+                or
+              </span>
             </div>
           </div>
           <Button variant="outline" className="w-full" onClick={handleGitHub}>


### PR DESCRIPTION
## Summary
- Replace warm orange/stone palette with emerald green primary (`oklch hue 155`) on cool slate surfaces (`oklch hue 250`)
- Introduce `--surface-1/2/3` CSS custom property scale and migrate all app components from semantic tokens (`bg-card`, `bg-muted`) to surface utilities (`bg-surface-2`, `bg-surface-3`)
- Hide `definitionOfDone` field from project UI (ref #104)

## Test plan
- [ ] Verify emerald primary renders on buttons, links, rings, and sidebar highlights
- [ ] Verify cool slate surfaces across background, cards, popovers, and muted areas
- [ ] Check sign-in/sign-up pages render correctly with new surface tokens
- [ ] Check project detail, area detail, and dashboard pages for correct surface hierarchy
- [ ] Verify project create/edit dialogs no longer show "Definition of Done" field
- [ ] Verify process-capture dialog no longer shows "Definition of Done" when creating a project