### PR TITLE
feat(inbox): replace Items with Tasks and When

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,49 +1,141 @@
-# VitaOS
+# Vita OS
 
-Personal life-management app. Holds the inventory of life-domains, multi-step efforts, and daily tactical items so the user's brain doesn't have to.
+Personal life-awareness app. Holds the inventory of life domains, open threads, and loose tasks so the user's brain does not have to.
 
 ## Language
 
 **Area**:
-A stable life-domain with no end date (e.g. Family Health, Career). Has a manually-set health status.
+A stable life domain with no end date, such as Family Health, Career, Finances, or Home.
 _Avoid_: Category, tag, label.
 
-**Project**:
-A multi-step effort with a defined end state. Belongs to exactly one **Area**.
-_Avoid_: Goal, initiative, epic.
+**Starter Area**:
+A minimal suggested **Area** offered to help a user begin their life inventory.
+_Avoid_: Template, default category, fixed category.
 
-**Item**:
-A lightweight tactical entry — text + optional date + completed flag. Does **not** belong to an **Area**.
-_Avoid_: Task, todo, ticket. (The product is deliberately not a "task manager".)
+**Condition**:
+The user's manual judgment on an **Area**: `healthy | needs_attention | critical`.
+_Avoid_: Health status, score, rating, traffic light.
+
+**Thread**:
+An ongoing effort, concern, decision, or situation that belongs to exactly one **Area** and may need attention over time.
+_Avoid_: Project, goal, initiative, epic.
+
+**Open Thread**:
+A **Thread** that still matters and may need attention, waiting, judgment, or future review.
+_Avoid_: Active, paused, waiting, monitoring.
+
+**Resolved Thread**:
+A **Thread** that no longer needs attention.
+_Avoid_: Completed, dropped, closed.
+
+**Summary**:
+An optional current-orientation note that explains what a **Thread** is about.
+_Avoid_: Definition of Done, description, brief.
+
+**Next Move**:
+The single next useful action that could move a **Thread** forward.
+_Avoid_: Action queue, subtask list, todo list, checklist.
+
+**Follow-up**:
+A soft resurfacing point on a **Thread** that brings the situation back into awareness around a chosen time.
+_Avoid_: Due date, deadline, reminder.
+
+**Activity Log**:
+The continuity record for a **Thread**, mixing manual notes with meaningful actions, decisions, updates, and automatic changes.
+_Avoid_: Project log, activity feed, audit log, comments.
+
+**Activity Log Entry**:
+A user-facing note, decision, action, reference, or meaningful automatic update in an **Activity Log**.
+_Avoid_: Audit event, comment.
+
+**Task**:
+A lightweight tactical entry in the **Inbox** that can be handled directly or moved into a **Thread**.
+_Avoid_: Item, todo, ticket.
+
+**Open Task**:
+A **Task** that has not been completed.
+_Avoid_: Pending item.
+
+**Done Task**:
+A **Task** that was completed directly from the **Inbox**.
+_Avoid_: Completed item.
+
+**When**:
+A soft attention date on a **Task**.
+_Avoid_: Due date, deadline.
 
 **Inbox**:
-The single view for all **Items**, regardless of date or completion status. Unprocessed items appear first; completed items appear in a collapsible section below.
+The single view for all visible **Tasks**, with **Open Tasks** first and **Done Tasks** in collapsed history.
 _Avoid_: Backlog.
 
-**Action queue**:
-The ordered list of tentative next steps on a **Project**. The first entry is effectively the next action; entries are suggestions, not commitments.
-_Avoid_: Subtask list, todo list, checklist.
-
-**Project log**:
-The append-only timeline on a **Project**. Mixes auto-entries (field changes) with manual entries (note / decision / reference).
-_Avoid_: Activity feed, audit log, comments.
-
-**Health status**:
-The user's manual judgment on an **Area**: `healthy | needs_attention | critical`. Never derived from project counts or activity.
-_Avoid_: Score, rating, traffic light (informally fine; not a domain term).
+**Dashboard**:
+The main awareness surface that groups **Open Threads** by derived attention state and lightly surfaces attention-worthy **Tasks**.
+_Avoid_: Task list, project board, backlog.
 
 ## Relationships
 
-- An **Area** has zero or more **Projects**; a **Project** belongs to exactly one **Area**.
-- An **Item** belongs to no **Area** and no **Project**. (If it deserves an **Area**, it should be a **Project**.)
-- A **Project** has one **Action queue** and one **Project log**.
-- **Processing** an **Item** means assigning it to a **Project**: as a log note, as the new head of the **Action queue**, or by promoting it into a new **Project**. The **Item** is consumed (deleted) in all cases. Adding a date, editing text, completing, and discarding are *not* processing — they are inline actions on the row.
-- An **Item** that has been processed no longer exists; its text lives on inside the **Project** it was assigned to.
+- An **Area** has zero or more **Threads**; a **Thread** belongs to exactly one **Area**.
+- The app may suggest minimal **Starter Areas**, but users can edit, delete, and reorder **Areas**.
+- An **Area** **Condition** affects the Area's visual prominence, but it does not change a **Thread**'s derived attention state.
+- A **Thread** has zero or one **Summary**, zero or one **Next Move**, zero or one **Follow-up**, and one **Activity Log**.
+- A **Thread** is either **Open** or **Resolved**.
+- A **Thread** may move from one **Area** to another.
+- An **Activity Log** has zero or more **Activity Log Entries**.
+- A **Task** belongs to no **Area** and no **Thread**.
+- **Tasks** are not created inside **Threads**.
+- A visible **Task** is either **Open** or **Done**.
+- A **Task** has zero or one **When**.
+- **Done Tasks** remain available as collapsed **Inbox** history in the MVP.
+- The **Inbox** shows all visible **Tasks**; **When** affects emphasis, not whether the **Task** exists in the Inbox.
 
-## Example dialogue
+## Thread Attention
 
-> **Dev:** "If I drag an **Item** onto a **Project**, does the **Item** end up belonging to the **Project**?"
-> **Builder:** "No. **Items** never belong to **Projects**. Processing it means we copy its text into the **Project log** as a `note` entry, or into the **Action queue** as the new first step — and then the **Item** itself is deleted. The data lives in the **Project**, not the **Item**."
+- The **Dashboard** groups **Open Threads** by derived attention state: follow-up due, scheduled, ready, or open.
+- **Follow-up Due** includes **Open Threads** whose **Follow-up** is today or earlier.
+- If an **Open Thread** has both a due **Follow-up** and a **Next Move**, it appears as **Follow-up Due**.
+- If an **Open Thread** has a future **Follow-up**, it appears as **Scheduled**, even when it also has a **Next Move**.
+- An **Open Thread** with no **Next Move** and no **Follow-up** is valid; it is not automatically overdue, stale, or broken.
+- Opening or reviewing a **Thread** does not clear its **Follow-up**; the user must clear, reschedule, or resolve it explicitly.
 
