### PR TITLE
feat(projects): replace TagInput with kibo-ui Tags

### DIFF
--- a/apps/web/components.json
+++ b/apps/web/components.json
@@ -18,6 +18,5 @@
     "ui": "@/components/ui",
     "lib": "@/lib",
     "hooks": "@/hooks"
-  },
-  "registries": {}
+  }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "better-auth": "1.4.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "convex": "^1.31.7",
     "convex-helpers": "^0.1.112",
     "date-fns": "^4.1.0",

--- a/apps/web/src/components/projects/tag-input.tsx
+++ b/apps/web/src/components/projects/tag-input.tsx
@@ -1,14 +1,15 @@
-import { X } from "lucide-react";
-import { useRef, useState } from "react";
-import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
+import { useState } from "react";
 import {
-  Popover,
-  PopoverAnchor,
-  PopoverContent,
-} from "@/components/ui/popover";
-
-const PROBLEM_TYPE_TAGS = ["clear", "complicated", "complex"];
+  Tags,
+  TagsContent,
+  TagsEmpty,
+  TagsGroup,
+  TagsInput,
+  TagsItem,
+  TagsList,
+  TagsTrigger,
+  TagsValue,
+} from "@/components/ui/tags";
 
 export function TagInput({
   tags,
@@ -21,124 +22,67 @@ export function TagInput({
   onAdd: (tag: string) => void;
   onRemove: (tag: string) => void;
 }) {
-  const [input, setInput] = useState("");
-  const [open, setOpen] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const [search, setSearch] = useState("");
 
-  const normalized = input.trim().toLowerCase();
+  const available = suggestions.filter((s) => !tags.includes(s));
 
-  // Merge suggestions with problem-type tags, excluding already-added tags
-  const allSuggestions = [
-    ...new Set([...suggestions, ...PROBLEM_TYPE_TAGS]),
-  ].filter((s) => !tags.includes(s));
-
-  const filtered = normalized
-    ? allSuggestions.filter((s) => s.includes(normalized))
-    : allSuggestions;
-
-  const handleAdd = (tag: string) => {
-    const t = tag.trim().toLowerCase();
-    if (!t || tags.includes(t)) return;
-    onAdd(t);
-    setInput("");
-    setOpen(false);
-    inputRef.current?.focus();
+  const handleSelect = (tag: string) => {
+    const normalized = tag.trim().toLowerCase();
+    if (!normalized || tags.includes(normalized)) return;
+    onAdd(normalized);
+    setSearch("");
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      if (normalized) handleAdd(normalized);
-    }
-    if (e.key === "Escape") {
-      setOpen(false);
-    }
-  };
+  const trimmed = search.trim().toLowerCase();
+  const canCreate =
+    trimmed && !tags.includes(trimmed) && !available.some((s) => s === trimmed);
 
   return (
-    <div className="space-y-1.5">
-      {tags.length > 0 && (
-        <div className="flex flex-wrap gap-1">
-          {tags.map((tag) => (
-            <Badge
-              key={tag}
-              variant="secondary"
-              className="gap-0.5 pr-1 text-xs"
-            >
-              {tag}
-              <button
-                type="button"
-                onClick={() => onRemove(tag)}
-                className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-muted-foreground/20"
+    <Tags>
+      <TagsTrigger
+        variant="ghost"
+        className="h-auto min-h-7 w-full justify-start gap-1 rounded-md border-none bg-transparent px-1 py-0.5 shadow-none hover:bg-surface-2"
+        placeholder="Add a tag..."
+      >
+        {tags.map((tag) => (
+          <TagsValue
+            key={tag}
+            variant="secondary"
+            className="gap-0.5 pr-1 text-xs"
+            onRemove={() => onRemove(tag)}
+          >
+            {tag}
+          </TagsValue>
+        ))}
+      </TagsTrigger>
+      <TagsContent align="start" className="w-56">
+        <TagsInput
+          placeholder="Search tags..."
+          value={search}
+          onValueChange={setSearch}
+        />
+        <TagsList>
+          <TagsEmpty>
+            {trimmed ? "No matching tags." : "No tags yet."}
+          </TagsEmpty>
+          <TagsGroup>
+            {available.map((suggestion) => (
+              <TagsItem
+                key={suggestion}
+                value={suggestion}
+                onSelect={() => handleSelect(suggestion)}
               >
-                <X className="h-2.5 w-2.5" />
-              </button>
-            </Badge>
-          ))}
-        </div>
-      )}
-      <Popover open={open && filtered.length > 0} onOpenChange={setOpen}>
-        <PopoverAnchor asChild>
-          <Input
-            ref={inputRef}
-            value={input}
-            onChange={(e) => {
-              setInput(e.target.value);
-              if (e.target.value.trim()) {
-                setOpen(true);
-              }
-            }}
-            onFocus={() => {
-              if (input.trim() || allSuggestions.length > 0) {
-                setOpen(true);
-              }
-            }}
-            onBlur={(e) => {
-              // Close unless focus moved into the popover
-              const related = e.relatedTarget as Node | null;
-              if (
-                related &&
-                e.currentTarget
-                  .closest("[data-slot='popover']")
-                  ?.contains(related)
-              ) {
-                return;
-              }
-              setTimeout(() => setOpen(false), 150);
-            }}
-            onKeyDown={handleKeyDown}
-            placeholder="Add a tag..."
-            className="h-7 text-xs"
-          />
-        </PopoverAnchor>
-        <PopoverContent
-          className="w-48 p-1"
-          align="start"
-          onOpenAutoFocus={(e) => e.preventDefault()}
-          onCloseAutoFocus={(e) => e.preventDefault()}
-          onInteractOutside={(e) => {
-            if (inputRef.current?.contains(e.target as Node)) {
-              e.preventDefault();
-            }
-          }}
-        >
-          {filtered.map((suggestion) => (
-            <button
-              key={suggestion}
-              type="button"
-              onClick={() => handleAdd(suggestion)}
-              className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-surface-3"
-            >
-              <span>{suggestion}</span>
-              {PROBLEM_TYPE_TAGS.includes(suggestion) && (
-                <span className="text-[10px] text-muted-foreground">
-                  cynefin
-                </span>
-              )}
-            </button>
-          ))}
-        </PopoverContent>
-      </Popover>
-    </div>
+                {suggestion}
+              </TagsItem>
+            ))}
+            {canCreate && (
+              <TagsItem value={trimmed} onSelect={() => handleSelect(trimmed)}>
+                Create &ldquo;{trimmed}&rdquo;
+              </TagsItem>
+            )}
+          </TagsGroup>
+        </TagsList>
+      </TagsContent>
+    </Tags>
   );
 }

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -1,0 +1,181 @@
+import { Command as CommandPrimitive } from "cmdk";
+import { SearchIcon } from "lucide-react";
+import type * as React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string;
+  description?: string;
+  className?: string;
+  showCloseButton?: boolean;
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("bg-border -mx-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+};

--- a/apps/web/src/components/ui/tags.tsx
+++ b/apps/web/src/components/ui/tags.tsx
@@ -1,0 +1,223 @@
+import { XIcon } from "lucide-react";
+import {
+  type ComponentProps,
+  createContext,
+  type MouseEventHandler,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+type TagsContextType = {
+  value?: string;
+  setValue?: (value: string) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  width?: number;
+  setWidth?: (width: number) => void;
+};
+
+const TagsContext = createContext<TagsContextType>({
+  value: undefined,
+  setValue: undefined,
+  open: false,
+  onOpenChange: () => {},
+  width: undefined,
+  setWidth: undefined,
+});
+
+const useTagsContext = () => {
+  const context = useContext(TagsContext);
+
+  if (!context) {
+    throw new Error("useTagsContext must be used within a TagsProvider");
+  }
+
+  return context;
+};
+
+export type TagsProps = {
+  value?: string;
+  setValue?: (value: string) => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children?: ReactNode;
+  className?: string;
+};
+
+export const Tags = ({
+  value,
+  setValue,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
+  children,
+  className,
+}: TagsProps) => {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const [width, setWidth] = useState<number>();
+  const ref = useRef<HTMLDivElement>(null);
+
+  const open = controlledOpen ?? uncontrolledOpen;
+  const onOpenChange = controlledOnOpenChange ?? setUncontrolledOpen;
+
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      setWidth(entries[0].contentRect.width);
+    });
+
+    resizeObserver.observe(ref.current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  return (
+    <TagsContext.Provider
+      value={{ value, setValue, open, onOpenChange, width, setWidth }}
+    >
+      <Popover onOpenChange={onOpenChange} open={open}>
+        <div className={cn("relative w-full", className)} ref={ref}>
+          {children}
+        </div>
+      </Popover>
+    </TagsContext.Provider>
+  );
+};
+
+export type TagsTriggerProps = ComponentProps<typeof Button> & {
+  placeholder?: string;
+};
+
+export const TagsTrigger = ({
+  className,
+  children,
+  placeholder = "Select a tag...",
+  ...props
+}: TagsTriggerProps) => (
+  <PopoverTrigger asChild>
+    <Button
+      className={cn("h-auto w-full justify-between p-2", className)}
+      role="combobox"
+      variant="outline"
+      {...props}
+    >
+      <div className="flex flex-wrap items-center gap-1">
+        {children}
+        {placeholder && (
+          <span className="px-2 py-px text-muted-foreground">
+            {placeholder}
+          </span>
+        )}
+      </div>
+    </Button>
+  </PopoverTrigger>
+);
+
+export type TagsValueProps = ComponentProps<typeof Badge>;
+
+export const TagsValue = ({
+  className,
+  children,
+  onRemove,
+  ...props
+}: TagsValueProps & { onRemove?: () => void }) => {
+  const handleRemove: MouseEventHandler<HTMLDivElement> = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onRemove?.();
+  };
+
+  return (
+    <Badge className={cn("flex items-center gap-2", className)} {...props}>
+      {children}
+      {onRemove && (
+        // biome-ignore lint/a11y/noStaticElementInteractions: "This is a clickable badge"
+        // biome-ignore lint/a11y/useKeyWithClickEvents: "This is a clickable badge"
+        <div
+          className="size-auto cursor-pointer hover:text-muted-foreground"
+          onClick={handleRemove}
+        >
+          <XIcon size={12} />
+        </div>
+      )}
+    </Badge>
+  );
+};
+
+export type TagsContentProps = ComponentProps<typeof PopoverContent>;
+
+export const TagsContent = ({
+  className,
+  children,
+  ...props
+}: TagsContentProps) => {
+  const { width } = useTagsContext();
+
+  return (
+    <PopoverContent
+      className={cn("p-0", className)}
+      style={{ width }}
+      {...props}
+    >
+      <Command>{children}</Command>
+    </PopoverContent>
+  );
+};
+
+export type TagsInputProps = ComponentProps<typeof CommandInput>;
+
+export const TagsInput = ({ className, ...props }: TagsInputProps) => (
+  <CommandInput className={cn("h-9", className)} {...props} />
+);
+
+export type TagsListProps = ComponentProps<typeof CommandList>;
+
+export const TagsList = ({ className, ...props }: TagsListProps) => (
+  <CommandList className={cn("max-h-[200px]", className)} {...props} />
+);
+
+export type TagsEmptyProps = ComponentProps<typeof CommandEmpty>;
+
+export const TagsEmpty = ({
+  children,
+  className,
+  ...props
+}: TagsEmptyProps) => (
+  <CommandEmpty {...props}>{children ?? "No tags found."}</CommandEmpty>
+);
+
+export type TagsGroupProps = ComponentProps<typeof CommandGroup>;
+
+export const TagsGroup = CommandGroup;
+
+export type TagsItemProps = ComponentProps<typeof CommandItem>;
+
+export const TagsItem = ({ className, ...props }: TagsItemProps) => (
+  <CommandItem
+    className={cn("cursor-pointer items-center justify-between", className)}
+    {...props}
+  />
+);

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "better-auth": "1.4.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "convex": "^1.31.7",
         "convex-helpers": "^0.1.112",
         "date-fns": "^4.1.0",
@@ -590,6 +591,8 @@
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "common-tags": ["common-tags@1.8.2", "", {}, "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="],
 


### PR DESCRIPTION
## Summary
- Replace hand-rolled Popover+Input tag component with kibo-ui Tags (built on cmdk Command)
- Remove hardcoded cynefin domain tags (clear, complicated, complex)
- Add new `command.tsx` and `tags.tsx` UI components
- Preserve same props interface — no changes needed in parent pages

Closes #110

## Test plan
- [ ] Open a project detail page and verify tags display correctly
- [ ] Click the tag trigger and verify the popover opens with suggestions
- [ ] Search for a tag and verify filtering works
- [ ] Type a new tag name and verify "Create" option appears
- [ ] Add and remove tags, verify optimistic updates work
- [ ] Verify area view project cards still show tags as before
- [ ] Verify keyboard navigation works in the tag popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)