### PR TITLE
Rename inbox processing actions for Thread workflow

### DIFF
--- a/apps/web/convex/items.ts
+++ b/apps/web/convex/items.ts
@@ -140,11 +140,11 @@ export const process = mutation({
         definitionOfDone: v.optional(v.string()),
       }),
       v.object({
-        type: v.literal("add_to_project"),
+        type: v.literal("add_activity_log_entry"),
         projectId: v.id("projects"),
       }),
       v.object({
-        type: v.literal("set_next_action"),
+        type: v.literal("set_next_move"),
         projectId: v.id("projects"),
       }),
       v.object({

--- a/apps/web/convex/lib/inboxProcessing.test.ts
+++ b/apps/web/convex/lib/inboxProcessing.test.ts
@@ -5,6 +5,7 @@ import {
   getInboxProcessingResultType,
   getItemProcessingDisposition,
   type InboxProcessingAction,
+  processInboxItem,
 } from "./inboxProcessing";
 
 const areaId = "area1" as Id<"areas">;
@@ -22,6 +23,23 @@ function makeItem(overrides: Partial<Doc<"items">> = {}): Doc<"items"> {
   };
 }
 
+function makeProject(
+  overrides: Partial<Doc<"projects">> = {},
+): Doc<"projects"> {
+  return {
+    _id: projectId,
+    _creationTime: 0,
+    userId: "user1",
+    name: "Book checkup",
+    slug: "book-checkup",
+    areaId: "area1" as Id<"areas">,
+    state: "active",
+    order: 0,
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
 describe("getItemProcessingDisposition", () => {
   it.each<InboxProcessingAction>([
     {
@@ -29,8 +47,8 @@ describe("getItemProcessingDisposition", () => {
       name: "Book health check",
       areaId,
     },
-    { type: "add_to_project", projectId },
-    { type: "set_next_action", projectId },
+    { type: "add_activity_log_entry", projectId },
+    { type: "set_next_move", projectId },
     { type: "discard" },
   ])("deletes the Item after %s processing", (action) => {
     expect(getItemProcessingDisposition(action)).toBe("delete_item");
@@ -40,8 +58,8 @@ describe("getItemProcessingDisposition", () => {
 describe("getInboxProcessingResultType", () => {
   it.each<[InboxProcessingAction, string]>([
     [{ type: "create_project", name: "Book health check", areaId }, "created"],
-    [{ type: "add_to_project", projectId }, "added"],
-    [{ type: "set_next_action", projectId }, "set_next_action"],
+    [{ type: "add_activity_log_entry", projectId }, "added"],
+    [{ type: "set_next_move", projectId }, "set_next_move"],
     [{ type: "discard" }, "discarded"],
   ])("maps processing action %# to its mutation result", (action, result) => {
     expect(getInboxProcessingResultType(action)).toBe(result);
@@ -54,5 +72,96 @@ describe("buildProjectNoteFromItem", () => {
       type: "note",
       content: "Call clinic",
     });
+  });
+});
+
+describe("processInboxItem", () => {
+  it("adds a Task to an existing Thread Activity Log and consumes the Task", async () => {
+    const item = makeItem();
+    const project = makeProject();
+    const inserted: Array<{ table: string; value: unknown }> = [];
+    const deleted: string[] = [];
+    const ctx = {
+      db: {
+        get: async (id: string) => (id === project._id ? project : null),
+        insert: async (table: string, value: unknown) => {
+          inserted.push({ table, value });
+          return "inserted";
+        },
+        delete: async (id: string) => {
+          deleted.push(id);
+        },
+      },
+    };
+
+    const result = await processInboxItem(ctx as never, {
+      userId: "user1",
+      item,
+      action: { type: "add_activity_log_entry", projectId: project._id },
+    });
+
+    expect(result).toEqual({ type: "added" });
+    expect(inserted).toEqual([
+      {
+        table: "projectLogs",
+        value: {
+          userId: "user1",
+          projectId: project._id,
+          type: "note",
+          content: "Call clinic",
+          createdAt: expect.any(Number),
+        },
+      },
+    ]);
+    expect(deleted).toEqual([item._id]);
+  });
+
+  it("sets a Task as an existing Thread Next Move and consumes the Task", async () => {
+    const item = makeItem();
+    const project = makeProject();
+    const inserted: Array<{ table: string; value: unknown }> = [];
+    const patched: Array<{ id: string; patch: unknown }> = [];
+    const deleted: string[] = [];
+    const ctx = {
+      db: {
+        get: async (id: string) => (id === project._id ? project : null),
+        insert: async (table: string, value: unknown) => {
+          inserted.push({ table, value });
+          return "inserted";
+        },
+        patch: async (id: string, patch: unknown) => {
+          patched.push({ id, patch });
+        },
+        delete: async (id: string) => {
+          deleted.push(id);
+        },
+      },
+    };
+
+    const result = await processInboxItem(ctx as never, {
+      userId: "user1",
+      item,
+      action: { type: "set_next_move", projectId: project._id },
+    });
+
+    expect(result).toEqual({ type: "set_next_move" });
+    expect(patched).toEqual([
+      { id: project._id, patch: { nextMove: "Call clinic" } },
+    ]);
+    expect(inserted).toEqual([
+      {
+        table: "projectLogs",
+        value: {
+          userId: "user1",
+          projectId: project._id,
+          type: "next_action_change",
+          content: 'Next move set to "Call clinic"',
+          previousValue: undefined,
+          newValue: "Call clinic",
+          createdAt: expect.any(Number),
+        },
+      },
+    ]);
+    expect(deleted).toEqual([item._id]);
   });
 });

--- a/apps/web/convex/lib/inboxProcessing.ts
+++ b/apps/web/convex/lib/inboxProcessing.ts
@@ -14,14 +14,14 @@ export type InboxProcessingAction =
       areaId: Id<"areas">;
       definitionOfDone?: string;
     }
-  | { type: "add_to_project"; projectId: Id<"projects"> }
-  | { type: "set_next_action"; projectId: Id<"projects"> }
+  | { type: "add_activity_log_entry"; projectId: Id<"projects"> }
+  | { type: "set_next_move"; projectId: Id<"projects"> }
   | { type: "discard" };
 
 export type InboxProcessingResult =
   | { type: "created"; slug: string }
   | { type: "added" }
-  | { type: "set_next_action" }
+  | { type: "set_next_move" }
   | { type: "discarded" };
 
 export type ItemProcessingDisposition = "keep_item" | "delete_item";
@@ -36,8 +36,8 @@ export function getInboxProcessingResultType(
   action: InboxProcessingAction,
 ): InboxProcessingResult["type"] {
   if (action.type === "create_project") return "created";
-  if (action.type === "add_to_project") return "added";
-  if (action.type === "set_next_action") return "set_next_action";
+  if (action.type === "add_activity_log_entry") return "added";
+  if (action.type === "set_next_move") return "set_next_move";
   return "discarded";
 }
 
@@ -85,7 +85,7 @@ export async function processInboxItem(
     return { type: "created", slug };
   }
 
-  if (args.action.type === "add_to_project") {
+  if (args.action.type === "add_activity_log_entry") {
     const project = await getProjectForProcessing(ctx, {
       userId: args.userId,
       projectId: args.action.projectId,
@@ -100,7 +100,7 @@ export async function processInboxItem(
     return { type: "added" };
   }
 
-  if (args.action.type === "set_next_action") {
+  if (args.action.type === "set_next_move") {
     const project = await getProjectForProcessing(ctx, {
       userId: args.userId,
       projectId: args.action.projectId,
@@ -112,7 +112,7 @@ export async function processInboxItem(
       patch: { nextMove: args.item.text },
     });
     await ctx.db.delete(args.item._id);
-    return { type: "set_next_action" };
+    return { type: "set_next_move" };
   }
 
   await ctx.db.delete(args.item._id);

--- a/apps/web/src/features/inbox/screens/inbox-screen.tsx
+++ b/apps/web/src/features/inbox/screens/inbox-screen.tsx
@@ -16,7 +16,7 @@ import { ItemRowContainer } from "@/features/items/item-row/item-row-container";
 import { ProcessItemDialogContainer } from "@/features/items/process-item/process-item-dialog-container";
 
 interface ProcessingNotification {
-  action: "create_project" | "add_to_project" | "set_next_action";
+  action: "create_project" | "add_activity_log_entry" | "set_next_move";
   project: Pick<Doc<"projects">, "name" | "slug">;
   area: Doc<"areas"> | undefined;
 }
@@ -115,9 +115,9 @@ function ProcessingToast({
   const message =
     notification.action === "create_project"
       ? "Created thread"
-      : notification.action === "set_next_action"
-        ? "Set as next action"
-        : "Added as note";
+      : notification.action === "set_next_move"
+        ? "Set Next Move"
+        : "Added Activity Log entry";
 
   return (
     <output className="fixed right-4 bottom-4 z-50 flex max-w-sm items-center gap-3 rounded-lg border border-border-subtle bg-popover px-4 py-3 text-sm text-popover-foreground shadow-lg">

--- a/apps/web/src/features/items/process-item/process-item-dialog-container.tsx
+++ b/apps/web/src/features/items/process-item/process-item-dialog-container.tsx
@@ -12,7 +12,7 @@ interface ProcessItemDialogProps {
   onProcessed?: (result: {
     action: Extract<
       ProcessItemAction,
-      { type: "create_project" | "add_to_project" | "set_next_action" }
+      { type: "create_project" | "add_activity_log_entry" | "set_next_move" }
     >["type"];
     project: Pick<Doc<"projects">, "name" | "slug">;
     area: Doc<"areas"> | undefined;
@@ -50,8 +50,8 @@ export function ProcessItemDialogContainer({
           });
         }
         if (
-          action.type === "add_to_project" ||
-          action.type === "set_next_action"
+          action.type === "add_activity_log_entry" ||
+          action.type === "set_next_move"
         ) {
           const project = visibleProjects.find(
             (candidate) => candidate._id === action.projectId,

--- a/apps/web/src/features/items/process-item/process-item-dialog.test.tsx
+++ b/apps/web/src/features/items/process-item/process-item-dialog.test.tsx
@@ -112,7 +112,7 @@ describe("ProcessItemDialog", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("reveals processing choices after Project selection and submits the selected action", async () => {
+  it("reveals explicit Thread destinations after Thread selection and submits the selected Next Move choice", async () => {
     const user = userEvent.setup();
     const onProcess = vi.fn();
     renderDialog(onProcess);
@@ -121,15 +121,13 @@ describe("ProcessItemDialog", () => {
     await user.click(screen.getByRole("option", { name: /book annual/i }));
 
     expect(
-      screen.getByRole("radio", { name: /add as note/i }),
+      screen.getByRole("radio", { name: /activity log entry/i }),
     ).toBeInTheDocument();
-    await user.click(
-      screen.getByRole("radio", { name: /set as next action/i }),
-    );
+    await user.click(screen.getByRole("radio", { name: /next move/i }));
     await user.click(screen.getByRole("button", { name: /process/i }));
 
     expect(onProcess).toHaveBeenCalledWith(item._id, {
-      type: "set_next_action",
+      type: "set_next_move",
       projectId: projects[0]._id,
     });
   });

--- a/apps/web/src/features/items/process-item/process-item-dialog.tsx
+++ b/apps/web/src/features/items/process-item/process-item-dialog.tsx
@@ -25,7 +25,7 @@ import {
   ProjectSearchAutocomplete,
 } from "./project-search-autocomplete";
 
-type ProcessingMode = "add_to_project" | "set_next_action";
+type ProcessingMode = "add_activity_log_entry" | "set_next_move";
 
 interface ProcessItemDialogProps {
   open: boolean;
@@ -51,7 +51,7 @@ export function ProcessItemDialog({
 }: ProcessItemDialogProps) {
   const [choice, setChoice] = useState<ProjectChoice | null>(null);
   const [inputValue, setInputValue] = useState("");
-  const [mode, setMode] = useState<ProcessingMode>("add_to_project");
+  const [mode, setMode] = useState<ProcessingMode>("add_activity_log_entry");
   const [creationDraft, setCreationDraft] = useState<{
     name: string;
   } | null>(null);
@@ -159,7 +159,8 @@ export function ProcessItemDialog({
 
         <InboxItemPreview item={item} />
         <p className="-mt-3 text-sm text-muted-foreground">
-          Turn this Inbox task into a clear outcome or next action.
+          Move this Inbox task into a Thread as an Activity Log entry or Next
+          Move.
         </p>
 
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -197,18 +198,18 @@ export function ProcessItemDialog({
           {selectedProject && (
             <div className="grid gap-2 sm:grid-cols-2">
               <ProcessingModeCard
-                mode="add_to_project"
+                mode="add_activity_log_entry"
                 selectedMode={mode}
                 onSelect={setMode}
-                title="Add as note"
+                title="Activity Log entry"
                 description="Logged in the thread activity log."
                 icon={<FileText className="h-4 w-4" />}
               />
               <ProcessingModeCard
-                mode="set_next_action"
+                mode="set_next_move"
                 selectedMode={mode}
                 onSelect={setMode}
-                title="Set as next action"
+                title="Next Move"
                 description="Becomes what to do next."
                 icon={<Target className="h-4 w-4" />}
               />

--- a/apps/web/src/features/items/use-process-item.ts
+++ b/apps/web/src/features/items/use-process-item.ts
@@ -9,8 +9,8 @@ export type ProcessItemAction =
       areaId: Id<"areas">;
       definitionOfDone?: string;
     }
-  | { type: "add_to_project"; projectId: Id<"projects"> }
-  | { type: "set_next_action"; projectId: Id<"projects"> };
+  | { type: "add_activity_log_entry"; projectId: Id<"projects"> }
+  | { type: "set_next_move"; projectId: Id<"projects"> };
 
 export function useProcessItem() {
   const processItem = useMutation(api.items.process);


### PR DESCRIPTION
## Summary
- Renames the existing inbox processing actions to `add_activity_log_entry` and `set_next_move` so the UI and mutation layer use Thread language.
- Updates the process dialog copy and choices to show `Activity Log entry` and `Next Move` for an existing Thread.
- Adds backend tests that verify processing into a Thread writes the expected log or next move and consumes the original Task.

## Testing
- `bun run test:run` passed
- `bun run lint` passed
- `bun run build` passed

Closes #154 