### PR TITLE
feat(items): create threads from tasks

### DIFF
--- a/apps/web/convex/lib/inboxProcessing.test.ts
+++ b/apps/web/convex/lib/inboxProcessing.test.ts
@@ -76,6 +76,84 @@ describe("buildProjectNoteFromItem", () => {
 });
 
 describe("processInboxItem", () => {
+  it("creates a new Thread from a Task, logs the original Task text, and consumes the Task", async () => {
+    const item = makeItem({ text: "Schedule a physical" });
+    const inserted: Array<{ table: string; value: Record<string, unknown> }> =
+      [];
+    const deleted: string[] = [];
+    const area = {
+      _id: areaId,
+      _creationTime: 0,
+      userId: "user1",
+      name: "Health",
+      slug: "health",
+      healthStatus: "healthy",
+      order: 0,
+      createdAt: 0,
+    };
+    const ctx = {
+      db: {
+        get: async (id: string) => (id === areaId ? area : null),
+        query: () => ({
+          withIndex: () => ({
+            order: () => ({
+              first: async () => null,
+            }),
+          }),
+        }),
+        insert: async (table: string, value: Record<string, unknown>) => {
+          inserted.push({ table, value });
+          return table === "projects" ? projectId : "log1";
+        },
+        delete: async (id: string) => {
+          deleted.push(id);
+        },
+      },
+    };
+
+    const result = await processInboxItem(ctx as never, {
+      userId: "user1",
+      item,
+      action: {
+        type: "create_project",
+        name: "Annual health check",
+        areaId,
+      },
+    });
+
+    expect(result).toEqual({
+      type: "created",
+      slug: expect.stringMatching(/^annual-health-check-[a-f0-9]{8}$/),
+    });
+    expect(inserted).toEqual([
+      {
+        table: "projects",
+        value: {
+          userId: "user1",
+          name: "Annual health check",
+          slug: expect.stringMatching(/^annual-health-check-[a-f0-9]{8}$/),
+          areaId,
+          order: 0,
+          state: "open",
+          createdAt: expect.any(Number),
+        },
+      },
+      {
+        table: "projectLogs",
+        value: {
+          userId: "user1",
+          projectId,
+          type: "note",
+          content: "Schedule a physical",
+          createdAt: expect.any(Number),
+        },
+      },
+    ]);
+    expect(inserted[0]?.value).not.toHaveProperty("nextMove");
+    expect(inserted[0]?.value).not.toHaveProperty("actionQueue");
+    expect(deleted).toEqual([item._id]);
+  });
+
   it("adds a Task to an existing Thread Activity Log and consumes the Task", async () => {
     const item = makeItem();
     const project = makeProject();

--- a/apps/web/convex/lib/inboxProcessing.ts
+++ b/apps/web/convex/lib/inboxProcessing.ts
@@ -65,16 +65,21 @@ export async function processInboxItem(
     const nextOrder = await getNextOrder(ctx, "projects", args.userId);
     const slug = generateSlug(args.action.name);
 
-    const projectId = await ctx.db.insert("projects", {
+    const project: Omit<Doc<"projects">, "_id" | "_creationTime"> = {
       userId: args.userId,
       name: args.action.name,
       slug,
-      definitionOfDone: args.action.definitionOfDone,
       areaId: args.action.areaId,
       order: nextOrder,
       state: "open",
       createdAt: Date.now(),
-    });
+    };
+
+    if (args.action.definitionOfDone) {
+      project.definitionOfDone = args.action.definitionOfDone;
+    }
+
+    const projectId = await ctx.db.insert("projects", project);
 
     await copyItemToProjectLog(ctx, {
       userId: args.userId,

--- a/apps/web/src/features/items/process-item/process-item-dialog.test.tsx
+++ b/apps/web/src/features/items/process-item/process-item-dialog.test.tsx
@@ -132,7 +132,7 @@ describe("ProcessItemDialog", () => {
     });
   });
 
-  it("offers inline Project creation for a non-matching search", async () => {
+  it("offers inline Thread creation for a non-matching title", async () => {
     const user = userEvent.setup();
     renderDialog();
 
@@ -145,12 +145,12 @@ describe("ProcessItemDialog", () => {
 
     expect(combobox).toHaveValue("Schedule dentist");
     expect(
-      screen.getByRole("textbox", { name: /summary/i }),
-    ).toBeInTheDocument();
+      screen.queryByRole("textbox", { name: /summary/i }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Health" })).toBeInTheDocument();
   });
 
-  it("submits inline Project creation with the selected Area", async () => {
+  it("submits new Thread creation with a separate title and selected Area", async () => {
     const user = userEvent.setup();
     const onProcess = vi.fn();
     renderDialog(onProcess);
@@ -162,21 +162,16 @@ describe("ProcessItemDialog", () => {
     );
     expect(combobox).toHaveValue("Schedule dentist");
     await user.click(screen.getByRole("button", { name: "Health" }));
-    await user.type(
-      screen.getByRole("textbox", { name: /summary/i }),
-      "Appointment is on the calendar",
-    );
     await user.click(screen.getByRole("button", { name: /process/i }));
 
     expect(onProcess).toHaveBeenCalledWith(item._id, {
       type: "create_project",
       name: "Schedule dentist",
       areaId: healthArea._id,
-      definitionOfDone: "Appointment is on the calendar",
     });
   });
 
-  it("keeps create details when the Project name is edited after selecting Create", async () => {
+  it("keeps create details when the Thread title is edited after selecting Create", async () => {
     const user = userEvent.setup();
     const onProcess = vi.fn();
     renderDialog(onProcess);
@@ -187,25 +182,13 @@ describe("ProcessItemDialog", () => {
       screen.getByRole("option", { name: /create 'schedule dentist'/i }),
     );
     await user.click(screen.getByRole("button", { name: "Health" }));
-    await user.type(
-      screen.getByRole("textbox", { name: /summary/i }),
-      "Appointment is on the calendar",
-    );
     expect(screen.getByRole("button", { name: /process/i })).toBeEnabled();
 
     await user.clear(combobox);
     await user.type(combobox, "Schedule dentist visit");
-    await user.click(
-      screen.getByRole("textbox", {
-        name: /summary/i,
-        hidden: true,
-      }),
-    );
 
-    expect(screen.getByRole("textbox", { name: /summary/i })).toHaveValue(
-      "Appointment is on the calendar",
-    );
     expect(combobox).toHaveValue("Schedule dentist visit");
+    await user.keyboard("{Escape}");
     const processButton = screen.getByRole("button", { name: /process/i });
     expect(processButton).toBeEnabled();
     await user.click(processButton);
@@ -214,7 +197,6 @@ describe("ProcessItemDialog", () => {
       type: "create_project",
       name: "Schedule dentist visit",
       areaId: healthArea._id,
-      definitionOfDone: "Appointment is on the calendar",
     });
   });
 });

--- a/apps/web/src/features/items/process-item/process-item-dialog.tsx
+++ b/apps/web/src/features/items/process-item/process-item-dialog.tsx
@@ -14,7 +14,6 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@vita-os/ui/components/responsive-dialog";
-import { Textarea } from "@vita-os/ui/components/textarea";
 import { cn } from "@vita-os/ui/lib/utils";
 import { formatDistanceToNow } from "date-fns";
 import { ArrowRight, Check, FileText, Target } from "lucide-react";
@@ -56,7 +55,6 @@ export function ProcessItemDialog({
     name: string;
   } | null>(null);
   const [createAreaId, setCreateAreaId] = useState<string | undefined>();
-  const [definitionOfDone, setDefinitionOfDone] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const isCreating = creationDraft !== null;
@@ -69,7 +67,6 @@ export function ProcessItemDialog({
 
   const resetCreationFields = () => {
     setCreateAreaId(undefined);
-    setDefinitionOfDone("");
   };
 
   const handleChoiceChange = (next: ProjectChoice | null) => {
@@ -136,7 +133,6 @@ export function ProcessItemDialog({
           type: "create_project",
           name: createName.trim(),
           areaId: createAreaId as Id<"areas">,
-          definitionOfDone: definitionOfDone.trim() || undefined,
         });
       } else if (selectedProject) {
         await onProcess(item._id, {
@@ -180,17 +176,6 @@ export function ProcessItemDialog({
                 areas={areas}
                 selectedAreaId={createAreaId}
                 onSelect={setCreateAreaId}
-              />
-              <Textarea
-                id="inline-project-dod"
-                aria-label="Summary"
-                value={definitionOfDone}
-                onChange={(event) =>
-                  setDefinitionOfDone(event.currentTarget.value)
-                }
-                placeholder="What is this thread about?"
-                rows={2}
-                className="resize-none"
               />
             </div>
           )}


### PR DESCRIPTION
## Summary
- Let the process Task dialog create a new Thread from a separate user-entered title and selected Area.
- Preserve the original Task text as the first Activity Log entry on the new Thread.
- Add regression coverage for new Thread creation, Area selection, first Activity Log entry, Task consumption, and no nested task creation.

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`

Closes #155