### PR TITLE
feat(dashboard): surface due tasks and inbox summary

### DIFF
--- a/apps/web/src/features/dashboard/components/recent-items-list.test.tsx
+++ b/apps/web/src/features/dashboard/components/recent-items-list.test.tsx
@@ -23,6 +23,7 @@ function item(
   text: string,
   createdAt: number,
   isCompleted = false,
+  date?: number,
 ): Doc<"items"> {
   return {
     _id: id as Id<"items">,
@@ -31,12 +32,68 @@ function item(
     text,
     isCompleted,
     createdAt,
+    date,
     completedAt: isCompleted ? createdAt + 1 : undefined,
   };
 }
 
 describe("RecentItemsList", () => {
-  it("shows at most five recent Open Tasks as a read-only list", () => {
+  const may18_2026 = new Date(2026, 4, 18, 12).getTime();
+  const may19_2026 = new Date(2026, 4, 19, 12).getTime();
+
+  it("surfaces Open Tasks with When today or earlier as due Tasks", () => {
+    render(
+      <RecentItemsList
+        items={[
+          item("item1", "Call clinic", 3, false, may18_2026),
+          item("item2", "Renew passport", 2, false, may19_2026),
+          item("item3", "Pay utility bill", 1, false, may18_2026 - 86_400_000),
+        ]}
+        referenceDate={may18_2026}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: /due tasks/i })).toBeVisible();
+    expect(screen.getByText("Call clinic")).toBeInTheDocument();
+    expect(screen.getByText("Pay utility bill")).toBeInTheDocument();
+    expect(screen.queryByText("Renew passport")).not.toBeInTheDocument();
+  });
+
+  it("summarizes remaining Open Tasks without counting Done Tasks", () => {
+    render(
+      <RecentItemsList
+        items={[
+          item("item1", "Call clinic", 4, false, may18_2026),
+          item("item2", "Renew passport", 3, false, may19_2026),
+          item("item3", "Sort receipts", 2),
+          item("item4", "Archived errand", 1, true),
+        ]}
+        referenceDate={may18_2026}
+      />,
+    );
+
+    expect(screen.getByText("2 more Open Tasks in Inbox")).toBeVisible();
+  });
+
+  it("summarizes Open Tasks instead of rendering the full Inbox when none are due", () => {
+    render(
+      <RecentItemsList
+        items={[
+          item("item1", "Renew passport", 3, false, may19_2026),
+          item("item2", "Sort receipts", 2),
+          item("item3", "Archived errand", 1, true),
+        ]}
+        referenceDate={may18_2026}
+      />,
+    );
+
+    expect(screen.getByText("2 Open Tasks in Inbox")).toBeVisible();
+    expect(screen.queryByText("Renew passport")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sort receipts")).not.toBeInTheDocument();
+    expect(screen.queryByText("Archived errand")).not.toBeInTheDocument();
+  });
+
+  it("keeps the Dashboard Task surface read-only with full handling in Inbox", () => {
     render(
       <RecentItemsList
         items={[
@@ -51,8 +108,9 @@ describe("RecentItemsList", () => {
       />,
     );
 
-    expect(screen.getByText("First active item")).toBeInTheDocument();
-    expect(screen.getByText("Fifth active item")).toBeInTheDocument();
+    expect(screen.getByText("6 Open Tasks in Inbox")).toBeVisible();
+    expect(screen.queryByText("First active item")).not.toBeInTheDocument();
+    expect(screen.queryByText("Fifth active item")).not.toBeInTheDocument();
     expect(screen.queryByText("Completed item")).not.toBeInTheDocument();
     expect(screen.queryByText("Sixth active item")).not.toBeInTheDocument();
 

--- a/apps/web/src/features/dashboard/components/recent-items-list.tsx
+++ b/apps/web/src/features/dashboard/components/recent-items-list.tsx
@@ -7,16 +7,29 @@ import {
 } from "@vita-os/ui/components/item";
 import { format, formatDistanceToNow } from "date-fns";
 import { ArrowRight, Inbox } from "lucide-react";
+import { isTaskWhenDue } from "@/features/tasks/inbox";
 
 const MAX_VISIBLE = 5;
 
 interface RecentItemsListProps {
   items: Doc<"items">[];
+  referenceDate?: number;
 }
 
-export function RecentItemsList({ items }: RecentItemsListProps) {
+export function RecentItemsList({
+  items,
+  referenceDate = Date.now(),
+}: RecentItemsListProps) {
   const activeItems = items.filter((item) => !item.isCompleted);
-  const visibleItems = activeItems.slice(0, MAX_VISIBLE);
+  const dueItems = activeItems.filter((item) =>
+    isTaskWhenDue(item.date, referenceDate),
+  );
+  const visibleItems = dueItems.slice(0, MAX_VISIBLE);
+  const remainingOpenCount = activeItems.length - visibleItems.length;
+  const hasDueItems = dueItems.length > 0;
+  const heading = hasDueItems ? "Due Tasks" : "Inbox";
+  const headingCount =
+    dueItems.length > 0 ? dueItems.length : activeItems.length;
 
   if (activeItems.length === 0) return null;
 
@@ -26,16 +39,28 @@ export function RecentItemsList({ items }: RecentItemsListProps) {
         <div className="flex h-6 w-6 items-center justify-center rounded-md bg-surface-3">
           <Inbox className="h-3.5 w-3.5 text-muted-foreground" />
         </div>
-        <h2 className="text-sm font-medium">Recent Tasks</h2>
-        <span className="text-xs text-muted-foreground">
-          {activeItems.length}
-        </span>
+        <h2 className="text-sm font-medium">{heading}</h2>
+        <span className="text-xs text-muted-foreground">{headingCount}</span>
       </div>
-      <div className="divide-y divide-border/50 rounded-xl border border-border-subtle bg-surface-2">
-        {visibleItems.map((item) => (
-          <RecentItemRow key={item._id} item={item} />
-        ))}
-      </div>
+      {hasDueItems && (
+        <div className="divide-y divide-border/50 rounded-xl border border-border-subtle bg-surface-2">
+          {visibleItems.map((item) => (
+            <RecentItemRow key={item._id} item={item} />
+          ))}
+        </div>
+      )}
+      {hasDueItems && remainingOpenCount > 0 && (
+        <p className="mt-3 text-xs text-muted-foreground">
+          {remainingOpenCount} more Open{" "}
+          {remainingOpenCount === 1 ? "Task" : "Tasks"} in Inbox
+        </p>
+      )}
+      {!hasDueItems && (
+        <p className="text-xs text-muted-foreground">
+          {activeItems.length} Open{" "}
+          {activeItems.length === 1 ? "Task" : "Tasks"} in Inbox
+        </p>
+      )}
       <div className="mt-3 flex justify-end">
         <Link
           to="/inbox"


### PR DESCRIPTION
## Summary
- Show Open Tasks with When today or earlier as due tasks on the dashboard (up to five)
- Summarize remaining open tasks when some are due, or all open tasks when none are due
- Keep the dashboard task surface read-only with full handling in Inbox

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run` (recent-items-list tests)

Closes #157 