### PR TITLE
feat(items): add inline item editing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ If tests exist for the affected code, also run `bun run test:run`.
 
 All commands use **bun** (not npm/yarn/pnpm). Run from the **repo root**:
 
+Do **not** run the dev server, Convex dev, or Convex generation unless the user explicitly asks. Assume the user is already running Vite and Convex locally. If those are needed, remind the user to run them: Vite dev generates the route tree, and Convex dev uploads functions and schema to Convex.
+
 ```bash
 bun run dev          # Start all dev servers via turbo
 bun run build        # Type-check + build all apps via turbo

--- a/apps/web/convex/items.ts
+++ b/apps/web/convex/items.ts
@@ -67,6 +67,34 @@ export const remove = mutation({
   },
 });
 
+export const updateText = mutation({
+  args: { id: v.id("items"), text: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+
+    const item = await ctx.db.get(args.id);
+    if (!item || item.userId !== userId) {
+      throw new Error("Item not found");
+    }
+
+    await ctx.db.patch(args.id, { text: args.text });
+  },
+});
+
+export const updateDate = mutation({
+  args: { id: v.id("items"), date: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+
+    const item = await ctx.db.get(args.id);
+    if (!item || item.userId !== userId) {
+      throw new Error("Item not found");
+    }
+
+    await ctx.db.patch(args.id, { date: args.date });
+  },
+});
+
 export const complete = mutation({
   args: { id: v.id("items") },
   handler: async (ctx, args) => {

--- a/apps/web/src/features/items/item-row/item-row-container.tsx
+++ b/apps/web/src/features/items/item-row/item-row-container.tsx
@@ -2,6 +2,8 @@ import type { Doc } from "@convex/_generated/dataModel";
 import { useCompleteItem } from "@/features/items/use-complete-item";
 import { useRemoveItem } from "@/features/items/use-remove-item";
 import { useUncompleteItem } from "@/features/items/use-uncomplete-item";
+import { useUpdateItemDate } from "@/features/items/use-update-item-date";
+import { useUpdateItemText } from "@/features/items/use-update-item-text";
 import { ItemRow } from "./item-row";
 
 interface ItemRowProps {
@@ -13,6 +15,8 @@ export function ItemRowContainer({ item, onProcess }: ItemRowProps) {
   const completeItem = useCompleteItem();
   const uncompleteItem = useUncompleteItem();
   const removeItem = useRemoveItem();
+  const updateItemText = useUpdateItemText();
+  const updateItemDate = useUpdateItemDate();
 
   return (
     <ItemRow
@@ -21,6 +25,8 @@ export function ItemRowContainer({ item, onProcess }: ItemRowProps) {
         item.isCompleted ? uncompleteItem(item._id) : completeItem(item._id)
       }
       onRemove={() => removeItem(item._id)}
+      onUpdateText={(text) => updateItemText(item._id, text)}
+      onUpdateDate={(date) => updateItemDate(item._id, date)}
       onProcess={onProcess ? () => onProcess(item) : undefined}
     />
   );

--- a/apps/web/src/features/items/item-row/item-row.tsx
+++ b/apps/web/src/features/items/item-row/item-row.tsx
@@ -11,7 +11,9 @@ import {
   AlertDialogTrigger,
 } from "@vita-os/ui/components/alert-dialog";
 import { Button } from "@vita-os/ui/components/button";
+import { Calendar } from "@vita-os/ui/components/calendar";
 import { Checkbox } from "@vita-os/ui/components/checkbox";
+import { Input } from "@vita-os/ui/components/input";
 import {
   Item,
   ItemActions,
@@ -19,13 +21,21 @@ import {
   ItemDescription,
   ItemMedia,
 } from "@vita-os/ui/components/item";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@vita-os/ui/components/popover";
 import { format, formatDistanceToNow } from "date-fns";
 import { ArrowRight, CalendarIcon, Trash2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 interface ItemRowProps {
   item: Doc<"items">;
   onToggleComplete: () => void;
   onRemove: () => void;
+  onUpdateText: (text: string) => void;
+  onUpdateDate: (date: number | undefined) => void;
   onProcess?: () => void;
 }
 
@@ -33,8 +43,28 @@ export function ItemRow({
   item,
   onToggleComplete,
   onRemove,
+  onUpdateText,
+  onUpdateDate,
   onProcess,
 }: ItemRowProps) {
+  const [isEditingText, setIsEditingText] = useState(false);
+  const [draftText, setDraftText] = useState(item.text);
+  const [isDateOpen, setIsDateOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isEditingText) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditingText]);
+
+  useEffect(() => {
+    if (!isEditingText) {
+      setDraftText(item.text);
+    }
+  }, [isEditingText, item.text]);
+
   const timestamp = item.isCompleted
     ? `Completed ${formatDistanceToNow(
         new Date(item.completedAt ?? item.createdAt),
@@ -45,6 +75,23 @@ export function ItemRow({
     : formatDistanceToNow(new Date(item.createdAt), {
         addSuffix: true,
       });
+  const itemDate = item.date === undefined ? undefined : new Date(item.date);
+
+  const saveText = () => {
+    const nextText = draftText.trim();
+    setIsEditingText(false);
+
+    if (nextText && nextText !== item.text) {
+      onUpdateText(nextText);
+    } else {
+      setDraftText(item.text);
+    }
+  };
+
+  const cancelTextEdit = () => {
+    setDraftText(item.text);
+    setIsEditingText(false);
+  };
 
   return (
     <Item size="sm" className="items-start gap-3 hover:bg-accent/50">
@@ -57,15 +104,37 @@ export function ItemRow({
       </ItemMedia>
       <ItemContent className="min-w-0 gap-1.5">
         <div className="flex min-w-0 items-start gap-2">
-          <p
-            className={
-              item.isCompleted
-                ? "min-w-0 flex-1 whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground/60 line-through decoration-muted-foreground/30"
-                : "min-w-0 flex-1 whitespace-pre-wrap text-sm leading-relaxed"
-            }
-          >
-            {item.text}
-          </p>
+          {isEditingText ? (
+            <Input
+              ref={inputRef}
+              value={draftText}
+              onChange={(event) => setDraftText(event.target.value)}
+              onBlur={saveText}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  saveText();
+                } else if (event.key === "Escape") {
+                  event.preventDefault();
+                  cancelTextEdit();
+                }
+              }}
+              aria-label="Edit item text"
+              className="h-7 min-w-0 flex-1 rounded-md px-2 text-sm"
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setIsEditingText(true)}
+              className={
+                item.isCompleted
+                  ? "min-w-0 flex-1 whitespace-pre-wrap text-left text-sm leading-relaxed text-muted-foreground/60 line-through decoration-muted-foreground/30 outline-none hover:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring/30"
+                  : "min-w-0 flex-1 whitespace-pre-wrap text-left text-sm leading-relaxed outline-none hover:text-foreground/80 focus-visible:ring-2 focus-visible:ring-ring/30"
+              }
+            >
+              {item.text}
+            </button>
+          )}
           <ItemActions className="shrink-0 opacity-0 transition-opacity group-hover/item:opacity-100">
             {onProcess && !item.isCompleted && (
               <Button
@@ -113,12 +182,51 @@ export function ItemRow({
           </ItemActions>
         </div>
         <ItemDescription className="flex items-center gap-2 text-[11px]">
-          {item.date && (
-            <span className="inline-flex items-center gap-1 rounded-md border border-primary/20 bg-primary/5 px-1.5 py-0.5 text-primary/80">
+          <Popover open={isDateOpen} onOpenChange={setIsDateOpen}>
+            <PopoverTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  className={
+                    itemDate
+                      ? "h-6 rounded-md border border-primary/20 bg-primary/5 px-1.5 text-primary/80 hover:bg-primary/10 hover:text-primary"
+                      : "h-6 rounded-md px-1.5 text-muted-foreground/55 hover:text-muted-foreground"
+                  }
+                />
+              }
+            >
               <CalendarIcon className="h-3 w-3" />
-              {format(new Date(item.date), "MMM d, yyyy")}
-            </span>
-          )}
+              {itemDate ? format(itemDate, "MMM d, yyyy") : "Add date"}
+            </PopoverTrigger>
+            <PopoverContent className="w-auto gap-0 p-0" align="start">
+              <Calendar
+                mode="single"
+                selected={itemDate}
+                onSelect={(date) => {
+                  if (!date) return;
+                  onUpdateDate(date.getTime());
+                  setIsDateOpen(false);
+                }}
+              />
+              {itemDate && (
+                <div className="border-t border-border/60 p-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="w-full justify-start text-muted-foreground"
+                    onClick={() => {
+                      onUpdateDate(undefined);
+                      setIsDateOpen(false);
+                    }}
+                  >
+                    Clear
+                  </Button>
+                </div>
+              )}
+            </PopoverContent>
+          </Popover>
           <span className="text-muted-foreground/60">{timestamp}</span>
         </ItemDescription>
       </ItemContent>

--- a/apps/web/src/features/items/optimistic.test.ts
+++ b/apps/web/src/features/items/optimistic.test.ts
@@ -5,6 +5,8 @@ import {
   isUnprocessedItem,
   removeItemFromInbox,
   uncompleteItemInInbox,
+  updateItemDateInInbox,
+  updateItemTextInInbox,
 } from "./optimistic";
 
 function makeItem(overrides: Partial<Doc<"items">> = {}): Doc<"items"> {
@@ -78,6 +80,32 @@ describe("Item optimistic updates", () => {
 
     expect(removeItemFromInbox([removing, keeping], removing._id)).toEqual([
       keeping,
+    ]);
+  });
+
+  it("updates an Item's text in the Inbox", () => {
+    const updating = makeItem({ _id: "updating" as Id<"items"> });
+    const unchanged = makeItem({ _id: "unchanged" as Id<"items"> });
+
+    expect(
+      updateItemTextInInbox([updating, unchanged], updating._id, "Book labs"),
+    ).toEqual([{ ...updating, text: "Book labs" }, unchanged]);
+  });
+
+  it("updates or clears an Item's date in the Inbox", () => {
+    const updating = makeItem({ _id: "updating" as Id<"items"> });
+    const unchanged = makeItem({ _id: "unchanged" as Id<"items"> });
+
+    const dated = updateItemDateInInbox(
+      [updating, unchanged],
+      updating._id,
+      1000,
+    );
+
+    expect(dated).toEqual([{ ...updating, date: 1000 }, unchanged]);
+    expect(updateItemDateInInbox(dated, updating._id, undefined)).toEqual([
+      { ...updating, date: undefined },
+      unchanged,
     ]);
   });
 

--- a/apps/web/src/features/items/optimistic.ts
+++ b/apps/web/src/features/items/optimistic.ts
@@ -1,5 +1,5 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
-import { removeById } from "@/features/shared/optimistic";
+import { patchById, removeById } from "@/features/shared/optimistic";
 
 type Item = Doc<"items">;
 
@@ -45,6 +45,22 @@ export function removeItemFromInbox<T extends Item>(
   id: Id<"items">,
 ): T[] {
   return removeById(items, id);
+}
+
+export function updateItemTextInInbox<T extends Item>(
+  items: T[],
+  id: Id<"items">,
+  text: string,
+): T[] {
+  return patchById(items, id, { text } as Partial<T>);
+}
+
+export function updateItemDateInInbox<T extends Item>(
+  items: T[],
+  id: Id<"items">,
+  date: number | undefined,
+): T[] {
+  return patchById(items, id, { date } as Partial<T>);
 }
 
 export function isUnprocessedItem(

--- a/apps/web/src/features/items/use-update-item-date.ts
+++ b/apps/web/src/features/items/use-update-item-date.ts
@@ -1,0 +1,37 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { useMutation } from "convex/react";
+import { isUnprocessedItem, updateItemDateInInbox } from "./optimistic";
+
+export function useUpdateItemDate() {
+  const updateItemDate = useMutation(api.items.updateDate).withOptimisticUpdate(
+    (localStore, args) => {
+      const current = localStore.getQuery(api.items.list, {});
+      if (current !== undefined) {
+        localStore.setQuery(
+          api.items.list,
+          {},
+          updateItemDateInInbox(current, args.id, args.date),
+        );
+      }
+
+      const count = localStore.getQuery(api.items.count, {});
+      const item = current?.find((item) => item._id === args.id);
+      if (count === undefined || item === undefined) {
+        return;
+      }
+
+      const wasUnprocessed = isUnprocessedItem(item);
+      const isNowUnprocessed = isUnprocessedItem({ ...item, date: args.date });
+
+      if (wasUnprocessed && !isNowUnprocessed) {
+        localStore.setQuery(api.items.count, {}, Math.max(0, count - 1));
+      } else if (!wasUnprocessed && isNowUnprocessed) {
+        localStore.setQuery(api.items.count, {}, count + 1);
+      }
+    },
+  );
+
+  return (id: Id<"items">, date: number | undefined) =>
+    updateItemDate({ id, date });
+}

--- a/apps/web/src/features/items/use-update-item-text.ts
+++ b/apps/web/src/features/items/use-update-item-text.ts
@@ -1,0 +1,21 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { useMutation } from "convex/react";
+import { updateItemTextInInbox } from "./optimistic";
+
+export function useUpdateItemText() {
+  const updateItemText = useMutation(api.items.updateText).withOptimisticUpdate(
+    (localStore, args) => {
+      const current = localStore.getQuery(api.items.list, {});
+      if (current !== undefined) {
+        localStore.setQuery(
+          api.items.list,
+          {},
+          updateItemTextInInbox(current, args.id, args.text),
+        );
+      }
+    },
+  );
+
+  return (id: Id<"items">, text: string) => updateItemText({ id, text });
+}


### PR DESCRIPTION
## Summary
- Add items.updateText and items.updateDate Convex mutations
- Add inline Item text editing and date picker/clear controls on Item rows
- Add optimistic update hooks/helpers and tests for text/date updates
- Document that agents should not run Vite/Convex dev or Convex generation unless explicitly asked

## Verification
- bunx vitest run src/features/items/optimistic.test.ts
- bun run lint
- bun run build
- bun run test:run

Closes #135