### PR TITLE
docs(agents): update ship changes workflow

### DIFF
--- a/.agents/skills/ship-changes/SKILL.md
+++ b/.agents/skills/ship-changes/SKILL.md
@@ -100,9 +100,9 @@ Use this body:
 Closes #123
 ```
 
-The PR body must reference the issue it closes whenever one can be found. Look for the issue number in the session context, the user's request, branch name, commit messages, recent issue discussion, or the diff itself. If the issue is still ambiguous, ask the user before creating the PR instead of guessing.
+The PR body must reference the issue it closes when the work is tied to an issue. Look for the issue number in the session context, the user's request, branch name, commit messages, recent issue discussion, or the diff itself.
 
-Use GitHub closing syntax, such as `Closes #123`, so merging the PR closes the issue automatically. Omit the closing line only when there is no issue to close after checking the available context. If a command was not run, say why instead of listing it.
+Use GitHub closing syntax, such as `Closes #123`, so merging the PR closes the issue automatically. If an issue appears relevant but cannot be identified, ask the user before creating the PR instead of guessing. If the change is clearly not issue-backed, such as a small agent-instruction cleanup requested directly in chat, omit the closing line and continue creating the PR. If a command was not run, say why instead of listing it.
 
 ## Workflow
 
@@ -110,5 +110,5 @@ Use GitHub closing syntax, such as `Closes #123`, so merging the PR closes the i
 2. Summarize what will ship and whether it needs one commit or multiple commits.
 3. Decide whether to keep the current branch or create a descriptive branch from the current worktree `HEAD`.
 4. Stage only intended files, commit with conventional messages, and push the branch.
-5. Create the PR with the standard title and body, including the inferred or confirmed closing issue reference.
+5. Create the PR with the standard title and body, including the inferred or confirmed closing issue reference when the work is issue-backed.
 6. Final response includes branch, commit hash or hashes, PR link, and verification status.

--- a/.agents/skills/ship-changes/SKILL.md
+++ b/.agents/skills/ship-changes/SKILL.md
@@ -26,6 +26,26 @@ changes
 issue-123
 ```
 
+## Branch Creation
+
+First inspect the current branch and worktree state:
+
+```bash
+git status --short
+git branch --show-current
+git rev-parse --show-toplevel
+```
+
+When working in a worktree, do not assume the branch should be based on `main`. Treat the checked-out worktree branch as the base unless the user explicitly asks to rebase, retarget, or start over from `main`.
+
+If the current branch is already a descriptive, non-`codex` feature branch for the work being shipped, keep using it. If the current branch is `main`, `master`, a `codex/*` branch, a `codex-*` branch, or a generic branch name, create a new descriptive branch from the current `HEAD`:
+
+```bash
+git switch -c <descriptive-branch-name>
+```
+
+Do not move, reset, or recreate the worktree from `main` just to make a shipping branch. Only change the base when the user asks or when the current branch clearly cannot be pushed or used for a PR.
+
 ## Commit Strategy
 
 Use one commit when the changes form one coherent feature or fix. Use multiple commits when changes are independently reviewable, such as production code plus a docs-only policy change, a refactor before a feature, or unrelated fixes discovered during the work.
@@ -80,13 +100,15 @@ Use this body:
 Closes #123
 ```
 
-Omit `Closes #123` when no issue is being closed. If a command was not run, say why instead of listing it.
+The PR body must reference the issue it closes whenever one can be found. Look for the issue number in the session context, the user's request, branch name, commit messages, recent issue discussion, or the diff itself. If the issue is still ambiguous, ask the user before creating the PR instead of guessing.
+
+Use GitHub closing syntax, such as `Closes #123`, so merging the PR closes the issue automatically. Omit the closing line only when there is no issue to close after checking the available context. If a command was not run, say why instead of listing it.
 
 ## Workflow
 
 1. Check current branch and worktree state with `git status --short`, `git diff --stat`, and targeted diffs.
 2. Summarize what will ship and whether it needs one commit or multiple commits.
-3. Create a branch from the current branch with a descriptive non-`codex` name.
+3. Decide whether to keep the current branch or create a descriptive branch from the current worktree `HEAD`.
 4. Stage only intended files, commit with conventional messages, and push the branch.
-5. Create the PR with the standard title and body.
+5. Create the PR with the standard title and body, including the inferred or confirmed closing issue reference.
 6. Final response includes branch, commit hash or hashes, PR link, and verification status.


### PR DESCRIPTION
## Summary
- Add explicit worktree branch creation guidance to the ship-changes skill
- Clarify when PR bodies should include issue-closing syntax versus omit it for non-issue-backed work

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run` not run; docs-only agent instruction change