### PR TITLE
feat(threads): add activity logs and thread area moves

### DIFF
--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type * as auth from "../auth.js";
 import type * as dashboard from "../dashboard.js";
 import type * as http from "../http.js";
 import type * as items from "../items.js";
+import type * as lib_activityLog from "../lib/activityLog.js";
 import type * as lib_areaProjects from "../lib/areaProjects.js";
 import type * as lib_condition from "../lib/condition.js";
 import type * as lib_healthStatus from "../lib/healthStatus.js";
@@ -39,6 +40,7 @@ declare const fullApi: ApiFromModules<{
   dashboard: typeof dashboard;
   http: typeof http;
   items: typeof items;
+  "lib/activityLog": typeof lib_activityLog;
   "lib/areaProjects": typeof lib_areaProjects;
   "lib/condition": typeof lib_condition;
   "lib/healthStatus": typeof lib_healthStatus;

--- a/apps/web/convex/lib/activityLog.test.ts
+++ b/apps/web/convex/lib/activityLog.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { Doc, Id } from "../_generated/dataModel";
+import {
+  AUTO_ACTIVITY_LOG_ENTRY_TYPES,
+  buildAreaMoveLogEntry,
+} from "./activityLog";
+import { buildProjectPatchLogEntries } from "./projectChanges";
+
+function makeProject(
+  overrides: Partial<Doc<"projects">> = {},
+): Doc<"projects"> {
+  return {
+    _id: "project1" as Id<"projects">,
+    _creationTime: 0,
+    userId: "user1",
+    name: "Renew passport",
+    slug: "renew-passport",
+    areaId: "area1" as Id<"areas">,
+    order: 0,
+    state: "active",
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+describe("buildAreaMoveLogEntry", () => {
+  it("records the from and to Area names", () => {
+    expect(buildAreaMoveLogEntry("Health", "Finances")).toEqual({
+      type: "area_move",
+      content: 'Moved from "Health" to "Finances"',
+      previousValue: "Health",
+      newValue: "Finances",
+    });
+  });
+});
+
+describe("buildProjectPatchLogEntries area moves", () => {
+  it("records an Area move when the thread changes Areas", () => {
+    const logs = buildProjectPatchLogEntries(
+      makeProject({ areaId: "area1" as Id<"areas"> }),
+      { areaId: "area2" as Id<"areas"> },
+      { fromAreaName: "Health", toAreaName: "Finances" },
+    );
+
+    expect(logs).toEqual([
+      {
+        type: "area_move",
+        content: 'Moved from "Health" to "Finances"',
+        previousValue: "Health",
+        newValue: "Finances",
+      },
+    ]);
+  });
+
+  it("does not record an Area move when the Area stays the same", () => {
+    const logs = buildProjectPatchLogEntries(
+      makeProject({ areaId: "area1" as Id<"areas"> }),
+      { areaId: "area1" as Id<"areas"> },
+      { fromAreaName: "Health", toAreaName: "Health" },
+    );
+
+    expect(logs).toEqual([]);
+  });
+});
+
+describe("Area Condition", () => {
+  it("is not modeled as a thread activity log entry type", () => {
+    expect(AUTO_ACTIVITY_LOG_ENTRY_TYPES).not.toContain("condition_change");
+  });
+});

--- a/apps/web/convex/lib/activityLog.ts
+++ b/apps/web/convex/lib/activityLog.ts
@@ -1,0 +1,38 @@
+export type ActivityLogEntryType =
+  | "note"
+  | "status_change"
+  | "next_action_change"
+  | "state_change"
+  | "decision"
+  | "reference"
+  | "waiting_change"
+  | "area_move";
+
+export const AUTO_ACTIVITY_LOG_ENTRY_TYPES = [
+  "status_change",
+  "next_action_change",
+  "state_change",
+  "decision",
+  "reference",
+  "waiting_change",
+  "area_move",
+] as const satisfies readonly Exclude<ActivityLogEntryType, "note">[];
+
+export type AutoActivityLogEntry = {
+  type: (typeof AUTO_ACTIVITY_LOG_ENTRY_TYPES)[number];
+  content: string;
+  previousValue?: string;
+  newValue?: string;
+};
+
+export function buildAreaMoveLogEntry(
+  fromAreaName: string,
+  toAreaName: string,
+): AutoActivityLogEntry {
+  return {
+    type: "area_move",
+    content: `Moved from "${fromAreaName}" to "${toAreaName}"`,
+    previousValue: fromAreaName,
+    newValue: toAreaName,
+  };
+}

--- a/apps/web/convex/lib/projectChanges.ts
+++ b/apps/web/convex/lib/projectChanges.ts
@@ -1,5 +1,9 @@
 import type { GenericMutationCtx } from "convex/server";
 import type { DataModel, Doc, Id } from "../_generated/dataModel";
+import {
+  type AutoActivityLogEntry,
+  buildAreaMoveLogEntry,
+} from "./activityLog";
 
 type MutationCtx = GenericMutationCtx<DataModel>;
 
@@ -24,16 +28,7 @@ type ProjectPatch = Partial<
   >
 >;
 
-type AutoProjectLog = {
-  type:
-    | "status_change"
-    | "next_action_change"
-    | "state_change"
-    | "waiting_change";
-  content: string;
-  previousValue?: string;
-  newValue?: string;
-};
+type AutoProjectLog = AutoActivityLogEntry;
 
 function hasOwn(obj: object, key: PropertyKey): boolean {
   return Object.keys(obj).includes(String(key));
@@ -42,8 +37,19 @@ function hasOwn(obj: object, key: PropertyKey): boolean {
 export function buildProjectPatchLogEntries(
   project: Doc<"projects">,
   patch: ProjectPatch,
+  options?: { fromAreaName?: string; toAreaName?: string },
 ): AutoProjectLog[] {
   const logs: AutoProjectLog[] = [];
+
+  if (
+    hasOwn(patch, "areaId") &&
+    patch.areaId !== undefined &&
+    patch.areaId !== project.areaId &&
+    options?.fromAreaName &&
+    options?.toAreaName
+  ) {
+    logs.push(buildAreaMoveLogEntry(options.fromAreaName, options.toAreaName));
+  }
 
   if (
     hasOwn(patch, "status") &&
@@ -148,10 +154,30 @@ export async function applyProjectPatch(
     patch: ProjectPatch;
   },
 ): Promise<void> {
+  let areaMoveNames: { fromAreaName: string; toAreaName: string } | undefined;
+
+  if (
+    args.patch.areaId !== undefined &&
+    args.patch.areaId !== args.project.areaId
+  ) {
+    const fromArea = await ctx.db.get(args.project.areaId);
+    const toArea = await ctx.db.get(args.patch.areaId);
+    if (fromArea && toArea) {
+      areaMoveNames = {
+        fromAreaName: fromArea.name,
+        toAreaName: toArea.name,
+      };
+    }
+  }
+
   await ctx.db.patch(args.project._id, args.patch);
 
   const now = Date.now();
-  const logs = buildProjectPatchLogEntries(args.project, args.patch);
+  const logs = buildProjectPatchLogEntries(
+    args.project,
+    args.patch,
+    areaMoveNames,
+  );
   for (const log of logs) {
     await insertAutoProjectLog(ctx, {
       userId: args.userId,

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -75,6 +75,7 @@ export default defineSchema({
       v.literal("decision"),
       v.literal("reference"),
       v.literal("waiting_change"),
+      v.literal("area_move"),
     ),
     content: v.string(),
     previousValue: v.optional(v.string()),

--- a/apps/web/src/features/projects/activity-log-entry.test.ts
+++ b/apps/web/src/features/projects/activity-log-entry.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { getActivityLogEntryLabel } from "./activity-log-entry";
+
+describe("getActivityLogEntryLabel", () => {
+  it("uses user-facing labels instead of implementation type names", () => {
+    expect(getActivityLogEntryLabel("note")).toBe("Note");
+    expect(getActivityLogEntryLabel("status_change")).toBe("Status");
+    expect(getActivityLogEntryLabel("next_action_change")).toBe("Next move");
+    expect(getActivityLogEntryLabel("state_change")).toBe("Lifecycle");
+    expect(getActivityLogEntryLabel("area_move")).toBe("Area");
+    expect(getActivityLogEntryLabel("decision")).toBe("Decision");
+    expect(getActivityLogEntryLabel("reference")).toBe("Reference");
+    expect(getActivityLogEntryLabel("waiting_change")).toBe("Waiting");
+  });
+});

--- a/apps/web/src/features/projects/activity-log-entry.ts
+++ b/apps/web/src/features/projects/activity-log-entry.ts
@@ -1,0 +1,18 @@
+import type { Doc } from "@convex/_generated/dataModel";
+
+type ActivityLogType = Doc<"projectLogs">["type"];
+
+const ACTIVITY_LOG_ENTRY_LABELS: Record<ActivityLogType, string> = {
+  note: "Note",
+  status_change: "Status",
+  next_action_change: "Next move",
+  state_change: "Lifecycle",
+  decision: "Decision",
+  reference: "Reference",
+  waiting_change: "Waiting",
+  area_move: "Area",
+};
+
+export function getActivityLogEntryLabel(type: ActivityLogType): string {
+  return ACTIVITY_LOG_ENTRY_LABELS[type];
+}

--- a/apps/web/src/features/projects/components/project-log-section.tsx
+++ b/apps/web/src/features/projects/components/project-log-section.tsx
@@ -1,7 +1,7 @@
 import { api } from "@convex/_generated/api";
 import { useQuery } from "convex-helpers/react/cache/hooks";
-import { useCreateProjectLog } from "@/features/projects/use-create-project-log";
 import { useStableQuery } from "@/hooks/use-stable-query";
+import { useCreateProjectLog } from "../use-create-project-log";
 import { ProjectLog } from "./project-log";
 
 interface ProjectLogSectionProps {

--- a/apps/web/src/features/projects/components/project-log.test.tsx
+++ b/apps/web/src/features/projects/components/project-log.test.tsx
@@ -1,0 +1,100 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ProjectLog } from "./project-log";
+
+const now = new Date("2026-05-19T12:00:00Z").getTime();
+
+const note = {
+  _id: "log1" as Id<"projectLogs">,
+  _creationTime: 0,
+  userId: "user1",
+  projectId: "project1" as Id<"projects">,
+  type: "note",
+  content: "Called the clinic",
+  createdAt: now,
+} satisfies Doc<"projectLogs">;
+
+const areaMove = {
+  _id: "log2" as Id<"projectLogs">,
+  _creationTime: 0,
+  userId: "user1",
+  projectId: "project1" as Id<"projects">,
+  type: "area_move",
+  content: 'Moved from "Health" to "Finances"',
+  createdAt: now - 60_000,
+} satisfies Doc<"projectLogs">;
+
+describe("ProjectLog", () => {
+  it("shows Activity Log language and user-facing entry labels", () => {
+    render(<ProjectLog logs={[note, areaMove]} onAddNote={vi.fn()} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Activity log" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Called the clinic")).toBeInTheDocument();
+    expect(
+      screen.getByText('Moved from "Health" to "Finances"'),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Area")).toBeInTheDocument();
+    expect(screen.queryByText("area_move")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: "Activity log note" }),
+    ).toBeInTheDocument();
+  });
+
+  it("submits a trimmed note and clears the field", async () => {
+    const user = userEvent.setup();
+    const onAddNote = vi.fn();
+
+    render(<ProjectLog logs={[]} onAddNote={onAddNote} />);
+
+    const noteInput = screen.getByRole("textbox", {
+      name: "Activity log note",
+    });
+    await user.type(noteInput, "  Called the clinic  ");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(onAddNote).toHaveBeenCalledWith("Called the clinic");
+    expect(noteInput).toHaveValue("");
+  });
+
+  it("does not submit empty notes", async () => {
+    const user = userEvent.setup();
+    const onAddNote = vi.fn();
+
+    render(<ProjectLog logs={[]} onAddNote={onAddNote} />);
+
+    const addButton = screen.getByRole("button", { name: "Add" });
+    expect(addButton).toBeDisabled();
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Activity log note" }),
+      "   ",
+    );
+
+    expect(addButton).toBeDisabled();
+    expect(onAddNote).not.toHaveBeenCalled();
+  });
+
+  it("submits with Enter while preserving Shift+Enter line breaks", async () => {
+    const user = userEvent.setup();
+    const onAddNote = vi.fn();
+
+    render(<ProjectLog logs={[]} onAddNote={onAddNote} />);
+
+    const noteInput = screen.getByRole("textbox", {
+      name: "Activity log note",
+    });
+    await user.type(noteInput, "Line one");
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    await user.type(noteInput, "Line two");
+    expect(noteInput).toHaveValue("Line one\nLine two");
+
+    await user.keyboard("{Enter}");
+
+    expect(onAddNote).toHaveBeenCalledWith("Line one\nLine two");
+    expect(noteInput).toHaveValue("");
+  });
+});

--- a/apps/web/src/features/projects/components/project-log.tsx
+++ b/apps/web/src/features/projects/components/project-log.tsx
@@ -5,6 +5,7 @@ import { Textarea } from "@vita-os/ui/components/textarea";
 import { formatDistanceToNow } from "date-fns";
 import { MessageSquare, Pen } from "lucide-react";
 import { type FormEvent, type KeyboardEvent, useState } from "react";
+import { getActivityLogEntryLabel } from "@/features/projects/activity-log-entry";
 
 interface ProjectLogProps {
   logs: Doc<"projectLogs">[] | undefined;
@@ -40,7 +41,7 @@ export function ProjectLog({ logs, onAddNote }: ProjectLogProps) {
         <div className="flex h-6 w-6 items-center justify-center rounded-md bg-surface-3">
           <MessageSquare className="h-3.5 w-3.5 text-muted-foreground" />
         </div>
-        <h2 className="text-sm font-medium">Activity</h2>
+        <h2 className="text-sm font-medium">Activity log</h2>
         {logs && logs.length > 0 && (
           <span className="text-xs text-muted-foreground">{logs.length}</span>
         )}
@@ -50,7 +51,8 @@ export function ProjectLog({ logs, onAddNote }: ProjectLogProps) {
         <Textarea
           value={noteText}
           onChange={(event) => setNoteText(event.target.value)}
-          placeholder="Add a note..."
+          aria-label="Activity log note"
+          placeholder="Add to activity log..."
           className="min-h-9 bg-surface-2"
           rows={1}
           onKeyDown={handleNoteKeyDown}
@@ -119,6 +121,9 @@ function ProjectLogTimeline({
         ) : (
           <div key={log._id} className="relative py-1.5 pl-8">
             <div className="absolute left-[7px] top-[13px] h-3 w-3 rounded-full border-2 border-border/60 bg-surface-1" />
+            <p className="text-xs font-medium text-muted-foreground">
+              {getActivityLogEntryLabel(log.type)}
+            </p>
             <p className="text-xs text-muted-foreground italic">
               {log.content}
             </p>

--- a/apps/web/src/features/projects/components/thread-area-section-section.tsx
+++ b/apps/web/src/features/projects/components/thread-area-section-section.tsx
@@ -1,0 +1,47 @@
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { useNavigate } from "@tanstack/react-router";
+import { useQuery } from "convex-helpers/react/cache/hooks";
+import { ThreadAreaSection } from "@/features/projects/components/thread-area-section";
+import { useUpdateProject } from "@/features/projects/use-update-project";
+import { useStableQuery } from "@/hooks/use-stable-query";
+
+interface ThreadAreaSectionSectionProps {
+  areaSlug: string;
+  projectSlug: string;
+}
+
+export function ThreadAreaSectionSection({
+  areaSlug,
+  projectSlug,
+}: ThreadAreaSectionSectionProps) {
+  const areas = useQuery(api.areas.list);
+  const project = useStableQuery(api.projects.getBySlug, {
+    slug: projectSlug,
+  });
+  const navigate = useNavigate();
+  const updateProject = useUpdateProject(projectSlug);
+
+  if (!areas || !project) return null;
+
+  const handleMove = async (areaId: Id<"areas">) => {
+    if (areaId === project.areaId) return;
+
+    await updateProject({ id: project._id, areaId });
+    const targetArea = areas.find((area) => area._id === areaId);
+    if (!targetArea) return;
+
+    const nextAreaSlug = targetArea.slug ?? targetArea._id;
+    if (nextAreaSlug !== areaSlug) {
+      navigate({
+        to: "/$areaSlug/$projectSlug",
+        params: { areaSlug: nextAreaSlug, projectSlug },
+        replace: true,
+      });
+    }
+  };
+
+  return (
+    <ThreadAreaSection areas={areas} project={project} onMove={handleMove} />
+  );
+}

--- a/apps/web/src/features/projects/components/thread-area-section.test.tsx
+++ b/apps/web/src/features/projects/components/thread-area-section.test.tsx
@@ -1,0 +1,74 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { ThreadAreaSection } from "./thread-area-section";
+
+const healthArea = {
+  _id: "area1" as Id<"areas">,
+  _creationTime: 0,
+  userId: "user1",
+  name: "Health",
+  slug: "health",
+  healthStatus: "healthy",
+  order: 0,
+  createdAt: 0,
+} satisfies Doc<"areas">;
+
+const financesArea = {
+  _id: "area2" as Id<"areas">,
+  _creationTime: 0,
+  userId: "user1",
+  name: "Finances",
+  slug: "finances",
+  healthStatus: "healthy",
+  order: 1,
+  createdAt: 0,
+} satisfies Doc<"areas">;
+
+const project = {
+  _id: "project1" as Id<"projects">,
+  _creationTime: 0,
+  userId: "user1",
+  name: "Renew passport",
+  slug: "renew-passport",
+  areaId: healthArea._id,
+  state: "active",
+  order: 0,
+  createdAt: 0,
+} satisfies Doc<"projects">;
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ??
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+});
+
+describe("ThreadAreaSection", () => {
+  it("lets the user move a thread to another area", async () => {
+    const user = userEvent.setup();
+    const onMove = vi.fn();
+
+    render(
+      <ThreadAreaSection
+        areas={[healthArea, financesArea]}
+        project={project}
+        onMove={onMove}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Health" }));
+    await user.click(screen.getByRole("button", { name: "Finances" }));
+
+    expect(onMove).toHaveBeenCalledWith(financesArea._id);
+  });
+});

--- a/apps/web/src/features/projects/components/thread-area-section.tsx
+++ b/apps/web/src/features/projects/components/thread-area-section.tsx
@@ -1,0 +1,31 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+import { Compass } from "lucide-react";
+import { AreaPicker } from "@/features/areas/components/area-picker";
+
+interface ThreadAreaSectionProps {
+  areas: Doc<"areas">[];
+  project: Doc<"projects">;
+  onMove: (areaId: Id<"areas">) => void;
+}
+
+export function ThreadAreaSection({
+  areas,
+  project,
+  onMove,
+}: ThreadAreaSectionProps) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="flex w-36 shrink-0 items-center gap-2 pt-1 text-xs text-muted-foreground">
+        <Compass className="h-3.5 w-3.5" />
+        Area
+      </div>
+      <div className="min-w-0 flex-1">
+        <AreaPicker
+          areas={areas}
+          selectedAreaId={project.areaId}
+          onSelect={(id) => onMove(id as Id<"areas">)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/projects/optimistic.ts
+++ b/apps/web/src/features/projects/optimistic.ts
@@ -112,6 +112,35 @@ export function optimisticallyUpdateProject(
       { ...bySlug, ...patch },
     );
   }
+
+  if (patch.areaId !== undefined && bySlug !== undefined && bySlug !== null) {
+    const previousAreaId = bySlug.areaId;
+    if (previousAreaId !== patch.areaId) {
+      const previousAreaProjects = localStore.getQuery(
+        api.projects.listByArea,
+        {
+          areaId: previousAreaId,
+        },
+      );
+      if (previousAreaProjects !== undefined) {
+        localStore.setQuery(
+          api.projects.listByArea,
+          { areaId: previousAreaId },
+          removeById(previousAreaProjects, id),
+        );
+      }
+
+      const nextAreaProjects = localStore.getQuery(api.projects.listByArea, {
+        areaId: patch.areaId,
+      });
+      if (nextAreaProjects !== undefined) {
+        localStore.setQuery(api.projects.listByArea, { areaId: patch.areaId }, [
+          ...nextAreaProjects,
+          { ...bySlug, ...patch },
+        ]);
+      }
+    }
+  }
 }
 
 export function optimisticallyRemoveProject(

--- a/apps/web/src/features/projects/project-detail/project-detail-screen.tsx
+++ b/apps/web/src/features/projects/project-detail/project-detail-screen.tsx
@@ -6,6 +6,7 @@ import { ProjectHeaderSection } from "@/features/projects/components/project-hea
 import { ProjectLifecycleActionsSection } from "@/features/projects/components/project-lifecycle-actions-section";
 import { ProjectLogSection } from "@/features/projects/components/project-log-section";
 import { ProjectStatusCardSection } from "@/features/projects/components/project-status-card-section";
+import { ThreadAreaSectionSection } from "@/features/projects/components/thread-area-section-section";
 import { useDocumentTitle } from "@/hooks/use-document-title";
 import { useStableQuery } from "@/hooks/use-stable-query";
 import { ProjectNotFound } from "./project-not-found";
@@ -37,6 +38,8 @@ export function ProjectDetailScreen({
   return (
     <div className="mx-auto max-w-3xl space-y-8">
       <ProjectHeaderSection areaSlug={areaSlug} projectSlug={projectSlug} />
+
+      <ThreadAreaSectionSection areaSlug={areaSlug} projectSlug={projectSlug} />
 
       <ProjectStatusCardSection projectSlug={projectSlug} />
 


### PR DESCRIPTION
## Summary
- Log thread area moves as activity log entries with readable from/to area names
- Present activity log UI with user-facing entry labels instead of implementation types
- Let users move a thread to another area from thread detail, with optimistic list updates

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`

Closes #149

Made with [Cursor](https://cursor.com)