-> **Dev:** "What about adding a date to an **Item** — is that processing?"
-> **Builder:** "No. Adding a date, editing text, completing, and discarding are all inline actions on the row. Processing specifically means consuming the **Item** into a **Project**."
+## Task Handling
+
+- **Processing** a **Task** means assigning it to a **Thread**: as an **Activity Log** entry, as the **Next Move**, or by promoting it into a new **Thread**.
+- Adding a date, editing text, completing, and discarding are inline actions on a **Task**, not processing.
+- A processed **Task** is consumed; its text lives on inside the **Thread** it was assigned to.
+- Moving a **Task** into a **Thread** requires choosing whether it becomes an **Activity Log** entry or the **Next Move**.
+- Creating a new **Thread** from a **Task** uses a user-provided **Thread** title; the original **Task** text becomes the first **Activity Log** entry by default.
+- Discarding a **Task** consumes it.
+
+## Activity Rules
+
+- Setting, changing, or intentionally clearing a saved **Next Move** adds an **Activity Log** entry.
+- Setting, changing, or intentionally clearing a saved **Follow-up** adds an **Activity Log** entry.
+- Completing a **Next Move** clears it and adds an **Activity Log** entry.
+- Moving a **Thread** between **Areas** adds an **Activity Log** entry.
+- Resolving a **Thread** adds an **Activity Log** entry.
+- Resolving a **Thread** may include an optional resolution note; when present, it becomes an **Activity Log** entry.
+- Resolving a **Thread** clears its current **Next Move** and **Follow-up**.
+- Reopening a **Resolved Thread** makes it an **Open Thread** and adds an **Activity Log** entry.
+- Reopening a **Thread** does not restore old **Follow-ups** automatically.
+- Changing an **Area** **Condition** does not add entries to **Thread** **Activity Logs**.
+
+## Example Dialogue
+
+> **Dev:** "If I move a **Task** into a **Thread**, does the **Task** become part of that **Thread**?"
+> **Builder:** "No. **Tasks** never belong to **Threads**. Moving it means its text becomes either an **Activity Log** entry or the **Next Move**, then the original **Task** is consumed."
+
+> **Dev:** "If a **Thread** has no **Next Move** and no **Follow-up**, is it broken?"
+> **Builder:** "No. A plain **Open Thread** is valid. It means the situation still matters, but there is no clear move or resurfacing date right now."
+
+> **Dev:** "Does a **Follow-up** clear when I open the **Thread**?"
+> **Builder:** "No. Reading the **Thread** is not the same as handling it. The user must clear, reschedule, or resolve it explicitly."
+
+## Flagged Ambiguities
+
+- "Project" was the old term for a multi-step effort with a defined end state. Resolved: **Thread** is canonical because these life situations may not have a clean execution plan or defined finish line.
+- "Item" was the old neutral term for a lightweight Inbox entry. Resolved: **Task** is canonical, but only for the Inbox capture layer.
+- "Action queue" was the old term for ordered tentative next steps. Resolved: **Next Move** is singular so a **Thread** stays directional without becoming a checklist.
+- "Project log" was the old term for the timeline on a **Thread**. Resolved: **Activity Log** is canonical and should capture continuity, not every small edit.
+- "Health status" was the old term for the manual judgment on an **Area**. Resolved: **Condition** is canonical.
+- "Definition of Done" belongs to project-management language and is not a **Thread** concept. Resolved: use **Summary** or the **Activity Log** when context is needed.
+- "Stale Thread" is not part of the MVP domain language. Resolved: use the plain **Open Thread** group until there is a stronger rule.

