### PR TITLE
Group dashboard threads by attention state and hide area cards on non-empty dashboards

### DIFF
--- a/apps/web/convex/dashboard.ts
+++ b/apps/web/convex/dashboard.ts
@@ -55,7 +55,7 @@ export const overview = query({
   args: {},
   handler: async (ctx) => {
     const userId = await safeGetAuthUserId(ctx);
-    if (!userId) return { areas: [], attentionItems: [] };
+    if (!userId) return { areas: [], attentionThreads: [] };
 
     const areas = await ctx.db
       .query("areas")
@@ -69,31 +69,35 @@ export const overview = query({
       .collect();
 
     const projectCounts: Record<string, number> = {};
-    const attentionCounts: Record<string, number> = {};
     const areaById = new Map(areas.map((area) => [area._id as string, area]));
-    const attentionItems: Array<{
+    const attentionThreads: Array<{
       projectId: string;
       projectName: string;
       projectSlug: string | undefined;
       areaId: string;
-      reason: "no_next_action";
+      lifecycle: "open";
+      nextMove: string | undefined;
+      followUp: number | undefined;
     }> = [];
 
     for (const project of activeProjects) {
       projectCounts[project.areaId] = (projectCounts[project.areaId] ?? 0) + 1;
 
-      const hasAction = project.nextMove != null;
-      if (!hasAction) {
-        attentionItems.push({
-          projectId: project._id,
-          projectName: project.name,
-          projectSlug: project.slug,
-          areaId: project.areaId,
-          reason: "no_next_action",
-        });
-        attentionCounts[project.areaId] =
-          (attentionCounts[project.areaId] ?? 0) + 1;
-      }
+      attentionThreads.push({
+        projectId: project._id,
+        projectName: project.name,
+        projectSlug: project.slug,
+        areaId: project.areaId,
+        lifecycle: "open",
+        nextMove: project.nextMove,
+        followUp: project.followUp,
+      });
+    }
+
+    const attentionCounts: Record<string, number> = {};
+    for (const thread of attentionThreads) {
+      attentionCounts[thread.areaId] =
+        (attentionCounts[thread.areaId] ?? 0) + 1;
     }
 
     return {
@@ -102,14 +106,19 @@ export const overview = query({
         projectCount: projectCounts[area._id] ?? 0,
         attentionCount: attentionCounts[area._id] ?? 0,
       })),
-      attentionItems: attentionItems.map((item) => {
-        const area = areaById.get(item.areaId);
+      attentionThreads: attentionThreads.map((thread) => {
+        const area = areaById.get(thread.areaId);
         return {
-          key: `${item.projectId}-${item.reason}`,
-          projectName: item.projectName,
+          id: thread.projectId,
+          key: thread.projectId,
+          projectName: thread.projectName,
+          name: thread.projectName,
           area,
-          areaSlug: area?.slug ?? area?._id ?? item.areaId,
-          projectSlug: item.projectSlug ?? item.projectId,
+          areaSlug: area?.slug ?? area?._id ?? thread.areaId,
+          projectSlug: thread.projectSlug ?? thread.projectId,
+          lifecycle: thread.lifecycle,
+          nextMove: thread.nextMove,
+          followUp: thread.followUp,
         };
       }),
     };

--- a/apps/web/src/features/areas/components/area-card.tsx
+++ b/apps/web/src/features/areas/components/area-card.tsx
@@ -1,7 +1,7 @@
 import type { Doc } from "@convex/_generated/dataModel";
 import { conditionColors, conditionLabels } from "@convex/lib/condition";
 import { Link } from "@tanstack/react-router";
-import { AlertTriangle } from "lucide-react";
+import { CircleDot } from "lucide-react";
 
 interface AreaCardProps {
   area: Doc<"areas">;
@@ -32,9 +32,9 @@ export function AreaCard({
         {projectCount} {projectCount === 1 ? "thread" : "threads"}
       </p>
       {attentionCount > 0 && (
-        <p className="mt-1.5 flex items-center gap-1 text-xs text-amber-500">
-          <AlertTriangle className="h-3 w-3" />
-          {attentionCount} without a next action
+        <p className="mt-1.5 flex items-center gap-1 text-xs text-muted-foreground">
+          <CircleDot className="h-3 w-3" />
+          {attentionCount} on Dashboard
         </p>
       )}
     </Link>

--- a/apps/web/src/features/dashboard/attention-state.test.ts
+++ b/apps/web/src/features/dashboard/attention-state.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { groupThreadsByAttentionState } from "./attention-state";
+
+describe("groupThreadsByAttentionState", () => {
+  const today = new Date(2026, 4, 20, 12).getTime();
+  const yesterday = new Date(2026, 4, 19, 12).getTime();
+  const tomorrow = new Date(2026, 4, 21, 12).getTime();
+
+  it("groups open Threads by attention state with Follow-up precedence", () => {
+    const groups = groupThreadsByAttentionState({
+      currentDate: today,
+      threads: [
+        {
+          id: "resolved",
+          lifecycle: "resolved",
+          name: "Resolved Thread",
+        },
+        {
+          id: "follow-up-due",
+          lifecycle: "open",
+          name: "Due Follow-up Thread",
+          nextMove: "Call the clinic",
+          followUp: yesterday,
+        },
+        {
+          id: "scheduled",
+          lifecycle: "open",
+          name: "Scheduled Thread",
+          nextMove: "Draft the note",
+          followUp: tomorrow,
+        },
+        {
+          id: "ready",
+          lifecycle: "open",
+          name: "Ready Thread",
+          nextMove: "Send the form",
+        },
+        {
+          id: "open",
+          lifecycle: "open",
+          name: "Open Thread",
+        },
+      ],
+    });
+
+    expect(groups).toEqual({
+      followUpDue: [
+        {
+          id: "follow-up-due",
+          lifecycle: "open",
+          name: "Due Follow-up Thread",
+          nextMove: "Call the clinic",
+          followUp: yesterday,
+        },
+      ],
+      scheduled: [
+        {
+          id: "scheduled",
+          lifecycle: "open",
+          name: "Scheduled Thread",
+          nextMove: "Draft the note",
+          followUp: tomorrow,
+        },
+      ],
+      ready: [
+        {
+          id: "ready",
+          lifecycle: "open",
+          name: "Ready Thread",
+          nextMove: "Send the form",
+        },
+      ],
+      open: [
+        {
+          id: "open",
+          lifecycle: "open",
+          name: "Open Thread",
+        },
+      ],
+    });
+  });
+});

--- a/apps/web/src/features/dashboard/attention-state.ts
+++ b/apps/web/src/features/dashboard/attention-state.ts
@@ -1,0 +1,75 @@
+export type ThreadLifecycle = "open" | "resolved";
+
+export interface DashboardAttentionThread {
+  id: string;
+  lifecycle: ThreadLifecycle;
+  name: string;
+  nextMove?: string;
+  followUp?: number;
+}
+
+export interface DashboardAttentionGroups<TThread> {
+  followUpDue: TThread[];
+  scheduled: TThread[];
+  ready: TThread[];
+  open: TThread[];
+}
+
+interface GroupThreadsByAttentionStateArgs<
+  TThread extends DashboardAttentionThread,
+> {
+  currentDate: number;
+  threads: TThread[];
+}
+
+export function groupThreadsByAttentionState<
+  TThread extends DashboardAttentionThread,
+>({
+  currentDate,
+  threads,
+}: GroupThreadsByAttentionStateArgs<TThread>): DashboardAttentionGroups<TThread> {
+  const groups: DashboardAttentionGroups<TThread> = {
+    followUpDue: [],
+    scheduled: [],
+    ready: [],
+    open: [],
+  };
+  const currentDay = startOfLocalDay(currentDate);
+
+  for (const thread of threads) {
+    if (thread.lifecycle === "resolved") continue;
+
+    if (thread.followUp != null) {
+      const followUpDay = startOfLocalDay(thread.followUp);
+
+      if (followUpDay <= currentDay) {
+        groups.followUpDue.push(thread);
+      } else {
+        groups.scheduled.push(thread);
+      }
+
+      continue;
+    }
+
+    if (hasNextMove(thread.nextMove)) {
+      groups.ready.push(thread);
+    } else {
+      groups.open.push(thread);
+    }
+  }
+
+  return groups;
+}
+
+function startOfLocalDay(timestamp: number) {
+  const date = new Date(timestamp);
+  return new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+  ).getTime();
+}
+
+function hasNextMove(nextMove: string | undefined) {
+  return nextMove != null && nextMove.trim().length > 0;
+}

--- a/apps/web/src/features/dashboard/components/attention-list.tsx
+++ b/apps/web/src/features/dashboard/components/attention-list.tsx
@@ -1,9 +1,16 @@
 import type { Doc } from "@convex/_generated/dataModel";
 import { Link } from "@tanstack/react-router";
 import { Badge } from "@vita-os/ui/components/badge";
-import { AlertTriangle, CircleAlert } from "lucide-react";
+import {
+  Bell,
+  CalendarClock,
+  Circle,
+  CircleCheck,
+  CircleDot,
+} from "lucide-react";
+import type { DashboardAttentionThread } from "@/features/dashboard/attention-state";
 
-export interface AttentionListItem {
+export interface AttentionListItem extends DashboardAttentionThread {
   key: string;
   projectName: string;
   projectSlug: string;
@@ -12,19 +19,52 @@ export interface AttentionListItem {
 }
 
 interface AttentionListProps {
+  title: string;
+  tone: "due" | "scheduled" | "ready" | "open";
   items: AttentionListItem[];
 }
 
-export function AttentionList({ items }: AttentionListProps) {
+const groupTone = {
+  due: {
+    Icon: Bell,
+    badge: "Follow-up due",
+    className: "border-amber-500/25 bg-amber-500/10 text-amber-500",
+    iconClassName: "bg-amber-500/15 text-amber-500",
+  },
+  scheduled: {
+    Icon: CalendarClock,
+    badge: "Scheduled",
+    className: "border-sky-500/25 bg-sky-500/10 text-sky-600",
+    iconClassName: "bg-sky-500/15 text-sky-600",
+  },
+  ready: {
+    Icon: CircleCheck,
+    badge: "Ready",
+    className: "border-emerald-500/25 bg-emerald-500/10 text-emerald-600",
+    iconClassName: "bg-emerald-500/15 text-emerald-600",
+  },
+  open: {
+    Icon: Circle,
+    badge: "Open",
+    className: "border-muted-foreground/20 bg-surface-3 text-muted-foreground",
+    iconClassName: "bg-surface-3 text-muted-foreground",
+  },
+};
+
+export function AttentionList({ title, tone, items }: AttentionListProps) {
   if (items.length === 0) return null;
+
+  const { Icon, badge, className, iconClassName } = groupTone[tone];
 
   return (
     <section>
       <div className="mb-4 flex items-center gap-2.5">
-        <div className="flex h-6 w-6 items-center justify-center rounded-md bg-amber-500/15">
-          <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+        <div
+          className={`flex h-6 w-6 items-center justify-center rounded-md ${iconClassName}`}
+        >
+          <Icon className="h-3.5 w-3.5" />
         </div>
-        <h2 className="text-sm font-medium">Needs Attention</h2>
+        <h2 className="text-sm font-medium">{title}</h2>
         <span className="text-xs text-muted-foreground">{items.length}</span>
       </div>
       <div className="divide-y divide-border/50 rounded-xl border border-border-subtle bg-surface-2">
@@ -45,10 +85,10 @@ export function AttentionList({ items }: AttentionListProps) {
             </div>
             <Badge
               variant="outline"
-              className="shrink-0 gap-1 border-amber-500/25 bg-amber-500/10 text-[10px] text-amber-500"
+              className={`shrink-0 gap-1 text-[10px] ${className}`}
             >
-              <CircleAlert className="h-3 w-3" />
-              No next action
+              <CircleDot className="h-3 w-3" />
+              {badge}
             </Badge>
           </Link>
         ))}

--- a/apps/web/src/features/dashboard/components/attention-section.test.tsx
+++ b/apps/web/src/features/dashboard/components/attention-section.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import type { ComponentPropsWithoutRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { AttentionSection } from "./attention-section";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    children,
+    ...props
+  }: ComponentPropsWithoutRef<"a"> & {
+    to: string;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("AttentionSection", () => {
+  const today = new Date(2026, 4, 20, 12).getTime();
+
+  it("renders Dashboard Thread groups from attention state", () => {
+    render(
+      <AttentionSection
+        currentDate={today}
+        threads={[
+          {
+            id: "resolved",
+            key: "resolved",
+            name: "Resolved passport renewal",
+            projectName: "Resolved passport renewal",
+            projectSlug: "resolved-passport-renewal",
+            areaSlug: "life-admin",
+            lifecycle: "resolved",
+          },
+          {
+            id: "due",
+            key: "due",
+            name: "Call clinic",
+            projectName: "Call clinic",
+            projectSlug: "call-clinic",
+            areaSlug: "health",
+            lifecycle: "open",
+            followUp: today,
+          },
+          {
+            id: "scheduled",
+            key: "scheduled",
+            name: "Check insurance reply",
+            projectName: "Check insurance reply",
+            projectSlug: "check-insurance-reply",
+            areaSlug: "life-admin",
+            lifecycle: "open",
+            followUp: today + 86_400_000,
+            nextMove: "Draft reply",
+          },
+          {
+            id: "ready",
+            key: "ready",
+            name: "Send signed form",
+            projectName: "Send signed form",
+            projectSlug: "send-signed-form",
+            areaSlug: "life-admin",
+            lifecycle: "open",
+            nextMove: "Email the PDF",
+          },
+          {
+            id: "open",
+            key: "open",
+            name: "Think about winter trip",
+            projectName: "Think about winter trip",
+            projectSlug: "winter-trip",
+            areaSlug: "travel",
+            lifecycle: "open",
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Follow-up Due" }),
+    ).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Scheduled" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Ready" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Open" })).toBeVisible();
+
+    expect(screen.getByRole("link", { name: /call clinic/i })).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: /check insurance reply/i }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: /send signed form/i }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: /think about winter trip/i }),
+    ).toBeVisible();
+    expect(
+      screen.queryByText("Resolved passport renewal"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/dashboard/components/attention-section.tsx
+++ b/apps/web/src/features/dashboard/components/attention-section.tsx
@@ -1,18 +1,46 @@
-import type { Doc } from "@convex/_generated/dataModel";
-import { AttentionList } from "./attention-list";
-
-interface AttentionItem {
-  projectName: string;
-  projectSlug: string;
-  area?: Doc<"areas">;
-  areaSlug: string;
-  key: string;
-}
+import { groupThreadsByAttentionState } from "@/features/dashboard/attention-state";
+import { AttentionList, type AttentionListItem } from "./attention-list";
 
 interface AttentionSectionProps {
-  items: AttentionItem[];
+  currentDate: number;
+  threads: AttentionListItem[];
 }
 
-export function AttentionSection({ items }: AttentionSectionProps) {
-  return <AttentionList items={items} />;
+const groups = [
+  { key: "followUpDue", title: "Follow-up Due", tone: "due" },
+  { key: "scheduled", title: "Scheduled", tone: "scheduled" },
+  { key: "ready", title: "Ready", tone: "ready" },
+  { key: "open", title: "Open", tone: "open" },
+] as const;
+
+export function AttentionSection({
+  currentDate,
+  threads,
+}: AttentionSectionProps) {
+  const groupedThreads = groupThreadsByAttentionState({
+    currentDate,
+    threads,
+  });
+
+  if (
+    groupedThreads.followUpDue.length === 0 &&
+    groupedThreads.scheduled.length === 0 &&
+    groupedThreads.ready.length === 0 &&
+    groupedThreads.open.length === 0
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-8">
+      {groups.map((group) => (
+        <AttentionList
+          key={group.key}
+          title={group.title}
+          tone={group.tone}
+          items={groupedThreads[group.key]}
+        />
+      ))}
+    </div>
+  );
 }

--- a/apps/web/src/features/dashboard/screens/dashboard-screen-state.test.ts
+++ b/apps/web/src/features/dashboard/screens/dashboard-screen-state.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowAreaSetup } from "./dashboard-screen-state";
+
+describe("shouldShowAreaSetup", () => {
+  it("keeps Area setup only for a first-run empty Dashboard", () => {
+    expect(shouldShowAreaSetup({ areaCount: 0, attentionThreadCount: 0 })).toBe(
+      true,
+    );
+    expect(shouldShowAreaSetup({ areaCount: 1, attentionThreadCount: 0 })).toBe(
+      false,
+    );
+    expect(shouldShowAreaSetup({ areaCount: 0, attentionThreadCount: 1 })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/web/src/features/dashboard/screens/dashboard-screen-state.ts
+++ b/apps/web/src/features/dashboard/screens/dashboard-screen-state.ts
@@ -1,0 +1,11 @@
+interface ShouldShowAreaSetupArgs {
+  areaCount: number;
+  attentionThreadCount: number;
+}
+
+export function shouldShowAreaSetup({
+  areaCount,
+  attentionThreadCount,
+}: ShouldShowAreaSetupArgs) {
+  return areaCount === 0 && attentionThreadCount === 0;
+}

--- a/apps/web/src/features/dashboard/screens/dashboard-screen.tsx
+++ b/apps/web/src/features/dashboard/screens/dashboard-screen.tsx
@@ -6,23 +6,32 @@ import { useCreateStarterArea } from "@/features/areas/area-form/use-create-area
 import { AttentionSection } from "@/features/dashboard/components/attention-section";
 import { DashboardAreasSection } from "@/features/dashboard/components/dashboard-areas-section";
 import { RecentItems } from "@/features/dashboard/components/recent-items";
+import { shouldShowAreaSetup } from "./dashboard-screen-state";
 
 export function DashboardScreen() {
   const overview = useQuery(api.dashboard.overview);
   const createStarterArea = useCreateStarterArea();
   const [showCreateArea, setShowCreateArea] = useState(false);
+  const areas = overview?.areas ?? [];
+  const attentionThreads = overview?.attentionThreads ?? [];
+  const showAreaSetup = shouldShowAreaSetup({
+    areaCount: areas.length,
+    attentionThreadCount: attentionThreads.length,
+  });
 
   return (
     <div className="mx-auto max-w-4xl space-y-10">
       <h1 className="text-lg font-medium tracking-tight">Dashboard</h1>
 
-      <DashboardAreasSection
-        areas={overview?.areas ?? []}
-        onCreateArea={() => setShowCreateArea(true)}
-        onCreateStarterArea={createStarterArea}
-      />
+      {showAreaSetup && (
+        <DashboardAreasSection
+          areas={areas}
+          onCreateArea={() => setShowCreateArea(true)}
+          onCreateStarterArea={createStarterArea}
+        />
+      )}
 
-      <AttentionSection items={overview?.attentionItems ?? []} />
+      <AttentionSection currentDate={Date.now()} threads={attentionThreads} />
 
       <RecentItems />
 


### PR DESCRIPTION
## Summary
- Add a pure attention-state module that groups open Threads into `Follow-up Due`, `Scheduled`, `Ready`, and `Open`.
- Update the Dashboard query and screen to surface grouped Threads instead of the old single attention list.
- Hide the Area setup block once the Dashboard has Areas or attention Threads, so the main surface leads with Thread awareness instead of Area cards.
- Refresh Area card copy to avoid the old “without a next action” framing.

## Testing
- Added unit coverage for attention-state precedence and the Dashboard first-run setup rule.
- Added component coverage for the grouped Thread sections.
- `bun run lint`, `bun run build`, and `bun run test:run` pass.