### PR TITLE
feat(threads): add follow-up date with activity logging

### DIFF
--- a/apps/web/convex/lib/activityLog.ts
+++ b/apps/web/convex/lib/activityLog.ts
@@ -6,6 +6,7 @@ export type ActivityLogEntryType =
   | "decision"
   | "reference"
   | "waiting_change"
+  | "follow_up_change"
   | "area_move";
 
 export const AUTO_ACTIVITY_LOG_ENTRY_TYPES = [
@@ -15,6 +16,7 @@ export const AUTO_ACTIVITY_LOG_ENTRY_TYPES = [
   "decision",
   "reference",
   "waiting_change",
+  "follow_up_change",
   "area_move",
 ] as const satisfies readonly Exclude<ActivityLogEntryType, "note">[];
 

--- a/apps/web/convex/lib/inboxProcessing.ts
+++ b/apps/web/convex/lib/inboxProcessing.ts
@@ -2,6 +2,7 @@ import type { GenericMutationCtx } from "convex/server";
 import type { DataModel, Doc, Id } from "../_generated/dataModel";
 import { getAreaForUser } from "./areaProjects";
 import { getNextOrder } from "./helpers";
+import { applyProjectPatch } from "./projectChanges";
 import { generateSlug } from "./slugs";
 
 type MutationCtx = GenericMutationCtx<DataModel>;
@@ -105,7 +106,11 @@ export async function processInboxItem(
       projectId: args.action.projectId,
     });
 
-    await ctx.db.patch(project._id, { nextMove: args.item.text });
+    await applyProjectPatch(ctx, {
+      userId: args.userId,
+      project,
+      patch: { nextMove: args.item.text },
+    });
     await ctx.db.delete(args.item._id);
     return { type: "set_next_action" };
   }

--- a/apps/web/convex/lib/projectChanges.test.ts
+++ b/apps/web/convex/lib/projectChanges.test.ts
@@ -127,6 +127,67 @@ describe("buildProjectPatchLogEntries", () => {
       },
     ]);
   });
