### PR TITLE
style: add border-subtle token and apply to card containers

### DIFF
--- a/apps/web/src/components/areas/area-card.tsx
+++ b/apps/web/src/components/areas/area-card.tsx
@@ -18,7 +18,7 @@ export function AreaCard({
     <Link
       to="/$areaSlug"
       params={{ areaSlug: area.slug ?? area._id }}
-      className="group relative rounded-xl bg-surface-2 p-5 transition-colors hover:bg-surface-3/60"
+      className="group relative rounded-xl border border-border-subtle bg-surface-2 p-5 transition-colors hover:bg-surface-3/60"
     >
       <div className="flex items-center gap-2.5">
         <span

--- a/apps/web/src/components/dashboard/attention-section.tsx
+++ b/apps/web/src/components/dashboard/attention-section.tsx
@@ -34,7 +34,7 @@ export function AttentionSection({ items, areas }: AttentionSectionProps) {
         <h2 className="text-sm font-medium">Needs Attention</h2>
         <span className="text-xs text-muted-foreground">{items.length}</span>
       </div>
-      <div className="divide-y divide-border/50 rounded-xl bg-surface-2">
+      <div className="divide-y divide-border/50 rounded-xl border border-border-subtle bg-surface-2">
         {items.map((item) => {
           const area = areaMap.get(item.areaId);
           const areaSlug = area?.slug ?? area?._id ?? item.areaId;

--- a/apps/web/src/components/dashboard/recent-captures.tsx
+++ b/apps/web/src/components/dashboard/recent-captures.tsx
@@ -50,7 +50,7 @@ export function RecentCaptures() {
         <h2 className="text-sm font-medium">Recent Captures</h2>
         <span className="text-xs text-muted-foreground">{captures.length}</span>
       </div>
-      <div className="divide-y divide-border/50 rounded-xl bg-surface-2">
+      <div className="divide-y divide-border/50 rounded-xl border border-border-subtle bg-surface-2">
         {visible.map((capture) => (
           <CaptureRow
             key={capture._id}

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border border-border-subtle py-6",
         className,
       )}
       {...props}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -26,6 +26,7 @@
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.93 0 0);
   --border: oklch(0.34 0.006 250);
+  --border-subtle: oklch(0.34 0.006 250 / 0.2);
   --input: var(--surface-3);
   --ring: oklch(0.7 0.17 155);
   --chart-1: oklch(0.7 0.17 155);
@@ -88,6 +89,7 @@
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
   --color-border: var(--border);
+  --color-border-subtle: var(--border-subtle);
   --color-input: var(--input);
   --color-ring: var(--ring);
   --color-chart-1: var(--chart-1);

--- a/apps/web/src/routes/_authenticated/$areaSlug/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/$projectSlug.tsx
@@ -252,7 +252,7 @@ function AreaProjectDetailPage() {
 
       {/* Primary: Status & Next Action */}
       <div className="grid gap-3 sm:grid-cols-2">
-        <div className="rounded-xl bg-surface-2 p-4">
+        <div className="rounded-xl border border-border-subtle bg-surface-2 p-4">
           <div className="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
             <Target className="h-3.5 w-3.5" />
             Status
@@ -265,7 +265,7 @@ function AreaProjectDetailPage() {
           />
         </div>
 
-        <div className="rounded-xl bg-surface-2 p-4">
+        <div className="rounded-xl border border-border-subtle bg-surface-2 p-4">
           <div className="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
             <ArrowRight className="h-3.5 w-3.5" />
             Next Action
@@ -462,7 +462,7 @@ function AreaProjectDetailPage() {
                   <div className="absolute left-0 top-[17px] flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 ring-2 ring-background">
                     <Pen className="h-3 w-3 text-primary" />
                   </div>
-                  <div className="rounded-lg bg-surface-2 px-4 py-3">
+                  <div className="rounded-lg border border-border-subtle bg-surface-2 px-4 py-3">
                     <p className="whitespace-pre-wrap text-sm leading-relaxed">
                       {log.content}
                     </p>
@@ -528,11 +528,11 @@ function ProjectDetailSkeleton() {
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2">
-        <div className="rounded-xl bg-surface-2 p-4">
+        <div className="rounded-xl border border-border-subtle bg-surface-2 p-4">
           <Skeleton className="mb-2 h-3 w-12" />
           <Skeleton className="h-5 w-3/4" />
         </div>
-        <div className="rounded-xl bg-surface-2 p-4">
+        <div className="rounded-xl border border-border-subtle bg-surface-2 p-4">
           <Skeleton className="mb-2 h-3 w-16" />
           <Skeleton className="h-5 w-3/4" />
         </div>

--- a/apps/web/src/routes/_authenticated/$areaSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/index.tsx
@@ -275,7 +275,7 @@ function AreaDetailPage() {
 
       {/* Standard */}
       {area.standard && (
-        <div className="rounded-xl bg-surface-2 p-5">
+        <div className="rounded-xl border border-border-subtle bg-surface-2 p-5">
           <h2 className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
             Standard
           </h2>
@@ -320,7 +320,7 @@ function AreaDetailPage() {
             </Button>
           </div>
         ) : (
-          <div className="divide-y divide-border/50 rounded-xl bg-surface-2">
+          <div className="divide-y divide-border/50 rounded-xl border border-border-subtle bg-surface-2">
             {projects.map((project) => {
               const slug = project.slug ?? project._id;
               return (
@@ -471,7 +471,7 @@ function AreaDetailSkeleton() {
           <Skeleton className="h-6 w-6 rounded-md" />
           <Skeleton className="h-4 w-16" />
         </div>
-        <div className="divide-y divide-border/50 rounded-xl bg-surface-2">
+        <div className="divide-y divide-border/50 rounded-xl border border-border-subtle bg-surface-2">
           {Array.from({ length: 2 }).map((_, i) => (
             <div
               // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id

--- a/apps/web/src/routes/_authenticated/inbox.tsx
+++ b/apps/web/src/routes/_authenticated/inbox.tsx
@@ -60,7 +60,7 @@ function InboxPage() {
           </p>
         </div>
       ) : (
-        <div className="rounded-lg border">
+        <div className="rounded-lg border border-border-subtle">
           {captures.map((capture) => (
             <CaptureRow
               key={capture._id}

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -146,7 +146,7 @@ function DashboardSkeleton() {
             <div
               // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
               key={i}
-              className="rounded-xl bg-surface-2 p-5"
+              className="rounded-xl border border-border-subtle bg-surface-2 p-5"
             >
               <div className="space-y-3">
                 <div className="flex items-center gap-2.5">


### PR DESCRIPTION
## Summary
- Adds a `--border-subtle` design token (`oklch(0.34 0.006 250 / 0.2)`) — a 20% opacity version of `--border` for clean, barely-there container edges
- Registers it as a Tailwind color (`border-border-subtle`) so it's reusable without hardcoding opacity
- Applies the subtle border to all `bg-surface-2` containers: cards, area cards, section lists, project detail boxes, note bubbles, and skeletons
- Removes the previous `shadow-sm` from Card in favor of the flat border approach

## Test plan
- [ ] Verify area cards, attention section, recent captures, and inbox list all render with a faint border
- [ ] Verify project detail status/next-action boxes and activity note bubbles have the subtle border
- [ ] Verify Card component (used in auth pages) renders correctly
- [ ] Confirm no visual regressions on skeleton loading states