### PR TITLE
feat(captures): add set as next action option to process dialog

### DIFF
--- a/apps/web/src/components/dashboard/recent-captures.tsx
+++ b/apps/web/src/components/dashboard/recent-captures.tsx
@@ -34,7 +34,8 @@ export function RecentCaptures() {
           areaId: Id<"areas">;
           description?: string;
         }
-      | { type: "add_to_project"; projectId: Id<"projects"> },
+      | { type: "add_to_project"; projectId: Id<"projects"> }
+      | { type: "set_next_action"; projectId: Id<"projects"> },
   ) => {
     await processCapture({ id: captureId, action });
     setProcessingCapture(undefined);

--- a/apps/web/src/routes/_authenticated/inbox.tsx
+++ b/apps/web/src/routes/_authenticated/inbox.tsx
@@ -38,7 +38,8 @@ function InboxPage() {
           areaId: Id<"areas">;
           description?: string;
         }
-      | { type: "add_to_project"; projectId: Id<"projects"> },
+      | { type: "add_to_project"; projectId: Id<"projects"> }
+      | { type: "set_next_action"; projectId: Id<"projects"> },
   ) => {
     await processCapture({ id: captureId, action });
     setProcessingCapture(undefined);


### PR DESCRIPTION
## Summary
- Add "Set next action" tab to the process capture dialog, allowing users to set capture text as a project's next action
- Add `set_next_action` action type to the `captures.process` mutation with automatic `next_action_change` log generation
- Update action types in inbox and dashboard capture handlers

## Test plan
- [ ] Open inbox, click process on a capture
- [ ] Switch to "Set next action" tab, select a project, submit
- [ ] Verify the project's next action is updated to the capture text
- [ ] Verify a `next_action_change` log entry appears in the project timeline
- [ ] Verify the capture is removed from the inbox
- [ ] Verify "New project" and "Add to project" tabs still work as before

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)