### PR TITLE
feat(threads): use Thread and Summary language in primary UI

### DIFF
--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -167,7 +167,7 @@ export function AppSidebar() {
                         onClick={() => openCreateProject(area._id)}
                       >
                         <Plus />
-                        <span className="sr-only">New project</span>
+                        <span className="sr-only">New thread</span>
                       </SidebarMenuAction>
                       {hasProjects && (
                         <CollapsibleTrigger

--- a/apps/web/src/features/areas/components/area-card.tsx
+++ b/apps/web/src/features/areas/components/area-card.tsx
@@ -29,7 +29,7 @@ export function AreaCard({
         <p className="truncate font-medium">{area.name}</p>
       </div>
       <p className="mt-2 text-xs text-muted-foreground">
-        {projectCount} {projectCount === 1 ? "project" : "projects"}
+        {projectCount} {projectCount === 1 ? "thread" : "threads"}
       </p>
       {attentionCount > 0 && (
         <p className="mt-1.5 flex items-center gap-1 text-xs text-amber-500">

--- a/apps/web/src/features/areas/components/area-header.tsx
+++ b/apps/web/src/features/areas/components/area-header.tsx
@@ -84,7 +84,7 @@ export function AreaHeader({
                 <AlertDialogTitle>Delete area?</AlertDialogTitle>
                 <AlertDialogDescription>
                   This area and its data will be permanently deleted. Move or
-                  delete all projects first.
+                  delete all threads first.
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
@@ -126,7 +126,7 @@ export function AreaHeader({
           </SelectContent>
         </Select>
         <span className="text-xs text-muted-foreground">
-          {projectCount} {projectCount === 1 ? "project" : "projects"}
+          {projectCount} {projectCount === 1 ? "thread" : "threads"}
         </span>
       </div>
     </div>

--- a/apps/web/src/features/areas/components/area-projects.test.tsx
+++ b/apps/web/src/features/areas/components/area-projects.test.tsx
@@ -1,0 +1,63 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { AreaProjects } from "./area-projects";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children: ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+const project = {
+  _id: "project1" as Id<"projects">,
+  _creationTime: 0,
+  userId: "user1",
+  name: "Renew passport",
+  slug: "renew-passport",
+  areaId: "area1" as Id<"areas">,
+  state: "active",
+  order: 0,
+  createdAt: 0,
+} satisfies Doc<"projects">;
+
+describe("AreaProjects", () => {
+  it("lists threads under the area with Thread language", () => {
+    render(
+      <AreaProjects
+        areaSlug="admin"
+        projects={[project]}
+        onCreateProject={vi.fn()}
+        onRemoveProject={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Threads" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "New thread" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Renew passport")).toBeInTheDocument();
+    expect(screen.queryByText("Projects")).not.toBeInTheDocument();
+  });
+
+  it("shows an empty state that invites creating a thread", () => {
+    render(
+      <AreaProjects
+        areaSlug="admin"
+        projects={[]}
+        onCreateProject={vi.fn()}
+        onRemoveProject={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("No threads in this area yet."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create thread" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/areas/components/area-projects.tsx
+++ b/apps/web/src/features/areas/components/area-projects.tsx
@@ -34,7 +34,7 @@ export function AreaProjects({
           <div className="flex h-6 w-6 items-center justify-center rounded-md bg-surface-3">
             <FolderOpen className="h-3.5 w-3.5 text-muted-foreground" />
           </div>
-          <h2 className="text-sm font-medium">Projects</h2>
+          <h2 className="text-sm font-medium">Threads</h2>
         </div>
         <Button
           variant="ghost"
@@ -43,7 +43,7 @@ export function AreaProjects({
           onClick={onCreateProject}
         >
           <Plus className="h-3.5 w-3.5" />
-          New project
+          New thread
         </Button>
       </div>
 
@@ -51,10 +51,10 @@ export function AreaProjects({
         <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border/50 py-10 text-center">
           <FolderOpen className="mb-3 h-8 w-8 text-muted-foreground/60" />
           <p className="mb-4 max-w-xs text-sm text-muted-foreground">
-            No projects in this area yet.
+            No threads in this area yet.
           </p>
           <Button variant="outline" size="sm" onClick={onCreateProject}>
-            Create project
+            Create thread
           </Button>
         </div>
       ) : (
@@ -105,7 +105,7 @@ function AreaProjectRow({
               variant="ghost"
               size="icon-sm"
               className="mr-2 opacity-0 transition-opacity group-hover:opacity-100"
-              aria-label="Delete project"
+              aria-label="Delete thread"
             />
           }
         >
@@ -113,7 +113,7 @@ function AreaProjectRow({
         </AlertDialogTrigger>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete project?</AlertDialogTitle>
+            <AlertDialogTitle>Delete thread?</AlertDialogTitle>
             <AlertDialogDescription>
               &ldquo;{project.name}&rdquo; will be permanently removed.
             </AlertDialogDescription>

--- a/apps/web/src/features/inbox/screens/inbox-screen.tsx
+++ b/apps/web/src/features/inbox/screens/inbox-screen.tsx
@@ -114,7 +114,7 @@ function ProcessingToast({
 }) {
   const message =
     notification.action === "create_project"
-      ? "Created project"
+      ? "Created thread"
       : notification.action === "set_next_action"
         ? "Set as next action"
         : "Added as note";

--- a/apps/web/src/features/items/process-item/process-item-dialog.test.tsx
+++ b/apps/web/src/features/items/process-item/process-item-dialog.test.tsx
@@ -98,7 +98,7 @@ describe("ProcessItemDialog", () => {
     const combobox = screen.getByRole("combobox");
     expect(combobox).toHaveAttribute(
       "placeholder",
-      "Search or type a new Project...",
+      "Search or type a new thread...",
     );
     await user.type(combobox, "heal");
 
@@ -147,7 +147,7 @@ describe("ProcessItemDialog", () => {
 
     expect(combobox).toHaveValue("Schedule dentist");
     expect(
-      screen.getByRole("textbox", { name: /definition of done/i }),
+      screen.getByRole("textbox", { name: /summary/i }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Health" })).toBeInTheDocument();
   });
@@ -165,7 +165,7 @@ describe("ProcessItemDialog", () => {
     expect(combobox).toHaveValue("Schedule dentist");
     await user.click(screen.getByRole("button", { name: "Health" }));
     await user.type(
-      screen.getByRole("textbox", { name: /definition of done/i }),
+      screen.getByRole("textbox", { name: /summary/i }),
       "Appointment is on the calendar",
     );
     await user.click(screen.getByRole("button", { name: /process/i }));
@@ -190,7 +190,7 @@ describe("ProcessItemDialog", () => {
     );
     await user.click(screen.getByRole("button", { name: "Health" }));
     await user.type(
-      screen.getByRole("textbox", { name: /definition of done/i }),
+      screen.getByRole("textbox", { name: /summary/i }),
       "Appointment is on the calendar",
     );
     expect(screen.getByRole("button", { name: /process/i })).toBeEnabled();
@@ -199,14 +199,14 @@ describe("ProcessItemDialog", () => {
     await user.type(combobox, "Schedule dentist visit");
     await user.click(
       screen.getByRole("textbox", {
-        name: /definition of done/i,
+        name: /summary/i,
         hidden: true,
       }),
     );
 
-    expect(
-      screen.getByRole("textbox", { name: /definition of done/i }),
-    ).toHaveValue("Appointment is on the calendar");
+    expect(screen.getByRole("textbox", { name: /summary/i })).toHaveValue(
+      "Appointment is on the calendar",
+    );
     expect(combobox).toHaveValue("Schedule dentist visit");
     const processButton = screen.getByRole("button", { name: /process/i });
     expect(processButton).toBeEnabled();

--- a/apps/web/src/features/items/process-item/process-item-dialog.tsx
+++ b/apps/web/src/features/items/process-item/process-item-dialog.tsx
@@ -182,12 +182,12 @@ export function ProcessItemDialog({
               />
               <Textarea
                 id="inline-project-dod"
-                aria-label="Definition of Done"
+                aria-label="Summary"
                 value={definitionOfDone}
                 onChange={(event) =>
                   setDefinitionOfDone(event.currentTarget.value)
                 }
-                placeholder="Definition of Done"
+                placeholder="What is this thread about?"
                 rows={2}
                 className="resize-none"
               />
@@ -201,7 +201,7 @@ export function ProcessItemDialog({
                 selectedMode={mode}
                 onSelect={setMode}
                 title="Add as note"
-                description="Logged in the Project."
+                description="Logged in the thread activity log."
                 icon={<FileText className="h-4 w-4" />}
               />
               <ProcessingModeCard

--- a/apps/web/src/features/items/process-item/project-search-autocomplete.tsx
+++ b/apps/web/src/features/items/process-item/project-search-autocomplete.tsx
@@ -103,12 +103,12 @@ export function ProjectSearchAutocomplete({
       }}
     >
       <ComboboxInput
-        placeholder="Search or type a new Project..."
+        placeholder="Search or type a new thread..."
         autoFocus
         showClear={!!value || inputValue.length > 0}
       />
       <ComboboxContent>
-        <ComboboxEmpty>No Projects yet</ComboboxEmpty>
+        <ComboboxEmpty>No threads yet</ComboboxEmpty>
         <ComboboxList>
           {(choice: ProjectChoice) =>
             choice.kind === "create" ? (

--- a/apps/web/src/features/projects/components/project-definition.test.tsx
+++ b/apps/web/src/features/projects/components/project-definition.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ProjectDefinition } from "./project-definition";
+
+describe("ProjectDefinition", () => {
+  it("presents optional Summary instead of Definition of Done", () => {
+    render(<ProjectDefinition definitionOfDone="" onSave={vi.fn()} />);
+
+    expect(screen.getByText("Summary")).toBeInTheDocument();
+    expect(screen.queryByText("Definition of Done")).not.toBeInTheDocument();
+    expect(screen.getByText("What is this thread about?")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/projects/components/project-definition.tsx
+++ b/apps/web/src/features/projects/components/project-definition.tsx
@@ -15,13 +15,13 @@ export function ProjectDefinition({
     <div className="space-y-4">
       <MetadataRow
         icon={<CheckCircle2 className="h-3.5 w-3.5" />}
-        label="Definition of Done"
+        label="Summary"
       >
         <EditableField
           value={definitionOfDone}
           onSave={onSave}
           variant="textarea"
-          placeholder="What does done look like?"
+          placeholder="What is this thread about?"
           className="text-sm"
         />
       </MetadataRow>

--- a/apps/web/src/features/projects/components/project-lifecycle-actions.tsx
+++ b/apps/web/src/features/projects/components/project-lifecycle-actions.tsx
@@ -37,7 +37,7 @@ export function ProjectLifecycleActions({
         </AlertDialogTrigger>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Complete project?</AlertDialogTitle>
+            <AlertDialogTitle>Complete thread?</AlertDialogTitle>
             <AlertDialogDescription>
               &ldquo;{project.name}&rdquo; will be marked as completed.
             </AlertDialogDescription>
@@ -64,7 +64,7 @@ export function ProjectLifecycleActions({
         </AlertDialogTrigger>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Drop project?</AlertDialogTitle>
+            <AlertDialogTitle>Drop thread?</AlertDialogTitle>
             <AlertDialogDescription>
               &ldquo;{project.name}&rdquo; will be marked as dropped.
             </AlertDialogDescription>
@@ -98,7 +98,7 @@ export function ProjectLifecycleActions({
         </AlertDialogTrigger>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete project?</AlertDialogTitle>
+            <AlertDialogTitle>Delete thread?</AlertDialogTitle>
             <AlertDialogDescription>
               &ldquo;{project.name}&rdquo; will be permanently removed.
             </AlertDialogDescription>

--- a/apps/web/src/features/projects/components/project-picker.tsx
+++ b/apps/web/src/features/projects/components/project-picker.tsx
@@ -39,7 +39,7 @@ export function ProjectPicker({
         }
       >
         <FolderOpen className="h-3 w-3" />
-        {selected ? selected.name : "Select project"}
+        {selected ? selected.name : "Select thread"}
       </PopoverTrigger>
       <PopoverContent className="w-56 p-1" align="start">
         {projectsByArea.map(({ area, projects: areaProjects }) => (
@@ -64,7 +64,7 @@ export function ProjectPicker({
         ))}
         {projectsByArea.length === 0 && (
           <p className="px-2 py-3 text-center text-xs text-muted-foreground">
-            No active projects
+            No active threads
           </p>
         )}
       </PopoverContent>

--- a/apps/web/src/features/projects/project-detail/project-detail-screen.tsx
+++ b/apps/web/src/features/projects/project-detail/project-detail-screen.tsx
@@ -24,7 +24,7 @@ export function ProjectDetailScreen({
     slug: projectSlug,
   });
 
-  useDocumentTitle(project?.name ?? "Project");
+  useDocumentTitle(project?.name ?? "Thread");
 
   if (area === undefined || project === undefined) {
     return <ProjectDetailSkeleton />;

--- a/apps/web/src/features/projects/project-detail/project-not-found.tsx
+++ b/apps/web/src/features/projects/project-detail/project-not-found.tsx
@@ -7,7 +7,7 @@ interface ProjectNotFoundProps {
 export function ProjectNotFound({ areaSlug }: ProjectNotFoundProps) {
   return (
     <div className="py-16 text-center">
-      <p className="text-sm text-muted-foreground">Project not found.</p>
+      <p className="text-sm text-muted-foreground">Thread not found.</p>
       <Link
         to="/$areaSlug"
         params={{ areaSlug }}

--- a/apps/web/src/features/projects/project-form/project-form-dialog.test.tsx
+++ b/apps/web/src/features/projects/project-form/project-form-dialog.test.tsx
@@ -1,0 +1,56 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { ProjectFormDialog } from "./project-form-dialog";
+
+const areas = [
+  {
+    _id: "area1" as Id<"areas">,
+    _creationTime: 0,
+    userId: "user1",
+    name: "Health",
+    slug: "health",
+    healthStatus: "healthy",
+    order: 0,
+    createdAt: 0,
+  },
+] satisfies Doc<"areas">[];
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ??
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+});
+
+describe("ProjectFormDialog", () => {
+  it("uses Thread language and optional Summary on create", () => {
+    render(
+      <ProjectFormDialog
+        mode="create"
+        open
+        onOpenChange={vi.fn()}
+        areas={areas}
+        defaultAreaId={areas[0]._id}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "New thread" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Summary/i)).toBeInTheDocument();
+    expect(screen.queryByText("Definition of Done")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create thread" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/projects/project-form/project-form-dialog.tsx
+++ b/apps/web/src/features/projects/project-form/project-form-dialog.tsx
@@ -72,19 +72,19 @@ export function ProjectFormDialog({
       <ResponsiveDialogContent>
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>
-            {mode === "edit" ? "Edit project" : "New project"}
+            {mode === "edit" ? "Edit thread" : "New thread"}
           </ResponsiveDialogTitle>
           <ResponsiveDialogDescription>
             {mode === "edit"
-              ? "Update this project's details."
-              : "Projects are active efforts with a defined end state."}
+              ? "Update this thread's details."
+              : "Threads are ongoing situations that belong to an area."}
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
         <form onSubmit={handleSubmit} className="space-y-5">
           <div className="space-y-2">
-            <Label htmlFor="project-name">Name</Label>
+            <Label htmlFor="thread-name">Title</Label>
             <Input
-              id="project-name"
+              id="thread-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. Renew passport, File Q4 taxes"
@@ -92,17 +92,17 @@ export function ProjectFormDialog({
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="project-dod">
-              Definition of Done
+            <Label htmlFor="thread-summary">
+              Summary
               <span className="ml-1 font-normal text-muted-foreground">
                 (optional)
               </span>
             </Label>
             <Textarea
-              id="project-dod"
+              id="thread-summary"
               value={definitionOfDone}
               onChange={(e) => setDefinitionOfDone(e.target.value)}
-              placeholder="What does done look like?"
+              placeholder="What is this thread about?"
               rows={2}
             />
           </div>
@@ -123,7 +123,7 @@ export function ProjectFormDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={!name.trim() || !areaId}>
-              {mode === "edit" ? "Save changes" : "Create project"}
+              {mode === "edit" ? "Save changes" : "Create thread"}
             </Button>
           </ResponsiveDialogFooter>
         </form>


### PR DESCRIPTION
## Summary
- Rename primary user-facing copy from Project to Thread across area lists, create/edit forms, detail surfaces, sidebar, and process-task flow
- Replace Definition of Done with optional Summary on thread create, detail, and inline create-from-inbox
- Add component tests for thread form, summary field, and area thread list

Schema and API still use legacy `projects` / `definitionOfDone` names; #158 covers persistence migration.

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`

Closes #148

Made with [Cursor](https://cursor.com)