### PR TITLE
feat(projects): replace description with definition of done

### DIFF
--- a/apps/web/convex/captures.ts
+++ b/apps/web/convex/captures.ts
@@ -66,7 +66,6 @@ export const process = mutation({
         type: v.literal("create_project"),
         name: v.string(),
         areaId: v.id("areas"),
-        description: v.optional(v.string()),
         definitionOfDone: v.optional(v.string()),
       }),
       v.object({
@@ -94,7 +93,6 @@ export const process = mutation({
         userId,
         name: args.action.name,
         slug,
-        description: args.action.description,
         definitionOfDone: args.action.definitionOfDone,
         areaId: args.action.areaId,
         order: nextOrder,

--- a/apps/web/convex/projects.ts
+++ b/apps/web/convex/projects.ts
@@ -62,7 +62,6 @@ export const listByArea = query({
 export const create = mutation({
   args: {
     name: v.string(),
-    description: v.optional(v.string()),
     definitionOfDone: v.optional(v.string()),
     areaId: v.id("areas"),
   },
@@ -75,7 +74,6 @@ export const create = mutation({
       userId,
       name: args.name,
       slug,
-      description: args.description,
       definitionOfDone: args.definitionOfDone,
       areaId: args.areaId,
       order: nextOrder,
@@ -91,7 +89,6 @@ export const update = mutation({
   args: {
     id: v.id("projects"),
     name: v.optional(v.string()),
-    description: v.optional(v.union(v.string(), v.null())),
     definitionOfDone: v.optional(v.union(v.string(), v.null())),
     areaId: v.optional(v.id("areas")),
     status: v.optional(v.union(v.string(), v.null())),

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -23,7 +23,6 @@ export default defineSchema({
     userId: v.string(),
     name: v.string(),
     slug: v.optional(v.string()),
-    description: v.optional(v.string()),
     definitionOfDone: v.optional(v.string()),
     areaId: v.id("areas"),
     order: v.number(),

--- a/apps/web/src/components/captures/process-capture-dialog.tsx
+++ b/apps/web/src/components/captures/process-capture-dialog.tsx
@@ -30,7 +30,7 @@ interface ProcessCaptureDialogProps {
           type: "create_project";
           name: string;
           areaId: Id<"areas">;
-          description?: string;
+          definitionOfDone?: string;
         }
       | { type: "add_to_project"; projectId: Id<"projects"> }
       | { type: "discard" },
@@ -47,7 +47,7 @@ export function ProcessCaptureDialog({
 }: ProcessCaptureDialogProps) {
   const [mode, setMode] = useState<ProcessMode>("create_project");
   const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
+  const [definitionOfDone, setDefinitionOfDone] = useState("");
   const [areaId, setAreaId] = useState<string | undefined>(areas[0]?._id);
   const [projectId, setProjectId] = useState<string | undefined>(undefined);
 
@@ -61,7 +61,7 @@ export function ProcessCaptureDialog({
         type: "create_project",
         name: trimmedName,
         areaId: areaId as Id<"areas">,
-        description: description.trim() || undefined,
+        definitionOfDone: definitionOfDone.trim() || undefined,
       });
     } else if (mode === "add_to_project") {
       if (!projectId) return;
@@ -143,19 +143,18 @@ export function ProcessCaptureDialog({
                 </div>
                 <div className="space-y-1.5">
                   <Label
-                    htmlFor="process-desc"
+                    htmlFor="process-dod"
                     className="text-xs text-muted-foreground"
                   >
-                    Description
+                    Definition of Done
                   </Label>
                   <Input
-                    id="process-desc"
-                    value={description}
-                    onChange={(e) => setDescription(e.target.value)}
-                    placeholder="Optional description"
+                    id="process-dod"
+                    value={definitionOfDone}
+                    onChange={(e) => setDefinitionOfDone(e.target.value)}
+                    placeholder="What does done look like?"
                   />
                 </div>
-                {/* definitionOfDone field hidden — pending removal from backend */}
               </div>
             </TabsContent>
 

--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -71,7 +71,7 @@ export function AppSidebar() {
             userId: "",
             name: args.name,
             slug: generateSlug(args.name),
-            description: args.description,
+            definitionOfDone: args.definitionOfDone,
             areaId: args.areaId,
             order: maxOrder + 1,
             state: "active" as const,

--- a/apps/web/src/components/projects/project-form-dialog.tsx
+++ b/apps/web/src/components/projects/project-form-dialog.tsx
@@ -19,7 +19,7 @@ interface ProjectFormDialogProps {
   onOpenChange: (open: boolean) => void;
   onSubmit: (data: {
     name: string;
-    description?: string;
+    definitionOfDone?: string;
     areaId: string;
   }) => void;
   project?: Doc<"projects">;
@@ -36,7 +36,9 @@ export function ProjectFormDialog({
   defaultAreaId,
 }: ProjectFormDialogProps) {
   const [name, setName] = useState(project?.name ?? "");
-  const [description, setDescription] = useState(project?.description ?? "");
+  const [definitionOfDone, setDefinitionOfDone] = useState(
+    project?.definitionOfDone ?? "",
+  );
   const [areaId, setAreaId] = useState<string | undefined>(
     project?.areaId ?? defaultAreaId,
   );
@@ -44,7 +46,7 @@ export function ProjectFormDialog({
   useEffect(() => {
     if (open && !project) {
       setName("");
-      setDescription("");
+      setDefinitionOfDone("");
       setAreaId(defaultAreaId);
     }
   }, [open, project, defaultAreaId]);
@@ -56,13 +58,13 @@ export function ProjectFormDialog({
 
     onSubmit({
       name: trimmedName,
-      description: description.trim() || undefined,
+      definitionOfDone: definitionOfDone.trim() || undefined,
       areaId,
     });
 
     if (!project) {
       setName("");
-      setDescription("");
+      setDefinitionOfDone("");
       setAreaId(defaultAreaId);
     }
     onOpenChange(false);
@@ -93,21 +95,20 @@ export function ProjectFormDialog({
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="project-description">
-              Description
+            <Label htmlFor="project-dod">
+              Definition of Done
               <span className="ml-1 font-normal text-muted-foreground">
                 (optional)
               </span>
             </Label>
             <Textarea
-              id="project-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Brief context about this project..."
+              id="project-dod"
+              value={definitionOfDone}
+              onChange={(e) => setDefinitionOfDone(e.target.value)}
+              placeholder="What does done look like?"
               rows={2}
             />
           </div>
-          {/* definitionOfDone field hidden — pending removal from backend */}
           {areas && (
             <div className="space-y-2">
               <Label>Area</Label>

--- a/apps/web/src/routes/_authenticated/$areaSlug/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/$projectSlug.tsx
@@ -195,7 +195,7 @@ function AreaProjectDetailPage() {
   };
 
   const handleFieldSave = (
-    field: "description" | "status" | "nextAction",
+    field: "definitionOfDone" | "status" | "nextAction",
     value: string,
   ) => {
     updateProject({
@@ -247,16 +247,6 @@ function AreaProjectDetailPage() {
           onSave={handleNameSave}
           className="text-xl font-semibold tracking-tight"
         />
-
-        <div className="mt-1">
-          <EditableField
-            value={project.description ?? ""}
-            onSave={(v) => handleFieldSave("description", v)}
-            variant="textarea"
-            placeholder="Add a description..."
-            className="text-sm text-muted-foreground"
-          />
-        </div>
       </div>
 
       {/* Primary: Status & Next Action */}
@@ -314,7 +304,18 @@ function AreaProjectDetailPage() {
           />
         </MetadataRow>
 
-        {/* definitionOfDone field hidden — pending removal from backend */}
+        <MetadataRow
+          icon={<CheckCircle2 className="h-3.5 w-3.5" />}
+          label="Definition of Done"
+        >
+          <EditableField
+            value={project.definitionOfDone ?? ""}
+            onSave={(v) => handleFieldSave("definitionOfDone", v)}
+            variant="textarea"
+            placeholder="What does done look like?"
+            className="text-sm"
+          />
+        </MetadataRow>
       </div>
 
       {/* Actions */}

--- a/apps/web/src/routes/_authenticated/$areaSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/index.tsx
@@ -132,7 +132,7 @@ function AreaDetailPage() {
             userId: "",
             name: args.name,
             slug: generateSlug(args.name),
-            description: args.description,
+            definitionOfDone: args.definitionOfDone,
             areaId: args.areaId,
             order: maxOrder + 1,
             state: "active" as const,


### PR DESCRIPTION
## Summary
- Remove the `description` field from the project schema, backend mutations, and all UI surfaces
- Restore the `definitionOfDone` field in the project detail page (as a metadata row), create-project form, and process-capture dialog
- Migration-safe: removing an optional field from the Convex schema is non-breaking

Closes #107

## Test plan
- [ ] Create a new project via the sidebar — "Definition of Done" field appears instead of "Description"
- [ ] Create a project from a capture — "Definition of Done" field appears
- [ ] Open a project detail page — definition of done is editable in the metadata section
- [ ] Verify existing projects with old description data still load without errors
- [ ] `bun run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)