--- a/apps/web/convex/items.ts
+++ b/apps/web/convex/items.ts
@@ -60,7 +60,7 @@ export const remove = mutation({
 
     const item = await ctx.db.get(args.id);
     if (!item || item.userId !== userId) {
-      throw new Error("Item not found");
+      throw new Error("Task not found");
     }
 
     await ctx.db.delete(args.id);
@@ -74,7 +74,7 @@ export const updateText = mutation({
 
     const item = await ctx.db.get(args.id);
     if (!item || item.userId !== userId) {
-      throw new Error("Item not found");
+      throw new Error("Task not found");
     }
 
     await ctx.db.patch(args.id, { text: args.text });
@@ -88,7 +88,7 @@ export const updateDate = mutation({
 
     const item = await ctx.db.get(args.id);
     if (!item || item.userId !== userId) {
-      throw new Error("Item not found");
+      throw new Error("Task not found");
     }
 
     await ctx.db.patch(args.id, { date: args.date });
@@ -102,7 +102,7 @@ export const complete = mutation({
 
     const item = await ctx.db.get(args.id);
     if (!item || item.userId !== userId) {
-      throw new Error("Item not found");
+      throw new Error("Task not found");
     }
 
     await ctx.db.patch(args.id, {
@@ -119,7 +119,7 @@ export const uncomplete = mutation({
 
     const item = await ctx.db.get(args.id);
     if (!item || item.userId !== userId) {
-      throw new Error("Item not found");
+      throw new Error("Task not found");
     }
 
     await ctx.db.patch(args.id, {
@@ -157,7 +157,7 @@ export const process = mutation({
 
     const item = await ctx.db.get(args.id);
     if (!item || item.userId !== userId) {
-      throw new Error("Item not found");
+      throw new Error("Task not found");
     }
 
     return processInboxItem(ctx, { userId, item, action: args.action });

--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -100,7 +100,7 @@ export function AppSidebar() {
                   className="flex w-full items-center gap-2 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
                 >
                   <CirclePlus className="size-4" />
-                  <span>New item</span>
+                  <span>New task</span>
                   <Kbd className="ml-auto bg-primary-foreground/15 text-primary-foreground/70">
                     Q
                   </Kbd>

--- a/apps/web/src/features/dashboard/components/recent-items-list.test.tsx
+++ b/apps/web/src/features/dashboard/components/recent-items-list.test.tsx
@@ -36,7 +36,7 @@ function item(
 }
 
 describe("RecentItemsList", () => {
-  it("shows at most five recent uncompleted Items as a read-only list", () => {
+  it("shows at most five recent Open Tasks as a read-only list", () => {
     render(
       <RecentItemsList
         items={[
@@ -58,18 +58,18 @@ describe("RecentItemsList", () => {
 
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /process item/i }),
+      screen.queryByRole("button", { name: /process task/i }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /discard item/i }),
+      screen.queryByRole("button", { name: /discard task/i }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /add date/i }),
+      screen.queryByRole("button", { name: /add when/i }),
     ).not.toBeInTheDocument();
-    expect(screen.queryByLabelText(/edit item text/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/edit task text/i)).not.toBeInTheDocument();
 
     expect(
-      screen.getByRole("link", { name: /view all items/i }),
+      screen.getByRole("link", { name: /view all tasks/i }),
     ).toHaveAttribute("href", "/inbox");
   });
 });

--- a/apps/web/src/features/dashboard/components/recent-items-list.tsx
+++ b/apps/web/src/features/dashboard/components/recent-items-list.tsx
@@ -26,7 +26,7 @@ export function RecentItemsList({ items }: RecentItemsListProps) {
         <div className="flex h-6 w-6 items-center justify-center rounded-md bg-surface-3">
           <Inbox className="h-3.5 w-3.5 text-muted-foreground" />
         </div>
-        <h2 className="text-sm font-medium">Recent Items</h2>
+        <h2 className="text-sm font-medium">Recent Tasks</h2>
         <span className="text-xs text-muted-foreground">
           {activeItems.length}
         </span>
@@ -41,7 +41,7 @@ export function RecentItemsList({ items }: RecentItemsListProps) {
           to="/inbox"
           className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
         >
-          View all items
+          View all tasks
           <ArrowRight className="h-3 w-3" />
         </Link>
       </div>

--- a/apps/web/src/features/inbox/screens/inbox-screen.tsx
+++ b/apps/web/src/features/inbox/screens/inbox-screen.tsx
@@ -34,8 +34,8 @@ export function InboxScreen() {
     return <InboxSkeleton />;
   }
 
-  const activeItems = items.filter((item) => !item.isCompleted);
-  const completedItems = items.filter((item) => item.isCompleted);
+  const openTasks = items.filter((task) => !task.isCompleted);
+  const doneTasks = items.filter((task) => task.isCompleted);
 
   return (
     <div className="mx-auto max-w-3xl">
@@ -49,32 +49,32 @@ export function InboxScreen() {
         </div>
       ) : (
         <div className="space-y-3">
-          {activeItems.length > 0 && (
+          {openTasks.length > 0 && (
             <div className="divide-y divide-border/50 rounded-xl border border-border-subtle bg-surface-2">
-              {activeItems.map((item) => (
+              {openTasks.map((task) => (
                 <ItemRowContainer
-                  key={item._id}
-                  item={item}
+                  key={task._id}
+                  item={task}
                   onProcess={setProcessingItem}
                 />
               ))}
             </div>
           )}
 
-          {completedItems.length > 0 && (
+          {doneTasks.length > 0 && (
             <Collapsible>
               <div className="rounded-xl border border-border-subtle bg-surface-2">
                 <CollapsibleTrigger className="group flex w-full items-center gap-2 px-3 py-2 text-left text-sm font-medium text-muted-foreground hover:text-foreground">
                   <ChevronRight className="h-4 w-4 transition-transform group-data-[state=open]:rotate-90" />
-                  <span>Completed</span>
+                  <span>Done</span>
                   <span className="ml-auto text-xs tabular-nums">
-                    {completedItems.length}
+                    {doneTasks.length}
                   </span>
                 </CollapsibleTrigger>
                 <CollapsibleContent>
                   <div className="divide-y divide-border/50 border-t border-border/50">
-                    {completedItems.map((item) => (
-                      <ItemRowContainer key={item._id} item={item} />
+                    {doneTasks.map((task) => (
+                      <ItemRowContainer key={task._id} item={task} />
                     ))}
                   </div>
                 </CollapsibleContent>

--- a/apps/web/src/features/items/item-row/item-row.tsx
+++ b/apps/web/src/features/items/item-row/item-row.tsx
@@ -29,6 +29,7 @@ import {
 import { format, formatDistanceToNow } from "date-fns";
 import { ArrowRight, CalendarIcon, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { isTaskWhenEmphasized } from "@/features/tasks/inbox";
 
 interface ItemRowProps {
   item: Doc<"items">;
@@ -65,8 +66,9 @@ export function ItemRow({
     }
   }, [isEditingText, item.text]);
 
+  const now = Date.now();
   const timestamp = item.isCompleted
-    ? `Completed ${formatDistanceToNow(
+    ? `Done ${formatDistanceToNow(
         new Date(item.completedAt ?? item.createdAt),
         {
           addSuffix: true,
@@ -75,7 +77,8 @@ export function ItemRow({
     : formatDistanceToNow(new Date(item.createdAt), {
         addSuffix: true,
       });
-  const itemDate = item.date === undefined ? undefined : new Date(item.date);
+  const taskWhen = item.date === undefined ? undefined : new Date(item.date);
+  const whenIsEmphasized = isTaskWhenEmphasized(item, now);
 
   const saveText = () => {
     const nextText = draftText.trim();
@@ -99,7 +102,7 @@ export function ItemRow({
         <Checkbox
           checked={item.isCompleted}
           onCheckedChange={onToggleComplete}
-          aria-label={item.isCompleted ? "Uncomplete item" : "Complete item"}
+          aria-label={item.isCompleted ? "Mark task open" : "Mark task done"}
         />
       </ItemMedia>
       <ItemContent className="min-w-0 gap-1.5">
@@ -119,7 +122,7 @@ export function ItemRow({
                   cancelTextEdit();
                 }
               }}
-              aria-label="Edit item text"
+              aria-label="Edit task text"
               className="h-7 min-w-0 flex-1 rounded-md px-2 text-sm"
             />
           ) : (
@@ -142,7 +145,7 @@ export function ItemRow({
                 size="icon"
                 className="h-7 w-7"
                 onClick={onProcess}
-                aria-label="Process item"
+                aria-label="Process task"
               >
                 <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
               </Button>
@@ -154,7 +157,7 @@ export function ItemRow({
                     variant="ghost"
                     size="icon"
                     className="h-7 w-7"
-                    aria-label="Discard item"
+                    aria-label="Discard task"
                   />
                 }
               >
@@ -162,10 +165,10 @@ export function ItemRow({
               </AlertDialogTrigger>
               <AlertDialogContent>
                 <AlertDialogHeader>
-                  <AlertDialogTitle>Discard item?</AlertDialogTitle>
+                  <AlertDialogTitle>Discard task?</AlertDialogTitle>
                   <AlertDialogDescription>
-                    This item will be permanently deleted. This action cannot be
-                    undone.
+                    This task will be permanently removed from your Inbox. This
+                    action cannot be undone.
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
@@ -189,27 +192,29 @@ export function ItemRow({
                   variant="ghost"
                   size="xs"
                   className={
-                    itemDate
+                    whenIsEmphasized
                       ? "h-6 rounded-md border border-primary/20 bg-primary/5 px-1.5 text-primary/80 hover:bg-primary/10 hover:text-primary"
-                      : "h-6 rounded-md px-1.5 text-muted-foreground/55 hover:text-muted-foreground"
+                      : taskWhen
+                        ? "h-6 rounded-md border border-border-subtle bg-surface-3 px-1.5 text-muted-foreground hover:text-foreground"
+                        : "h-6 rounded-md px-1.5 text-muted-foreground/55 hover:text-muted-foreground"
                   }
                 />
               }
             >
               <CalendarIcon className="h-3 w-3" />
-              {itemDate ? format(itemDate, "MMM d, yyyy") : "Add date"}
+              {taskWhen ? format(taskWhen, "MMM d, yyyy") : "Add When"}
             </PopoverTrigger>
             <PopoverContent className="w-auto gap-0 p-0" align="start">
               <Calendar
                 mode="single"
-                selected={itemDate}
+                selected={taskWhen}
                 onSelect={(date) => {
                   if (!date) return;
                   onUpdateDate(date.getTime());
                   setIsDateOpen(false);
                 }}
               />
-              {itemDate && (
+              {taskWhen && (
                 <div className="border-t border-border/60 p-2">
                   <Button
                     type="button"

--- a/apps/web/src/features/items/new-item/new-item-dialog.tsx
+++ b/apps/web/src/features/items/new-item/new-item-dialog.tsx
@@ -39,7 +39,7 @@ export function NewItemDialog({
     <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
       <ResponsiveDialogContent>
         <ResponsiveDialogHeader>
-          <ResponsiveDialogTitle>New item</ResponsiveDialogTitle>
+          <ResponsiveDialogTitle>New task</ResponsiveDialogTitle>
         </ResponsiveDialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <Textarea
@@ -55,7 +55,7 @@ export function NewItemDialog({
               }
             }}
           />
-          <DatePicker value={date} onChange={setDate} placeholder="Add date" />
+          <DatePicker value={date} onChange={setDate} placeholder="Add When" />
           <ResponsiveDialogFooter>
             <Button
               type="button"

--- a/apps/web/src/features/items/optimistic.test.ts
+++ b/apps/web/src/features/items/optimistic.test.ts
@@ -9,9 +9,9 @@ import {
   updateItemTextInInbox,
 } from "./optimistic";
 
-function makeItem(overrides: Partial<Doc<"items">> = {}): Doc<"items"> {
+function makeTask(overrides: Partial<Doc<"items">> = {}): Doc<"items"> {
   return {
-    _id: "item1" as Id<"items">,
+    _id: "task1" as Id<"items">,
     _creationTime: 0,
     userId: "user1",
     text: "Call clinic",
@@ -21,23 +21,23 @@ function makeItem(overrides: Partial<Doc<"items">> = {}): Doc<"items"> {
   };
 }
 
-describe("Item optimistic updates", () => {
-  it("keeps completed Items in the Inbox after active Items", () => {
-    const active = makeItem({
-      _id: "active" as Id<"items">,
+describe("Task optimistic updates", () => {
+  it("keeps Done Tasks in the Inbox after Open Tasks", () => {
+    const open = makeTask({
+      _id: "open" as Id<"items">,
       text: "Buy vitamins",
       createdAt: 200,
     });
-    const completing = makeItem({
+    const completing = makeTask({
       _id: "completing" as Id<"items">,
       text: "Call clinic",
       createdAt: 300,
     });
 
     expect(
-      completeItemInInbox([completing, active], completing._id, 500),
+      completeItemInInbox([completing, open], completing._id, 500),
     ).toEqual([
-      active,
+      open,
       {
         ...completing,
         isCompleted: true,
@@ -46,16 +46,16 @@ describe("Item optimistic updates", () => {
     ]);
   });
 
-  it("moves uncompleted Items back above completed Items", () => {
-    const uncompleting = makeItem({
+  it("moves uncompleted Tasks back above Done history", () => {
+    const uncompleting = makeTask({
       _id: "uncompleting" as Id<"items">,
       text: "Call clinic",
       isCompleted: true,
       createdAt: 100,
       completedAt: 500,
     });
-    const completed = makeItem({
-      _id: "completed" as Id<"items">,
+    const done = makeTask({
+      _id: "done" as Id<"items">,
       text: "Buy vitamins",
       isCompleted: true,
       createdAt: 300,
@@ -63,55 +63,55 @@ describe("Item optimistic updates", () => {
     });
 
     expect(
-      uncompleteItemInInbox([completed, uncompleting], uncompleting._id),
+      uncompleteItemInInbox([done, uncompleting], uncompleting._id),
     ).toEqual([
       {
         ...uncompleting,
         isCompleted: false,
         completedAt: undefined,
       },
-      completed,
+      done,
     ]);
   });
 
-  it("removes discarded Items from the unified Inbox list", () => {
-    const keeping = makeItem({ _id: "keeping" as Id<"items"> });
-    const removing = makeItem({ _id: "removing" as Id<"items"> });
+  it("removes discarded Tasks from the unified Inbox list", () => {
+    const keeping = makeTask({ _id: "keeping" as Id<"items"> });
+    const removing = makeTask({ _id: "removing" as Id<"items"> });
 
     expect(removeItemFromInbox([removing, keeping], removing._id)).toEqual([
       keeping,
     ]);
   });
 
-  it("updates an Item's text in the Inbox", () => {
-    const updating = makeItem({ _id: "updating" as Id<"items"> });
-    const unchanged = makeItem({ _id: "unchanged" as Id<"items"> });
+  it("updates a Task's text in the Inbox", () => {
+    const updating = makeTask({ _id: "updating" as Id<"items"> });
+    const unchanged = makeTask({ _id: "unchanged" as Id<"items"> });
 
     expect(
       updateItemTextInInbox([updating, unchanged], updating._id, "Book labs"),
     ).toEqual([{ ...updating, text: "Book labs" }, unchanged]);
   });
 
-  it("updates or clears an Item's date in the Inbox", () => {
-    const updating = makeItem({ _id: "updating" as Id<"items"> });
-    const unchanged = makeItem({ _id: "unchanged" as Id<"items"> });
+  it("updates or clears a Task's When in the Inbox", () => {
+    const updating = makeTask({ _id: "updating" as Id<"items"> });
+    const unchanged = makeTask({ _id: "unchanged" as Id<"items"> });
 
-    const dated = updateItemDateInInbox(
+    const withWhen = updateItemDateInInbox(
       [updating, unchanged],
       updating._id,
       1000,
     );
 
-    expect(dated).toEqual([{ ...updating, date: 1000 }, unchanged]);
-    expect(updateItemDateInInbox(dated, updating._id, undefined)).toEqual([
+    expect(withWhen).toEqual([{ ...updating, date: 1000 }, unchanged]);
+    expect(updateItemDateInInbox(withWhen, updating._id, undefined)).toEqual([
       { ...updating, date: undefined },
       unchanged,
     ]);
   });
 
-  it("counts only Items that are neither completed nor dated as unprocessed", () => {
-    expect(isUnprocessedItem(makeItem())).toBe(true);
-    expect(isUnprocessedItem(makeItem({ date: 500 }))).toBe(false);
-    expect(isUnprocessedItem(makeItem({ isCompleted: true }))).toBe(false);
+  it("counts only Open Tasks without When as unprocessed", () => {
+    expect(isUnprocessedItem(makeTask())).toBe(true);
+    expect(isUnprocessedItem(makeTask({ date: 500 }))).toBe(false);
+    expect(isUnprocessedItem(makeTask({ isCompleted: true }))).toBe(false);
   });
 });

--- a/apps/web/src/features/items/optimistic.ts
+++ b/apps/web/src/features/items/optimistic.ts
@@ -1,70 +1,27 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
-import { patchById, removeById } from "@/features/shared/optimistic";
+import { patchById } from "@/features/shared/optimistic";
+import {
+  completeTaskInInbox,
+  isUnprocessedTask,
+  removeTaskFromInbox,
+  sortInboxTasks,
+  uncompleteTaskInInbox,
+  updateTaskWhenInInbox,
+} from "@/features/tasks/inbox";
 
-type Item = Doc<"items">;
+type Task = Doc<"items">;
 
-export function sortInboxItems<
-  T extends Pick<Item, "isCompleted" | "createdAt">,
->(items: T[]): T[] {
-  return [...items].sort((a, b) => {
-    if (a.isCompleted !== b.isCompleted) {
-      return a.isCompleted ? 1 : -1;
-    }
+export const sortInboxItems = sortInboxTasks;
+export const completeItemInInbox = completeTaskInInbox;
+export const uncompleteItemInInbox = uncompleteTaskInInbox;
+export const removeItemFromInbox = removeTaskFromInbox;
+export const updateItemDateInInbox = updateTaskWhenInInbox;
+export const isUnprocessedItem = isUnprocessedTask;
 
-    return b.createdAt - a.createdAt;
-  });
-}
-
-export function completeItemInInbox<T extends Item>(
-  items: T[],
-  id: Id<"items">,
-  completedAt: number,
-): T[] {
-  return sortInboxItems(
-    items.map((item) =>
-      item._id === id ? { ...item, isCompleted: true, completedAt } : item,
-    ),
-  );
-}
-
-export function uncompleteItemInInbox<T extends Item>(
-  items: T[],
-  id: Id<"items">,
-): T[] {
-  return sortInboxItems(
-    items.map((item) =>
-      item._id === id
-        ? { ...item, isCompleted: false, completedAt: undefined }
-        : item,
-    ),
-  );
-}
-
-export function removeItemFromInbox<T extends Item>(
-  items: T[],
-  id: Id<"items">,
-): T[] {
-  return removeById(items, id);
-}
-
-export function updateItemTextInInbox<T extends Item>(
+export function updateItemTextInInbox<T extends Task>(
   items: T[],
   id: Id<"items">,
   text: string,
 ): T[] {
   return patchById(items, id, { text } as Partial<T>);
-}
-
-export function updateItemDateInInbox<T extends Item>(
-  items: T[],
-  id: Id<"items">,
-  date: number | undefined,
-): T[] {
-  return patchById(items, id, { date } as Partial<T>);
-}
-
-export function isUnprocessedItem(
-  item: Pick<Item, "isCompleted" | "date">,
-): boolean {
-  return !item.isCompleted && item.date === undefined;
 }

--- a/apps/web/src/features/items/process-item/process-item-dialog.tsx
+++ b/apps/web/src/features/items/process-item/process-item-dialog.tsx
@@ -154,12 +154,12 @@ export function ProcessItemDialog({
     <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
       <ResponsiveDialogContent className="sm:max-w-lg">
         <ResponsiveDialogHeader>
-          <ResponsiveDialogTitle>Process item</ResponsiveDialogTitle>
+          <ResponsiveDialogTitle>Process task</ResponsiveDialogTitle>
         </ResponsiveDialogHeader>
 
         <InboxItemPreview item={item} />
         <p className="-mt-3 text-sm text-muted-foreground">
-          Turn this inbox item into a clear outcome or next action.
+          Turn this Inbox task into a clear outcome or next action.
         </p>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/apps/web/src/features/tasks/inbox.test.ts
+++ b/apps/web/src/features/tasks/inbox.test.ts
@@ -1,0 +1,157 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+import { describe, expect, it } from "vitest";
+import {
+  completeTaskInInbox,
+  isTaskWhenDue,
+  isTaskWhenEmphasized,
+  isUnprocessedTask,
+  removeTaskFromInbox,
+  sortInboxTasks,
+  uncompleteTaskInInbox,
+  updateTaskWhenInInbox,
+} from "./inbox";
+
+function makeTask(overrides: Partial<Doc<"items">> = {}): Doc<"items"> {
+  return {
+    _id: "task1" as Id<"items">,
+    _creationTime: 0,
+    userId: "user1",
+    text: "Call clinic",
+    isCompleted: false,
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+const may18_2026 = new Date(2026, 4, 18, 12).getTime();
+const may19_2026 = new Date(2026, 4, 19, 12).getTime();
+const may17_2026 = new Date(2026, 4, 17, 12).getTime();
+
+describe("Task inbox ordering", () => {
+  it("lists Open Tasks before Done Tasks", () => {
+    const open = makeTask({
+      _id: "open" as Id<"items">,
+      text: "Buy vitamins",
+      createdAt: 200,
+    });
+    const done = makeTask({
+      _id: "done" as Id<"items">,
+      text: "Call clinic",
+      isCompleted: true,
+      completedAt: 500,
+      createdAt: 300,
+    });
+
+    expect(sortInboxTasks([done, open])).toEqual([open, done]);
+  });
+});
+
+describe("Task When emphasis", () => {
+  it("treats When on or before today as due", () => {
+    expect(isTaskWhenDue(may18_2026, may18_2026)).toBe(true);
+    expect(isTaskWhenDue(may17_2026, may18_2026)).toBe(true);
+    expect(isTaskWhenDue(may19_2026, may18_2026)).toBe(false);
+    expect(isTaskWhenDue(undefined, may18_2026)).toBe(false);
+  });
+
+  it("emphasizes Open Tasks with due When", () => {
+    expect(
+      isTaskWhenEmphasized(makeTask({ date: may17_2026 }), may18_2026),
+    ).toBe(true);
+    expect(
+      isTaskWhenEmphasized(makeTask({ date: may19_2026 }), may18_2026),
+    ).toBe(false);
+    expect(
+      isTaskWhenEmphasized(
+        makeTask({ date: may17_2026, isCompleted: true }),
+        may18_2026,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("Task inbox mutations", () => {
+  it("moves completed Tasks into Done history after Open Tasks", () => {
+    const open = makeTask({
+      _id: "open" as Id<"items">,
+      text: "Buy vitamins",
+      createdAt: 200,
+    });
+    const completing = makeTask({
+      _id: "completing" as Id<"items">,
+      text: "Call clinic",
+      createdAt: 300,
+    });
+
+    expect(
+      completeTaskInInbox([completing, open], completing._id, 500),
+    ).toEqual([
+      open,
+      {
+        ...completing,
+        isCompleted: true,
+        completedAt: 500,
+      },
+    ]);
+  });
+
+  it("restores uncompleted Tasks above Done history", () => {
+    const uncompleting = makeTask({
+      _id: "uncompleting" as Id<"items">,
+      isCompleted: true,
+      completedAt: 500,
+      createdAt: 100,
+    });
+    const done = makeTask({
+      _id: "done" as Id<"items">,
+      isCompleted: true,
+      completedAt: 600,
+      createdAt: 300,
+    });
+
+    expect(
+      uncompleteTaskInInbox([done, uncompleting], uncompleting._id),
+    ).toEqual([
+      {
+        ...uncompleting,
+        isCompleted: false,
+        completedAt: undefined,
+      },
+      done,
+    ]);
+  });
+
+  it("removes discarded Tasks from the visible Inbox list", () => {
+    const keeping = makeTask({ _id: "keeping" as Id<"items"> });
+    const removing = makeTask({ _id: "removing" as Id<"items"> });
+
+    expect(removeTaskFromInbox([removing, keeping], removing._id)).toEqual([
+      keeping,
+    ]);
+  });
+
+  it("updates or clears Task When without removing the Task from the Inbox", () => {
+    const updating = makeTask({ _id: "updating" as Id<"items"> });
+    const unchanged = makeTask({ _id: "unchanged" as Id<"items"> });
+
+    const withWhen = updateTaskWhenInInbox(
+      [updating, unchanged],
+      updating._id,
+      may19_2026,
+    );
+
+    expect(withWhen).toEqual([{ ...updating, date: may19_2026 }, unchanged]);
+    expect(updateTaskWhenInInbox(withWhen, updating._id, undefined)).toEqual([
+      { ...updating, date: undefined },
+      unchanged,
+    ]);
+  });
+});
+
+describe("Unprocessed Tasks", () => {
+  it("counts only Open Tasks without When as unprocessed", () => {
+    expect(isUnprocessedTask(makeTask())).toBe(true);
+    expect(isUnprocessedTask(makeTask({ date: 500 }))).toBe(false);
+    expect(isUnprocessedTask(makeTask({ isCompleted: true }))).toBe(false);
+  });
+});

--- a/apps/web/src/features/tasks/inbox.ts
+++ b/apps/web/src/features/tasks/inbox.ts
@@ -1,0 +1,90 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+import { patchById, removeById } from "@/features/shared/optimistic";
+
+type Task = Doc<"items">;
+
+function startOfDayMs(timestamp: number): number {
+  const date = new Date(timestamp);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+export function isTaskWhenDue(
+  when: number | undefined,
+  referenceDate: number,
+): boolean {
+  if (when === undefined) {
+    return false;
+  }
+
+  return startOfDayMs(when) <= startOfDayMs(referenceDate);
+}
+
+export function isTaskWhenEmphasized(
+  task: Pick<Task, "isCompleted" | "date">,
+  referenceDate: number,
+): boolean {
+  if (task.isCompleted) {
+    return false;
+  }
+
+  return isTaskWhenDue(task.date, referenceDate);
+}
+
+export function sortInboxTasks<
+  T extends Pick<Task, "isCompleted" | "createdAt">,
+>(tasks: T[]): T[] {
+  return [...tasks].sort((a, b) => {
+    if (a.isCompleted !== b.isCompleted) {
+      return a.isCompleted ? 1 : -1;
+    }
+
+    return b.createdAt - a.createdAt;
+  });
+}
+
+export function completeTaskInInbox<T extends Task>(
+  tasks: T[],
+  id: Id<"items">,
+  completedAt: number,
+): T[] {
+  return sortInboxTasks(
+    tasks.map((task) =>
+      task._id === id ? { ...task, isCompleted: true, completedAt } : task,
+    ),
+  );
+}
+
+export function uncompleteTaskInInbox<T extends Task>(
+  tasks: T[],
+  id: Id<"items">,
+): T[] {
+  return sortInboxTasks(
+    tasks.map((task) =>
+      task._id === id
+        ? { ...task, isCompleted: false, completedAt: undefined }
+        : task,
+    ),
+  );
+}
+
+export function removeTaskFromInbox<T extends Task>(
+  tasks: T[],
+  id: Id<"items">,
+): T[] {
+  return removeById(tasks, id);
+}
+
+export function updateTaskWhenInInbox<T extends Task>(
+  tasks: T[],
+  id: Id<"items">,
+  when: number | undefined,
+): T[] {
+  return patchById(tasks, id, { date: when } as Partial<T>);
+}
+
+export function isUnprocessedTask(
+  task: Pick<Task, "isCompleted" | "date">,
+): boolean {
+  return !task.isCompleted && task.date === undefined;
+}

--- a/docs/adr/0003-area-thread-task-awareness-model.md
+++ b/docs/adr/0003-area-thread-task-awareness-model.md
@@ -1,0 +1,18 @@
+# Area, Thread, and Task awareness model
+
+Vita OS is shifting from a project/task-management model to a personal life-awareness model. We will use **Area**, **Thread**, and **Task** as the core product language because many important life situations need continuity, follow-up, and judgment rather than a defined project plan or task checklist.
+
+## Considered Options
+
+- **Keep Project / Item / Action queue**: familiar to the existing app and code, but pulls the product toward project management and makes slow-moving life situations feel like execution plans.
+- **Use Thread / Task / Next Move**: better fits open loops, waiting, monitoring, and unresolved decisions while still allowing lightweight capture and concrete next action.
+
+## Consequences
+
+- **Thread** replaces Project as the canonical ongoing situation.
+- **Task** replaces Item as the Inbox capture layer.
+- **Next Move** is singular and replaces Action queue.
+- **Follow-up** belongs to a Thread and is the core resurfacing mechanism.
+- **Condition** replaces Health status as the manual judgment on an Area.
+- Threads have an Open / Resolved lifecycle; manual states like active, waiting, paused, and monitoring are postponed.
+- Tasks remain outside Threads. Moving a Task into a Thread consumes the Task and copies its text into the Thread as an Activity Log entry or Next Move.

--- a/docs/temp/product-direction.md
+++ b/docs/temp/product-direction.md
@@ -1,0 +1,637 @@
+# Vita OS — Updated Product Direction
+
+## Core Idea
+
+**Vita OS is a personal life-awareness dashboard for managing important life domains and slow-moving open loops.**
+
+It is not primarily a productivity app, task manager, notes app, calendar, or project management tool. It can contain tasks, but tasks are not the center of the product.
+
+Vita OS exists to answer:
+
+> What important parts of my life need awareness, follow-up, or judgment now?
+
+The main value is reducing mental load by externalizing the user’s life inventory: ongoing domains, open threads, follow-ups, and loose tasks.
+
+---
+
+## Product Thesis
+
+Many important life responsibilities are not continuously actionable. They often follow this pattern:
+
+```text
+Notice issue → take one action → wait days/weeks/months → follow up → reassess → wait again
+```
+
+Examples:
+
+* family health follow-ups
+* personal health checkups
+* taxes and admin obligations
+* career moves
+* financial decisions
+* relationship maintenance
+* household issues
+* unresolved personal decisions
+* long-term learning efforts
+
+These are not well handled by pure task managers because the problem is not only execution. The problem is **continuity of awareness**.
+
+Vita OS helps the user stop mentally tracking every open loop by keeping the system visible, structured, and easy to review.
+
+---
+
+## Positioning
+
+A task manager asks:
+
+> What do I need to do?
+
+A calendar asks:
+
+> When does this happen?
+
+A notes app asks:
+
+> Where do I store this?
+
+A project manager asks:
+
+> How do we execute this work?
+
+Vita OS asks:
+
+> What is open across my life, what condition is each area in, and what deserves attention next?
+
+The dashboard is the product. Everything else exists to make the dashboard trustworthy.
+
+---
+
+# Core Model
+
+Vita OS has three main objects:
+
+```text
+Area → Thread → Activity Log / Next Move / Follow-up
+Inbox → Tasks
+```
+
+## 1. Area
+
+An **Area** is a stable life domain with no natural end date.
+
+Examples:
+
+```text
+Family Health
+Personal Health
+Career
+Finances
+Relationships
+Home
+Learning
+Legal/Admin
+```
+
+Each Area has a manually set **Condition**:
+
+```text
+Healthy
+Needs Attention
+Critical
+```
+
+The condition is the user’s judgment. It is not automatically calculated from task count, overdue items, or activity volume.
+
+A quiet Area may be critical. A busy Area may be healthy.
+
+### Purpose
+
+Areas answer:
+
+> Is this part of my life okay?
+
+---
+
+## 2. Thread
+
+A **Thread** is an ongoing effort, concern, decision, or situation that belongs to an Area and may need attention over time.
+
+Examples:
+
+```text
+Mom’s medical follow-up
+SUNAT/RHE cleanup
+Job search strategy
+Car vs motorcycle decision
+Improve English speaking practice
+Apartment search
+Personal health checkup
+```
+
+A Thread is broader than a project. It does not need to be continuously actionable or have a clean execution plan. It may involve action, waiting, monitoring, reassessment, or eventual resolution.
+
+### Purpose
+
+Threads answer:
+
+```text
+What is this about?
+Where does it belong?
+What happened so far?
+What might I do next?
+When should I look at it again?
+```
+
+---
+
+## 3. Task
+
+A **Task** is a lightweight captured action or loose input in the Inbox.
+
+Examples:
+
+```text
+Pay internet bill
+Ask accountant about April income
+Call clinic tomorrow
+Buy medicine
+Compare headphone prices
+Check if recruiter replied
+```
+
+Tasks are practical and familiar. They can be done directly, discarded, dated, or moved into a Thread.
+
+Tasks are not the core object of Vita OS. They are the capture/triage layer.
+
+### Purpose
+
+Tasks answer:
+
+> What loose thing do I need to handle or process?
+
+---
+
+# Key Concepts
+
+## Dashboard
+
+The Dashboard is the main product surface.
+
+It should show:
+
+```text
+Areas needing attention
+Threads needing follow-up
+Threads with next moves
+Stale/open Threads
+Inbox Tasks
+Recently updated Threads
+```
+
+The dashboard should not become a generic task list. Its job is to restore awareness quickly.
+
+Ideal use:
+
+```text
+Open dashboard
+See Area conditions
+Notice Threads needing follow-up
+Review today’s Tasks
+Update what changed
+Close app
+```
+
+The goal is a 1–2 minute orientation loop.
+
+---
+
+## Condition
+
+**Condition** belongs to an Area.
+
+Values:
+
+```text
+Healthy
+Needs Attention
+Critical
+```
+
+Condition is manual because only the user can judge the real state of a life domain.
+
+Example:
+
+```text
+Area: Finances
+Condition: Needs Attention
+```
+
+A domain should not become critical automatically just because it has many Threads or Tasks.
+
+---
+
+## Next Move
+
+A **Next Move** belongs to a Thread.
+
+It is the next useful action that could move the Thread forward.
+
+Examples:
+
+```text
+Ask accountant whether April needs monthly payment.
+Follow up with recruiter if no answer this week.
+Book a second medical appointment.
+Review car ownership costs again.
+```
+
+Next Move is singular. It replaces the idea of an action queue.
+
+This keeps Threads directional without turning them into checklist systems.
+
+---
+
+## Follow-up
+
+A **Follow-up** belongs to a Thread.
+
+It is a soft resurfacing point, not necessarily a hard due date.
+
+It means:
+
+> Bring this Thread back into awareness around this time.
+
+A Follow-up can optionally include a note.
+
+Examples:
+
+```text
+May 25 — Check if accountant confirmed April handling.
+Next week — See if symptoms changed.
+June 1 — Review whether this decision still matters.
+```
+
+Internally, this can be modeled as:
+
+```ts
+followUpAt?: Date
+followUpNote?: string
+```
+
+But in the UI it should feel like one lightweight control:
+
+```text
+Follow up: May 25 — Check if accountant replied
+```
+
+Follow-up is one of the app’s strongest differentiators because it fits slow-moving life threads better than ordinary due dates.
+
+---
+
+## Activity Log
+
+An **Activity Log** belongs to a Thread.
+
+It records what happened so far:
+
+```text
+May 12 — Asked accountant about RHE monthly payment.
+May 13 — Confirmed March has S/2 interest.
+May 18 — Set follow-up for May 25.
+```
+
+The log provides continuity. When returning to a Thread after days or weeks, the user should not need to reconstruct context from memory.
+
+The log can include:
+
+```text
+manual notes
+actions taken
+decisions made
+important updates
+meaningful automatic changes
+```
+
+Avoid noisy automatic logging.
+
+---
+
+## Task Date / “When”
+
+Tasks can have a date in the database:
+
+```ts
+date?: Date
+```
+
+But the UI should label this as:
+
+```text
+When
+```
+
+Not necessarily “Due date.”
+
+Why:
+
+* “Due date” implies a hard deadline.
+* “When” is broader and softer.
+* Vita OS often needs resurfacing, not strict deadline enforcement.
+
+Examples:
+
+```text
+Task: Call clinic
+When: Tomorrow
+
+Task: Pay credit card
+When: May 30
+
+Task: Compare vacuum options
+When: Weekend
+```
+
+For MVP, “When” can mean:
+
+> Show this task for attention around this date.
+
+Hard deadlines can be added later if needed.
+
+---
+
+# Task Lifecycle
+
+Tasks live in the Inbox.
+
+A Task can be:
+
+```text
+Open
+Done
+Discarded
+Moved to Thread
+```
+
+Recommended actions:
+
+```text
+Done
+Discard
+Move to Thread
+Set When
+```
+
+Examples:
+
+```text
+Task: Buy toothpaste
+→ Done
+
+Task: Ask accountant about April income
+→ Move to Thread: SUNAT/RHE cleanup
+
+Task: Random idea no longer relevant
+→ Discard
+
+Task: Call clinic
+→ Set When: Tomorrow
+```
+
+Tasks should be completable because forcing every small action into a Thread would be annoying.
+
+But completed Tasks should not dominate the app. They should disappear from the main Inbox or move into a collapsed history.
+
+---
+
+# Thread Lifecycle
+
+A Thread can be:
+
+```text
+Open
+Resolved
+```
+
+Avoid adding manual status in the MVP.
+
+Instead, derive dashboard status from existing fields.
+
+## Derived Thread Status
+
+```ts
+function getThreadStatus(thread) {
+  if (thread.resolvedAt) return "resolved";
+  if (thread.followUpAt && thread.followUpAt <= today) return "follow_up_due";
+  if (thread.followUpAt && thread.followUpAt > today) return "scheduled";
+  if (thread.nextMove) return "ready";
+  return "open";
+}
+```
+
+Possible display groups:
+
+```text
+Follow-up Due
+Scheduled
+Ready
+Open
+Resolved
+```
+
+This avoids making the user manually maintain states like Active, Waiting, Monitoring, or Paused.
+
+Manual status/mode can be added later if derived status is not enough.
+
+---
+
+# Recommended Data Model
+
+```ts
+type Area = {
+  id: string;
+  name: string;
+  condition: "healthy" | "needs_attention" | "critical";
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type Thread = {
+  id: string;
+  areaId: string;
+  title: string;
+  summary?: string;
+  nextMove?: string;
+  followUpAt?: Date;
+  followUpNote?: string;
+  resolvedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type ActivityLogEntry = {
+  id: string;
+  threadId: string;
+  content: string;
+  createdAt: Date;
+  type?: "note" | "decision" | "action" | "system";
+};
+
+type Task = {
+  id: string;
+  text: string;
+  date?: Date;
+  status: "open" | "done" | "discarded" | "moved_to_thread";
+  createdAt: Date;
+  updatedAt: Date;
+};
+```
+
+Optional later:
+
+```ts
+manualThreadMode?: "active" | "waiting" | "monitoring" | "paused";
+priority?: "low" | "medium" | "high";
+deadline?: Date;
+recurringFollowUp?: string;
+references?: Reference[];
+```
+
+Do not add these until the simple model proves insufficient.
+
+---
+
+# Recommended Vocabulary
+
+Use these terms consistently:
+
+```text
+Area
+Condition
+Thread
+Next Move
+Follow-up
+Activity Log
+Inbox
+Task
+When
+Done
+Discard
+Move to Thread
+Resolve Thread
+Dashboard
+```
+
+Avoid or postpone:
+
+```text
+Project
+Action queue
+Subtask
+Priority
+Due date
+Status
+Backlog
+Epic
+Ticket
+Goal
+```
+
+Not because those terms are always bad, but because they may pull the product toward task/project-management patterns too early.
+
+---
+
+# UX Principles
+
+## 1. Minimize required fields
+
+Creating a Thread should require only:
+
+```text
+Title
+Area
+```
+
+Everything else is optional:
+
+```text
+Summary
+Next Move
+Follow-up
+Activity Log entry
+```
+
+Creating a Task should require only:
+
+```text
+Text
+```
+
+Optional:
+
+```text
+When
+```
+
+## 2. Prefer derived structure over manual classification
+
+Do not force the user to constantly set statuses.
+
+Use fields like `followUpAt`, `nextMove`, and `resolvedAt` to infer what should appear on the dashboard.
+
+## 3. Keep Tasks lightweight
+
+Tasks are for capture and simple execution.
+
+If something needs continuity, move it into a Thread.
+
+## 4. Keep Threads alive but not noisy
+
+A Thread should preserve enough context to resume later, but it should not require constant maintenance.
+
+## 5. Make resurfacing central
+
+Follow-up should be easy to set and visible on the dashboard.
+
+This is core to the product’s value.
+
+---
+
+# MVP Scope
+
+## Must-have
+
+```text
+Areas
+Manual Area condition
+Threads assigned to Areas
+Thread summary
+Thread Next Move
+Thread Follow-up
+Thread Activity Log
+Inbox Tasks
+Task When
+Task Done / Discard / Move to Thread
+Dashboard
+Derived Thread status
+```
+
+## Should avoid for MVP
+
+```text
+manual Thread status
+complex priorities
+subtasks
+kanban views
+gamification
+automatic Area condition scoring
+collaboration
+heavy tagging
+AI planning
+recurring task engine
+```
+
+---
+
+# One-Sentence Product Definition
+
+**Vita OS is a personal life-awareness dashboard that helps you track important life Areas, open Threads, and loose Tasks so you can stop carrying every unresolved loop in your head.**


### PR DESCRIPTION
## Summary
- Evolve the Inbox from Item to Task language (Open/Done, When, discard) with a pure `tasks/inbox` module and tests for ordering, When emphasis, and optimistic updates
- Emphasize Open Tasks whose When is today or earlier; future-dated Tasks stay visible with softer styling
- Refresh domain docs: `CONTEXT.md`, ADR 0003, and draft `docs/temp/product-direction.md`
- Convex schema remains `items` / `date` until legacy migration (#158); see comment on #158

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`

Closes #153

Made with [Cursor](https://cursor.com)