+
+  describe("followUp", () => {
+    const may20 = new Date("2026-05-20").getTime();
+    const jun1 = new Date("2026-06-01").getTime();
+
+    it("logs when setting a follow-up from empty", () => {
+      const logs = buildProjectPatchLogEntries(makeProject(), {
+        followUp: may20,
+      });
+
+      expect(logs).toEqual([
+        {
+          type: "follow_up_change",
+          content: 'Follow-up set to "May 20, 2026"',
+          previousValue: undefined,
+          newValue: "May 20, 2026",
+        },
+      ]);
+    });
+
+    it("logs when changing an existing follow-up", () => {
+      const logs = buildProjectPatchLogEntries(
+        makeProject({ followUp: may20 } satisfies Partial<Doc<"projects">>),
+        { followUp: jun1 },
+      );
+
+      expect(logs).toEqual([
+        {
+          type: "follow_up_change",
+          content: 'Follow-up changed from "May 20, 2026" to "Jun 1, 2026"',
+          previousValue: "May 20, 2026",
+          newValue: "Jun 1, 2026",
+        },
+      ]);
+    });
+
+    it("logs when clearing a follow-up", () => {
+      const logs = buildProjectPatchLogEntries(
+        makeProject({ followUp: may20 } satisfies Partial<Doc<"projects">>),
+        { followUp: undefined },
+      );
+
+      expect(logs).toEqual([
+        {
+          type: "follow_up_change",
+          content: "Follow-up cleared",
+          previousValue: "May 20, 2026",
+          newValue: undefined,
+        },
+      ]);
+    });
+
+    it("does not log when follow-up stays the same", () => {
+      const logs = buildProjectPatchLogEntries(
+        makeProject({ followUp: may20 } satisfies Partial<Doc<"projects">>),
+        { followUp: may20 },
+      );
+
+      expect(logs).toEqual([]);
+    });
+  });
 });
 
 describe("buildCompleteNextMoveChange", () => {

--- a/apps/web/convex/lib/projectChanges.ts
+++ b/apps/web/convex/lib/projectChanges.ts
@@ -16,6 +16,7 @@ type ProjectPatch = Partial<
     | "areaId"
     | "status"
     | "nextMove"
+    | "followUp"
     | "state"
     | "actionDate"
     | "targetDate"
@@ -30,6 +31,51 @@ type AutoProjectLog = AutoActivityLogEntry;
 
 function hasOwn(obj: object, key: PropertyKey): boolean {
   return Object.keys(obj).includes(String(key));
+}
+
+function formatFollowUpDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function buildFieldChangeLogEntry(options: {
+  type: AutoProjectLog["type"];
+  oldValue: string | undefined;
+  newValue: string | undefined;
+  label: string;
+}): AutoProjectLog | null {
+  const { type, oldValue, newValue, label } = options;
+  if (oldValue === newValue) return null;
+
+  if (oldValue && newValue) {
+    return {
+      type,
+      content: `${label} changed from "${oldValue}" to "${newValue}"`,
+      previousValue: oldValue,
+      newValue,
+    };
+  }
+  if (!oldValue && newValue) {
+    return {
+      type,
+      content: `${label} set to "${newValue}"`,
+      previousValue: undefined,
+      newValue,
+    };
+  }
+  if (oldValue && !newValue) {
+    return {
+      type,
+      content: `${label} cleared`,
+      previousValue: oldValue,
+      newValue: undefined,
+    };
+  }
+  return null;
 }
 
 export function buildProjectPatchLogEntries(
@@ -66,33 +112,13 @@ export function buildProjectPatchLogEntries(
   }
 
   if (hasOwn(patch, "nextMove")) {
-    const oldNextMove = project.nextMove ?? undefined;
-    const newNextMove = patch.nextMove ?? undefined;
-
-    if (oldNextMove !== newNextMove) {
-      if (oldNextMove && newNextMove) {
-        logs.push({
-          type: "next_action_change",
-          content: `Next move changed from "${oldNextMove}" to "${newNextMove}"`,
-          previousValue: oldNextMove,
-          newValue: newNextMove,
-        });
-      } else if (!oldNextMove && newNextMove) {
-        logs.push({
-          type: "next_action_change",
-          content: `Next move set to "${newNextMove}"`,
-          previousValue: undefined,
-          newValue: newNextMove,
-        });
-      } else if (oldNextMove && !newNextMove) {
-        logs.push({
-          type: "next_action_change",
-          content: `Next move cleared`,
-          previousValue: oldNextMove,
-          newValue: undefined,
-        });
-      }
-    }
+    const entry = buildFieldChangeLogEntry({
+      type: "next_action_change",
+      oldValue: project.nextMove ?? undefined,
+      newValue: patch.nextMove ?? undefined,
+      label: "Next move",
+    });
+    if (entry) logs.push(entry);
   }
 
   if (
@@ -106,6 +132,27 @@ export function buildProjectPatchLogEntries(
       previousValue: project.state,
       newValue: patch.state,
     });
+  }
+
+  if (hasOwn(patch, "followUp")) {
+    const oldFollowUp = project.followUp ?? undefined;
+    const newFollowUp = patch.followUp ?? undefined;
+
+    if (oldFollowUp !== newFollowUp) {
+      const entry = buildFieldChangeLogEntry({
+        type: "follow_up_change",
+        oldValue:
+          oldFollowUp !== undefined
+            ? formatFollowUpDate(oldFollowUp)
+            : undefined,
+        newValue:
+          newFollowUp !== undefined
+            ? formatFollowUpDate(newFollowUp)
+            : undefined,
+        label: "Follow-up",
+      });
+      if (entry) logs.push(entry);
+    }
   }
 
   return logs;

--- a/apps/web/convex/projects.ts
+++ b/apps/web/convex/projects.ts
@@ -98,6 +98,7 @@ export const update = mutation({
     areaId: v.optional(v.id("areas")),
     status: v.optional(v.union(v.string(), v.null())),
     nextMove: v.optional(v.union(v.string(), v.null())),
+    followUp: v.optional(v.union(v.number(), v.null())),
     state: v.optional(
       v.union(
         v.literal("active"),

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -30,6 +30,7 @@ export default defineSchema({
     ),
     status: v.optional(v.string()),
     nextMove: v.optional(v.string()),
+    followUp: v.optional(v.number()),
     /** @deprecated Replaced by nextMove — retained for migration (#158) */
     actionQueue: v.optional(
       v.array(v.object({ id: v.string(), text: v.string() })),
@@ -77,6 +78,7 @@ export default defineSchema({
       v.literal("decision"),
       v.literal("reference"),
       v.literal("waiting_change"),
+      v.literal("follow_up_change"),
       v.literal("area_move"),
     ),
     content: v.string(),

--- a/apps/web/src/features/projects/activity-log-entry.test.ts
+++ b/apps/web/src/features/projects/activity-log-entry.test.ts
@@ -11,5 +11,6 @@ describe("getActivityLogEntryLabel", () => {
     expect(getActivityLogEntryLabel("decision")).toBe("Decision");
     expect(getActivityLogEntryLabel("reference")).toBe("Reference");
     expect(getActivityLogEntryLabel("waiting_change")).toBe("Waiting");
+    expect(getActivityLogEntryLabel("follow_up_change")).toBe("Follow-up");
   });
 });

--- a/apps/web/src/features/projects/activity-log-entry.ts
+++ b/apps/web/src/features/projects/activity-log-entry.ts
@@ -10,6 +10,7 @@ const ACTIVITY_LOG_ENTRY_LABELS: Record<ActivityLogType, string> = {
   decision: "Decision",
   reference: "Reference",
   waiting_change: "Waiting",
+  follow_up_change: "Follow-up",
   area_move: "Area",
 };
 

--- a/apps/web/src/features/projects/components/follow-up-section.tsx
+++ b/apps/web/src/features/projects/components/follow-up-section.tsx
@@ -1,0 +1,33 @@
+import { api } from "@convex/_generated/api";
+import { useUpdateProject } from "@/features/projects/use-update-project";
+import { useStableQuery } from "@/hooks/use-stable-query";
+import { FollowUp } from "./follow-up";
+
+interface FollowUpSectionProps {
+  projectSlug: string;
+}
+
+export function FollowUpSection({ projectSlug }: FollowUpSectionProps) {
+  const project = useStableQuery(api.projects.getBySlug, {
+    slug: projectSlug,
+  });
+  const updateProject = useUpdateProject(projectSlug);
+
+  const handleSet = (date: number) => {
+    if (!project) return;
+    updateProject({ id: project._id, followUp: date });
+  };
+
+  const handleClear = () => {
+    if (!project) return;
+    updateProject({ id: project._id, followUp: null });
+  };
+
+  return (
+    <FollowUp
+      followUp={project?.followUp ?? undefined}
+      onSet={handleSet}
+      onClear={handleClear}
+    />
+  );
+}

--- a/apps/web/src/features/projects/components/follow-up.tsx
+++ b/apps/web/src/features/projects/components/follow-up.tsx
@@ -1,0 +1,31 @@
+import { DatePicker } from "@vita-os/ui/components/date-picker";
+import { Bell } from "lucide-react";
+
+interface FollowUpProps {
+  followUp: number | undefined;
+  onSet: (date: number) => void;
+  onClear: () => void;
+}
+
+export function FollowUp({ followUp, onSet, onClear }: FollowUpProps) {
+  return (
+    <div className="rounded-xl border border-border-subtle bg-surface-2 p-4">
+      <div className="mb-3 flex items-center gap-2 text-xs font-medium text-muted-foreground">
+        <Bell className="h-3.5 w-3.5" />
+        Follow-up
+      </div>
+
+      <DatePicker
+        value={followUp ? new Date(followUp) : undefined}
+        onChange={(date) => {
+          if (date) {
+            onSet(date.getTime());
+          } else {
+            onClear();
+          }
+        }}
+        placeholder="Add a follow-up..."
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/projects/components/next-move.tsx
+++ b/apps/web/src/features/projects/components/next-move.tsx
@@ -96,7 +96,7 @@ function NextMoveItem({
   };
 
   return (
-    <div className="flex items-center gap-2 rounded-lg bg-surface-3/60 px-2 py-1.5">
+    <div className="group flex items-center gap-2 rounded-lg bg-surface-3/60 px-2 py-1.5">
       <Button
         variant="ghost"
         size="icon-xs"

--- a/apps/web/src/features/projects/optimistic.ts
+++ b/apps/web/src/features/projects/optimistic.ts
@@ -19,7 +19,13 @@ type NullablePatch<T> = {
 type ProjectPatch = NullablePatch<
   Pick<
     Project,
-    "name" | "definitionOfDone" | "areaId" | "status" | "nextMove" | "state"
+    | "name"
+    | "definitionOfDone"
+    | "areaId"
+    | "status"
+    | "nextMove"
+    | "followUp"
+    | "state"
   >
 >;
 

--- a/apps/web/src/features/projects/project-detail/project-detail-screen.tsx
+++ b/apps/web/src/features/projects/project-detail/project-detail-screen.tsx
@@ -1,4 +1,5 @@
 import { api } from "@convex/_generated/api";
+import { FollowUpSection } from "@/features/projects/components/follow-up-section";
 import { NextMoveSection } from "@/features/projects/components/next-move-section";
 import { ProjectDefinitionSection } from "@/features/projects/components/project-definition-section";
 import { ProjectDetailSkeleton } from "@/features/projects/components/project-detail-skeleton";
@@ -44,6 +45,8 @@ export function ProjectDetailScreen({
       <ProjectStatusCardSection projectSlug={projectSlug} />
 
       <NextMoveSection projectSlug={projectSlug} />
+
+      <FollowUpSection projectSlug={projectSlug} />
 
       <ProjectDefinitionSection projectSlug={projectSlug} />
 

--- a/apps/web/src/features/projects/use-update-project.ts
+++ b/apps/web/src/features/projects/use-update-project.ts
@@ -10,6 +10,7 @@ export type UpdateProjectValue = {
   areaId?: Id<"areas">;
   status?: string | null;
   nextMove?: string | null;
+  followUp?: number | null;
   state?: "active" | "completed" | "dropped";
 };
 


### PR DESCRIPTION
## Summary
- Add a follow-up date field to threads with a date picker on the thread detail screen
- Record follow-up set, change, and clear events in the activity log
- Restore activity logging when inbox processing sets a next move
- Fix the next-move clear button hover reveal and extract shared field-change log helper

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`

Made with [Cursor](https://cursor.com)