### PR TITLE
fix(dashboard): remove review cadence logic and nextReviewDate field

### DIFF
--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as lib_patch from "../lib/patch.js";
 import type * as lib_slugs from "../lib/slugs.js";
 import type * as lib_types from "../lib/types.js";
 import type * as lib_validation from "../lib/validation.js";
+import type * as migrations from "../migrations.js";
 import type * as projectLogs from "../projectLogs.js";
 import type * as projects from "../projects.js";
 
@@ -38,6 +39,7 @@ declare const fullApi: ApiFromModules<{
   "lib/slugs": typeof lib_slugs;
   "lib/types": typeof lib_types;
   "lib/validation": typeof lib_validation;
+  migrations: typeof migrations;
   projectLogs: typeof projectLogs;
   projects: typeof projects;
 }>;

--- a/apps/web/convex/migrations.ts
+++ b/apps/web/convex/migrations.ts
@@ -1,0 +1,35 @@
+import { internalMutation } from "./_generated/server";
+
+/**
+ * One-off migration: remove the deprecated `nextReviewDate` field from all
+ * project documents so the field can be dropped from the schema.
+ *
+ * Run via dashboard or CLI:
+ *   npx convex run migrations:removeNextReviewDate
+ *
+ * After confirming all documents are clean, remove `nextReviewDate` from
+ * schema.ts and delete this file.
+ */
+export const removeNextReviewDate = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const projects = await ctx.db.query("projects").collect();
+    let updated = 0;
+
+    for (const project of projects) {
+      if ("nextReviewDate" in project) {
+        const { nextReviewDate: _, ...rest } = project as Record<
+          string,
+          unknown
+        >;
+        await ctx.db.replace(
+          project._id,
+          rest as Record<string, unknown> as typeof project,
+        );
+        updated++;
+      }
+    }
+
+    return { updated, total: projects.length };
+  },
+});

