### PR TITLE
feat(dashboard): simplify recent items

### DIFF
--- a/apps/web/convex/dashboard.ts
+++ b/apps/web/convex/dashboard.ts
@@ -51,6 +51,71 @@ export const attention = query({
   },
 });
 
+export const overview = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await safeGetAuthUserId(ctx);
+    if (!userId) return { areas: [], attentionItems: [] };
+
+    const areas = await ctx.db
+      .query("areas")
+      .withIndex("by_user_order", (q) => q.eq("userId", userId))
+      .collect();
+    const activeProjects = await ctx.db
+      .query("projects")
+      .withIndex("by_user_state", (q) =>
+        q.eq("userId", userId).eq("state", "active"),
+      )
+      .collect();
+
+    const projectCounts: Record<string, number> = {};
+    const attentionCounts: Record<string, number> = {};
+    const areaById = new Map(areas.map((area) => [area._id as string, area]));
+    const attentionItems: Array<{
+      projectId: string;
+      projectName: string;
+      projectSlug: string | undefined;
+      areaId: string;
+      reason: "no_next_action";
+    }> = [];
+
+    for (const project of activeProjects) {
+      projectCounts[project.areaId] = (projectCounts[project.areaId] ?? 0) + 1;
+
+      const hasAction = (project.actionQueue?.length ?? 0) > 0;
+      if (!hasAction) {
+        attentionItems.push({
+          projectId: project._id,
+          projectName: project.name,
+          projectSlug: project.slug,
+          areaId: project.areaId,
+          reason: "no_next_action",
+        });
+        attentionCounts[project.areaId] =
+          (attentionCounts[project.areaId] ?? 0) + 1;
+      }
+    }
+
+    return {
+      areas: areas.map((area) => ({
+        area,
+        projectCount: projectCounts[area._id] ?? 0,
+        attentionCount: attentionCounts[area._id] ?? 0,
+      })),
+      attentionItems: attentionItems.map((item) => {
+        const area = areaById.get(item.areaId);
+        return {
+          key: `${item.projectId}-${item.reason}`,
+          projectName: item.projectName,
+          area,
+          areaSlug: area?.slug ?? area?._id ?? item.areaId,
+          projectSlug: item.projectSlug ?? item.projectId,
+        };
+      }),
+    };
+  },
+});
+
 export const lastReview = query({
   args: {},
   handler: async (ctx) => {

--- a/apps/web/src/features/dashboard/components/attention-section.tsx
+++ b/apps/web/src/features/dashboard/components/attention-section.tsx
@@ -1,41 +1,18 @@
-import { api } from "@convex/_generated/api";
 import type { Doc } from "@convex/_generated/dataModel";
-import { useQuery } from "convex-helpers/react/cache/hooks";
-import { useMemo } from "react";
 import { AttentionList } from "./attention-list";
 
 interface AttentionItem {
-  projectId: string;
   projectName: string;
-  projectSlug: string | undefined;
-  areaId: string;
-  reason: "no_next_action";
+  projectSlug: string;
+  area?: Doc<"areas">;
+  areaSlug: string;
+  key: string;
 }
 
-export function AttentionSection() {
-  const attention = useQuery(api.dashboard.attention);
-  const areas = useQuery(api.areas.list);
+interface AttentionSectionProps {
+  items: AttentionItem[];
+}
 
-  const areaMap = useMemo(
-    () => new Map((areas ?? []).map((a: Doc<"areas">) => [a._id as string, a])),
-    [areas],
-  );
-
-  return (
-    <AttentionList
-      items={(attention?.items ?? []).map((item: AttentionItem) => {
-        const area = areaMap.get(item.areaId);
-        const areaSlug = area?.slug ?? area?._id ?? item.areaId;
-        const projectSlug = item.projectSlug ?? item.projectId;
-
-        return {
-          key: `${item.projectId}-${item.reason}`,
-          projectName: item.projectName,
-          area,
-          areaSlug,
-          projectSlug,
-        };
-      })}
-    />
-  );
+export function AttentionSection({ items }: AttentionSectionProps) {
+  return <AttentionList items={items} />;
 }

--- a/apps/web/src/features/dashboard/components/dashboard-areas-section.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-areas-section.tsx
@@ -1,28 +1,20 @@
-import { api } from "@convex/_generated/api";
-import { useQuery } from "convex-helpers/react/cache/hooks";
+import type { Doc } from "@convex/_generated/dataModel";
 import { DashboardAreas } from "./dashboard-areas";
 
+interface DashboardArea {
+  area: Doc<"areas">;
+  projectCount: number;
+  attentionCount: number;
+}
+
 interface DashboardAreasSectionProps {
+  areas: DashboardArea[];
   onCreateArea: () => void;
 }
 
 export function DashboardAreasSection({
+  areas,
   onCreateArea,
 }: DashboardAreasSectionProps) {
-  const areas = useQuery(api.areas.list);
-  const projects = useQuery(api.projects.list);
-  const attention = useQuery(api.dashboard.attention);
-
-  return (
-    <DashboardAreas
-      areas={(areas ?? []).map((area) => ({
-        area,
-        projectCount: (projects ?? []).filter(
-          (project) => project.areaId === area._id,
-        ).length,
-        attentionCount: attention?.byArea?.[area._id] ?? 0,
-      }))}
-      onCreateArea={onCreateArea}
-    />
-  );
+  return <DashboardAreas areas={areas} onCreateArea={onCreateArea} />;
 }

--- a/apps/web/src/features/dashboard/components/recent-items-list.test.tsx
+++ b/apps/web/src/features/dashboard/components/recent-items-list.test.tsx
@@ -1,0 +1,75 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+import { render, screen } from "@testing-library/react";
+import type { ComponentPropsWithoutRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { RecentItemsList } from "./recent-items-list";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    children,
+    ...props
+  }: ComponentPropsWithoutRef<"a"> & {
+    to: string;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+function item(
+  id: string,
+  text: string,
+  createdAt: number,
+  isCompleted = false,
+): Doc<"items"> {
+  return {
+    _id: id as Id<"items">,
+    _creationTime: createdAt,
+    userId: "user1",
+    text,
+    isCompleted,
+    createdAt,
+    completedAt: isCompleted ? createdAt + 1 : undefined,
+  };
+}
+
+describe("RecentItemsList", () => {
+  it("shows at most five recent uncompleted Items as a read-only list", () => {
+    render(
+      <RecentItemsList
+        items={[
+          item("item1", "First active item", 7),
+          item("item2", "Completed item", 6, true),
+          item("item3", "Second active item", 5),
+          item("item4", "Third active item", 4),
+          item("item5", "Fourth active item", 3),
+          item("item6", "Fifth active item", 2),
+          item("item7", "Sixth active item", 1),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("First active item")).toBeInTheDocument();
+    expect(screen.getByText("Fifth active item")).toBeInTheDocument();
+    expect(screen.queryByText("Completed item")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sixth active item")).not.toBeInTheDocument();
+
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /process item/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /discard item/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /add date/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/edit item text/i)).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", { name: /view all items/i }),
+    ).toHaveAttribute("href", "/inbox");
+  });
+});

--- a/apps/web/src/features/dashboard/components/recent-items-list.tsx
+++ b/apps/web/src/features/dashboard/components/recent-items-list.tsx
@@ -1,22 +1,24 @@
 import type { Doc } from "@convex/_generated/dataModel";
 import { Link } from "@tanstack/react-router";
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+} from "@vita-os/ui/components/item";
+import { format, formatDistanceToNow } from "date-fns";
 import { ArrowRight, Inbox } from "lucide-react";
-import { ItemRowContainer } from "@/features/items/item-row/item-row-container";
+
+const MAX_VISIBLE = 5;
 
 interface RecentItemsListProps {
   items: Doc<"items">[];
-  hasMore: boolean;
-  totalCount: number;
-  onProcess: (item: Doc<"items">) => void;
 }
 
-export function RecentItemsList({
-  items,
-  hasMore,
-  totalCount,
-  onProcess,
-}: RecentItemsListProps) {
-  if (totalCount === 0) return null;
+export function RecentItemsList({ items }: RecentItemsListProps) {
+  const activeItems = items.filter((item) => !item.isCompleted);
+  const visibleItems = activeItems.slice(0, MAX_VISIBLE);
+
+  if (activeItems.length === 0) return null;
 
   return (
     <section>
@@ -25,24 +27,50 @@ export function RecentItemsList({
           <Inbox className="h-3.5 w-3.5 text-muted-foreground" />
         </div>
         <h2 className="text-sm font-medium">Recent Items</h2>
-        <span className="text-xs text-muted-foreground">{totalCount}</span>
+        <span className="text-xs text-muted-foreground">
+          {activeItems.length}
+        </span>
       </div>
       <div className="divide-y divide-border/50 rounded-xl border border-border-subtle bg-surface-2">
-        {items.map((item) => (
-          <ItemRowContainer key={item._id} item={item} onProcess={onProcess} />
+        {visibleItems.map((item) => (
+          <RecentItemRow key={item._id} item={item} />
         ))}
       </div>
-      {hasMore && (
-        <div className="mt-3 flex justify-end">
-          <Link
-            to="/inbox"
-            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-          >
-            View all items
-            <ArrowRight className="h-3 w-3" />
-          </Link>
-        </div>
-      )}
+      <div className="mt-3 flex justify-end">
+        <Link
+          to="/inbox"
+          className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          View all items
+          <ArrowRight className="h-3 w-3" />
+        </Link>
+      </div>
     </section>
+  );
+}
+
+function RecentItemRow({ item }: { item: Doc<"items"> }) {
+  const timestamp = formatDistanceToNow(new Date(item.createdAt), {
+    addSuffix: true,
+  });
+  const itemDate = item.date === undefined ? undefined : new Date(item.date);
+
+  return (
+    <Item size="sm" className="items-start gap-3">
+      <ItemContent className="min-w-0 gap-1.5">
+        <div className="min-w-0 whitespace-pre-wrap text-sm leading-relaxed">
+          {item.text}
+        </div>
+        <ItemDescription className="flex items-center gap-2 text-[11px]">
+          {itemDate && (
+            <>
+              <span>{format(itemDate, "MMM d, yyyy")}</span>
+              <span className="text-muted-foreground/40">/</span>
+            </>
+          )}
+          <span className="text-muted-foreground/60">{timestamp}</span>
+        </ItemDescription>
+      </ItemContent>
+    </Item>
   );
 }

--- a/apps/web/src/features/dashboard/components/recent-items.tsx
+++ b/apps/web/src/features/dashboard/components/recent-items.tsx
@@ -1,40 +1,9 @@
 import { api } from "@convex/_generated/api";
-import type { Doc } from "@convex/_generated/dataModel";
 import { useQuery } from "convex-helpers/react/cache/hooks";
-import { useState } from "react";
-import { ProcessItemDialogContainer } from "@/features/items/process-item/process-item-dialog-container";
 import { RecentItemsList } from "./recent-items-list";
-
-const MAX_VISIBLE = 5;
 
 export function RecentItems() {
   const items = useQuery(api.items.list);
 
-  const [processingItem, setProcessingItem] = useState<
-    Doc<"items"> | undefined
-  >(undefined);
-
-  const visible = (items ?? []).slice(0, MAX_VISIBLE);
-  const hasMore = (items?.length ?? 0) > MAX_VISIBLE;
-
-  return (
-    <>
-      <RecentItemsList
-        items={visible}
-        hasMore={hasMore}
-        totalCount={items?.length ?? 0}
-        onProcess={setProcessingItem}
-      />
-
-      {processingItem && (
-        <ProcessItemDialogContainer
-          open={!!processingItem}
-          onOpenChange={(open) => {
-            if (!open) setProcessingItem(undefined);
-          }}
-          item={processingItem}
-        />
-      )}
-    </>
-  );
+  return <RecentItemsList items={items ?? []} />;
 }

--- a/apps/web/src/features/dashboard/screens/dashboard-screen.tsx
+++ b/apps/web/src/features/dashboard/screens/dashboard-screen.tsx
@@ -1,5 +1,4 @@
 import { api } from "@convex/_generated/api";
-import { Skeleton } from "@vita-os/ui/components/skeleton";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useState } from "react";
 import { CreateAreaDialog } from "@/features/areas/area-form/create-area-dialog";
@@ -8,20 +7,19 @@ import { DashboardAreasSection } from "@/features/dashboard/components/dashboard
 import { RecentItems } from "@/features/dashboard/components/recent-items";
 
 export function DashboardScreen() {
-  const areas = useQuery(api.areas.list);
+  const overview = useQuery(api.dashboard.overview);
   const [showCreateArea, setShowCreateArea] = useState(false);
-
-  if (areas === undefined) {
-    return <DashboardSkeleton />;
-  }
 
   return (
     <div className="mx-auto max-w-4xl space-y-10">
       <h1 className="text-lg font-medium tracking-tight">Dashboard</h1>
 
-      <DashboardAreasSection onCreateArea={() => setShowCreateArea(true)} />
+      <DashboardAreasSection
+        areas={overview?.areas ?? []}
+        onCreateArea={() => setShowCreateArea(true)}
+      />
 
-      <AttentionSection />
+      <AttentionSection items={overview?.attentionItems ?? []} />
 
       <RecentItems />
 
@@ -29,35 +27,6 @@ export function DashboardScreen() {
         open={showCreateArea}
         onOpenChange={setShowCreateArea}
       />
-    </div>
-  );
-}
-
-function DashboardSkeleton() {
-  return (
-    <div className="mx-auto max-w-4xl space-y-10">
-      <Skeleton className="h-6 w-28" />
-
-      <div>
-        <Skeleton className="mb-4 h-4 w-12" />
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div
-              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
-              key={i}
-              className="rounded-xl border border-border-subtle bg-surface-2 p-5"
-            >
-              <div className="space-y-3">
-                <div className="flex items-center gap-2.5">
-                  <Skeleton className="h-2.5 w-2.5 rounded-full" />
-                  <Skeleton className="h-4 w-24" />
-                </div>
-                <Skeleton className="h-3 w-16" />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
     </div>
   );
 }

--- a/packages/ui/src/components/input-group.tsx
+++ b/packages/ui/src/components/input-group.tsx
@@ -45,6 +45,8 @@ function InputGroupAddon({
   ...props
 }: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
   return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: Addons are not focusable controls; the click target forwards focus to the input.
+    // biome-ignore lint/a11y/useSemanticElements: Input group addons are layout wrappers and should not imply fieldset semantics.
     <div
       role="group"
       data-slot="input-group-addon"


### PR DESCRIPTION
## Summary
- Simplify Dashboard Recent Items into a read-only list of recent uncompleted Items
- Remove inline item actions and processing dialog wiring from the dashboard
- Move dashboard area/project summary data behind a dashboard overview query
- Add coverage for Recent Items read-only behavior

## Verification
- `TMPDIR=/private/tmp bun run lint`
- `TMPDIR=/private/tmp bun run build`
- `TMPDIR=/private/tmp bun run test:run`

Closes #138