### PR TITLE
fix(captures): add discard confirmation, remove redundant dialog tab

### DIFF
--- a/apps/web/src/components/captures/capture-row.tsx
+++ b/apps/web/src/components/captures/capture-row.tsx
@@ -3,6 +3,17 @@ import type { Doc } from "@convex/_generated/dataModel";
 import { useMutation } from "convex/react";
 import { formatDistanceToNow } from "date-fns";
 import { ArrowRight, Trash2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 
 interface CaptureRowProps {
@@ -53,15 +64,36 @@ export function CaptureRow({ capture, onProcess }: CaptureRowProps) {
             <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
           </Button>
         )}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7"
-          onClick={() => removeCapture({ id: capture._id })}
-          aria-label="Discard capture"
-        >
-          <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
-        </Button>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              aria-label="Discard capture"
+            >
+              <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Discard capture?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This capture will be permanently deleted. This action cannot be
+                undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => removeCapture({ id: capture._id })}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                Discard
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
     </div>
   );

--- a/apps/web/src/components/captures/process-capture-dialog.tsx
+++ b/apps/web/src/components/captures/process-capture-dialog.tsx
@@ -1,5 +1,5 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
-import { FolderPlus, ListPlus, Trash2 } from "lucide-react";
+import { FolderPlus, ListPlus } from "lucide-react";
 import { useState } from "react";
 import { AreaPicker } from "@/components/areas/area-picker";
 import { ProjectPicker } from "@/components/projects/project-picker";
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/responsive-dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-type ProcessMode = "create_project" | "add_to_project" | "discard";
+type ProcessMode = "create_project" | "add_to_project";
 
 interface ProcessCaptureDialogProps {
   open: boolean;
@@ -32,8 +32,7 @@ interface ProcessCaptureDialogProps {
           areaId: Id<"areas">;
           description?: string;
         }
-      | { type: "add_to_project"; projectId: Id<"projects"> }
-      | { type: "discard" },
+      | { type: "add_to_project"; projectId: Id<"projects"> },
   ) => void;
 }
 
@@ -69,15 +68,12 @@ export function ProcessCaptureDialog({
         type: "add_to_project",
         projectId: projectId as Id<"projects">,
       });
-    } else {
-      onProcess(capture._id, { type: "discard" });
     }
 
     onOpenChange(false);
   };
 
   const canSubmit =
-    mode === "discard" ||
     (mode === "create_project" && name.trim() && areaId) ||
     (mode === "add_to_project" && projectId);
 
@@ -104,10 +100,6 @@ export function ProcessCaptureDialog({
             <TabsTrigger value="add_to_project" className="text-xs">
               <ListPlus className="h-3.5 w-3.5" />
               Add to project
-            </TabsTrigger>
-            <TabsTrigger value="discard" className="text-xs">
-              <Trash2 className="h-3.5 w-3.5" />
-              Discard
             </TabsTrigger>
           </TabsList>
 
@@ -175,16 +167,6 @@ export function ProcessCaptureDialog({
               </div>
             </TabsContent>
 
-            <TabsContent value="discard">
-              <div className="flex items-start gap-3 rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-3">
-                <Trash2 className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
-                <p className="text-sm text-muted-foreground">
-                  This capture will be permanently deleted. This action cannot
-                  be undone.
-                </p>
-              </div>
-            </TabsContent>
-
             <ResponsiveDialogFooter>
               <Button
                 type="button"
@@ -193,16 +175,10 @@ export function ProcessCaptureDialog({
               >
                 Cancel
               </Button>
-              <Button
-                type="submit"
-                disabled={!canSubmit}
-                variant={mode === "discard" ? "destructive" : "default"}
-              >
+              <Button type="submit" disabled={!canSubmit}>
                 {mode === "create_project"
                   ? "Create project"
-                  : mode === "add_to_project"
-                    ? "Add to project"
-                    : "Discard"}
+                  : "Add to project"}
               </Button>
             </ResponsiveDialogFooter>
           </form>

--- a/apps/web/src/components/dashboard/recent-captures.tsx
+++ b/apps/web/src/components/dashboard/recent-captures.tsx
@@ -34,8 +34,7 @@ export function RecentCaptures() {
           areaId: Id<"areas">;
           description?: string;
         }
-      | { type: "add_to_project"; projectId: Id<"projects"> }
-      | { type: "discard" },
+      | { type: "add_to_project"; projectId: Id<"projects"> },
   ) => {
     await processCapture({ id: captureId, action });
     setProcessingCapture(undefined);

--- a/apps/web/src/routes/_authenticated/inbox.tsx
+++ b/apps/web/src/routes/_authenticated/inbox.tsx
@@ -38,8 +38,7 @@ function InboxPage() {
           areaId: Id<"areas">;
           description?: string;
         }
-      | { type: "add_to_project"; projectId: Id<"projects"> }
-      | { type: "discard" },
+      | { type: "add_to_project"; projectId: Id<"projects"> },
   ) => {
     await processCapture({ id: captureId, action });
     setProcessingCapture(undefined);


### PR DESCRIPTION
## Summary
- Removed the "Discard" tab from the process capture dialog — it was redundant since captures can already be discarded from the row
- Added an AlertDialog confirmation to the trash icon on capture rows to prevent accidental, irreversible deletion

## Test plan
- [ ] Process capture dialog only shows "New project" and "Add to project" tabs
- [ ] Trash icon on capture row shows confirmation dialog before deleting
- [ ] Canceling the confirmation keeps the capture intact
- [ ] Confirming discard deletes the capture with existing optimistic update behavior

Closes #108

🤖 Generated with [Claude Code](https://claude.ai/claude-code)