--- a/apps/web/convex/projects.ts
+++ b/apps/web/convex/projects.ts
@@ -93,7 +93,6 @@ export const update = mutation({
     areaId: v.optional(v.id("areas")),
     status: v.optional(v.union(v.string(), v.null())),
     nextAction: v.optional(v.union(v.string(), v.null())),
-    nextReviewDate: v.optional(v.union(v.number(), v.null())),
     state: v.optional(
       v.union(
         v.literal("active"),

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -33,6 +33,7 @@ export default defineSchema({
     ),
     status: v.optional(v.string()),
     nextAction: v.optional(v.string()),
+    // Deprecated — being removed, kept temporarily for migration
     nextReviewDate: v.optional(v.number()),
     // Phase 2 fields
     actionDate: v.optional(v.number()),

--- a/apps/web/src/components/dashboard/attention-section.tsx
+++ b/apps/web/src/components/dashboard/attention-section.tsx
@@ -1,6 +1,5 @@
 import type { Doc } from "@convex/_generated/dataModel";
 import { Link } from "@tanstack/react-router";
-import { formatDistanceToNow } from "date-fns";
 import { AlertTriangle, CircleAlert } from "lucide-react";
 import { useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -10,8 +9,7 @@ interface AttentionItem {
   projectName: string;
   projectSlug: string | undefined;
   areaId: string;
-  reason: "no_next_action" | "review_overdue";
-  overdueBy?: number;
+  reason: "no_next_action";
 }
 
 interface AttentionSectionProps {
@@ -57,26 +55,13 @@ export function AttentionSection({ items, areas }: AttentionSectionProps) {
                   </p>
                 )}
               </div>
-              {item.reason === "no_next_action" ? (
-                <Badge
-                  variant="outline"
-                  className="shrink-0 gap-1 border-amber-500/25 bg-amber-500/10 text-[10px] text-amber-500"
-                >
-                  <CircleAlert className="h-3 w-3" />
-                  No next action
-                </Badge>
-              ) : (
-                <Badge
-                  variant="outline"
-                  className="shrink-0 gap-1 border-amber-500/25 bg-amber-500/10 text-[10px] text-amber-500"
-                >
-                  <AlertTriangle className="h-3 w-3" />
-                  Review overdue{" "}
-                  {item.overdueBy
-                    ? formatDistanceToNow(Date.now() - item.overdueBy)
-                    : ""}
-                </Badge>
-              )}
+              <Badge
+                variant="outline"
+                className="shrink-0 gap-1 border-amber-500/25 bg-amber-500/10 text-[10px] text-amber-500"
+              >
+                <CircleAlert className="h-3 w-3" />
+                No next action
+              </Badge>
             </Link>
           );
         })}

--- a/apps/web/src/components/dashboard/review-status.tsx
+++ b/apps/web/src/components/dashboard/review-status.tsx
@@ -2,8 +2,6 @@ import { formatDistanceToNow } from "date-fns";
 import { Check, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
-
 interface ReviewStatusProps {
   lastReviewDate: number | null;
   onMarkReviewed: () => void;
@@ -13,18 +11,8 @@ export function ReviewStatus({
   lastReviewDate,
   onMarkReviewed,
 }: ReviewStatusProps) {
-  const isOverdue =
-    !lastReviewDate || Date.now() - lastReviewDate >= SEVEN_DAYS_MS;
-
   return (
     <div className="flex items-center gap-3 text-sm text-muted-foreground">
-      <span
-        className={`inline-flex h-1.5 w-1.5 rounded-full ${
-          isOverdue ? "bg-amber-500" : "bg-green-500"
-        }`}
-        role="img"
-        aria-label={isOverdue ? "Review overdue" : "Up to date"}
-      />
       <Clock className="h-3.5 w-3.5" />
       <span>
         {lastReviewDate

--- a/apps/web/src/routes/_authenticated/$areaSlug/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/$projectSlug.tsx
@@ -7,7 +7,6 @@ import { useQuery } from "convex-helpers/react/cache/hooks";
 import { formatDistanceToNow } from "date-fns";
 import {
   ArrowRight,
-  Calendar,
   CheckCircle2,
   ChevronRight,
   MessageSquare,
@@ -32,7 +31,6 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { DatePicker } from "@/components/ui/date-picker";
 import { EditableField } from "@/components/ui/editable-field";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
@@ -205,13 +203,6 @@ function AreaProjectDetailPage() {
     });
   };
 
-  const handleReviewDateChange = (date: Date | undefined) => {
-    updateProject({
-      id: project._id,
-      nextReviewDate: date ? date.getTime() : null,
-    });
-  };
-
   const handleStateChange = (state: "completed" | "dropped") => {
     updateProject({ id: project._id, state });
     navigate({ to: "/$areaSlug", params: { areaSlug } });
@@ -287,21 +278,6 @@ function AreaProjectDetailPage() {
             suggestions={allTags}
             onAdd={(tag) => addTag({ id: project._id, tag })}
             onRemove={(tag) => removeTagMutation({ id: project._id, tag })}
-          />
-        </MetadataRow>
-
-        <MetadataRow
-          icon={<Calendar className="h-3.5 w-3.5" />}
-          label="Review Date"
-        >
-          <DatePicker
-            value={
-              project.nextReviewDate
-                ? new Date(project.nextReviewDate)
-                : undefined
-            }
-            onChange={handleReviewDateChange}
-            placeholder="Set review date..."
           />
         </MetadataRow>
 

--- a/apps/web/src/routes/_authenticated/$areaSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/index.tsx
@@ -6,10 +6,8 @@ import { healthColors } from "@convex/lib/types";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
 import { useQuery } from "convex-helpers/react/cache/hooks";
-import { format } from "date-fns";
 import {
   ArrowRight,
-  Calendar,
   ChevronRight,
   FolderOpen,
   Pencil,
@@ -369,12 +367,6 @@ function AreaDetailPage() {
                         </p>
                       )}
                     </div>
-                    {project.nextReviewDate && (
-                      <span className="flex shrink-0 items-center gap-1 pt-0.5 text-xs text-muted-foreground">
-                        <Calendar className="h-3 w-3" />
-                        {format(new Date(project.nextReviewDate), "MMM d")}
-                      </span>
-                    )}
                   </Link>
                   <AlertDialog>
                     <AlertDialogTrigger asChild>

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -10,7 +10,6 @@ import { AreaCard } from "@/components/areas/area-card";
 import { AreaFormDialog } from "@/components/areas/area-form-dialog";
 import { AttentionSection } from "@/components/dashboard/attention-section";
 import { RecentCaptures } from "@/components/dashboard/recent-captures";
-import { ReviewStatus } from "@/components/dashboard/review-status";
 import { RouteErrorFallback } from "@/components/error-boundary";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -27,7 +26,6 @@ function Dashboard() {
   const projects = useQuery(api.projects.list);
   const areas = useQuery(api.areas.list);
   const attention = useQuery(api.dashboard.attention);
-  const lastReviewDate = useQuery(api.dashboard.lastReview);
   const createArea = useMutation(api.areas.create).withOptimisticUpdate(
     (localStore, args) => {
       const current = localStore.getQuery(api.areas.list, {});
@@ -50,7 +48,6 @@ function Dashboard() {
       }
     },
   );
-  const markReviewed = useMutation(api.dashboard.markReviewed);
   const [showCreateArea, setShowCreateArea] = useState(false);
   const isLoading = areas === undefined;
 
@@ -60,13 +57,7 @@ function Dashboard() {
 
   return (
     <div className="mx-auto max-w-4xl space-y-10">
-      <div className="space-y-1">
-        <h1 className="text-lg font-medium tracking-tight">Dashboard</h1>
-        <ReviewStatus
-          lastReviewDate={lastReviewDate ?? null}
-          onMarkReviewed={() => markReviewed()}
-        />
-      </div>
+      <h1 className="text-lg font-medium tracking-tight">Dashboard</h1>
 
       <section>
         <div className="mb-4 flex items-center justify-between">
@@ -134,10 +125,7 @@ function Dashboard() {
 function DashboardSkeleton() {
   return (
     <div className="mx-auto max-w-4xl space-y-10">
-      <div className="space-y-1">
-        <Skeleton className="h-6 w-28" />
-        <Skeleton className="h-4 w-48" />
-      </div>
+      <Skeleton className="h-6 w-28" />
 
       <div>
         <Skeleton className="mb-4 h-4 w-12" />


### PR DESCRIPTION
## Summary

- Remove the `nextReviewDate` field from all UI, backend queries/mutations, and attention logic — it was an invented concept not in the planning doc
- Replace the 7-day cadence review status indicator (green/amber dot) with neutral text, then remove the entire ReviewStatus component from the dashboard since it serves no purpose without the guided review flow
- Simplify the attention query to only flag projects with no next action defined
- Add a one-off migration to strip `nextReviewDate` from existing project documents

## Deployment steps

1. Deploy this PR (schema still includes `nextReviewDate` as optional so existing docs pass validation)
2. Run `migrations:removeNextReviewDate` from the Convex dashboard to clean up existing documents
3. Follow-up PR: remove `nextReviewDate` from schema and delete the migration file

## Test plan

- [ ] Attention section only shows "No next action" items (no more "Review overdue" badges)
- [ ] Dashboard no longer shows the review status indicator or mark reviewed button
- [ ] Project detail page no longer shows the Review Date picker
- [ ] Area project list no longer shows review dates
- [ ] `bun run lint` and `bun run build` pass

Closes #117