### PR TITLE
feat(convex): add thread task migrations

### DIFF
--- a/apps/web/convex/README.md
+++ b/apps/web/convex/README.md
@@ -88,3 +88,39 @@ function handleButtonPress() {
 Use the Convex CLI to push your functions to a deployment. See everything
 the Convex CLI can do by running `npx convex -h` in your project root
 directory. To learn more, launch the docs with `npx convex docs`.
+
+## Area / Thread / Task migration operations
+
+Issue 172 adds the compatibility persistence shape and online Convex migrations
+for copying legacy Project / Item data into Thread / Task storage. Run these
+from the app root, `apps/web`, after the Convex deployment has the migration
+functions available.
+
+Dry-run the ordered migration set:
+
+```bash
+bunx convex run migrations:runAll '{"dryRun": true}'
+```
+
+Run or resume the ordered migration set:
+
+```bash
+bunx convex run migrations:runAll
+```
+
+Check status:
+
+```bash
+bunx convex run migrations:checkStatus
+```
+
+You can also watch the component's raw migration status:
+
+```bash
+bunx convex run --component migrations lib:getStatus --watch
+```
+
+If the generated Convex types or component references are stale after installing
+the migrations component, run Convex codegen/dev explicitly before operating on
+the deployment. Do not remove the legacy tables or fields until the separate
+cutover and cleanup slice has verified this migration.

--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -19,12 +19,15 @@ import type * as lib_condition from "../lib/condition.js";
 import type * as lib_healthStatus from "../lib/healthStatus.js";
 import type * as lib_helpers from "../lib/helpers.js";
 import type * as lib_inboxProcessing from "../lib/inboxProcessing.js";
+import type * as lib_legacyMigration from "../lib/legacyMigration.js";
+import type * as lib_legacyMigrationRunners from "../lib/legacyMigrationRunners.js";
 import type * as lib_patch from "../lib/patch.js";
 import type * as lib_projectChanges from "../lib/projectChanges.js";
 import type * as lib_slugs from "../lib/slugs.js";
 import type * as lib_types from "../lib/types.js";
 import type * as lib_validation from "../lib/validation.js";
 import type * as lib_validators from "../lib/validators.js";
+import type * as migrations from "../migrations.js";
 import type * as projectLogs from "../projectLogs.js";
 import type * as projects from "../projects.js";
 
@@ -46,12 +49,15 @@ declare const fullApi: ApiFromModules<{
   "lib/healthStatus": typeof lib_healthStatus;
   "lib/helpers": typeof lib_helpers;
   "lib/inboxProcessing": typeof lib_inboxProcessing;
+  "lib/legacyMigration": typeof lib_legacyMigration;
+  "lib/legacyMigrationRunners": typeof lib_legacyMigrationRunners;
   "lib/patch": typeof lib_patch;
   "lib/projectChanges": typeof lib_projectChanges;
   "lib/slugs": typeof lib_slugs;
   "lib/types": typeof lib_types;
   "lib/validation": typeof lib_validation;
   "lib/validators": typeof lib_validators;
+  migrations: typeof migrations;
   projectLogs: typeof projectLogs;
   projects: typeof projects;
 }>;
@@ -2058,6 +2064,93 @@ export declare const components: {
     adapterTest: {
       runCustomTests: FunctionReference<"action", "internal", any, any>;
       runTests: FunctionReference<"action", "internal", any, any>;
+    };
+  };
+  migrations: {
+    lib: {
+      cancel: FunctionReference<
+        "mutation",
+        "internal",
+        { name: string },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
+      cancelAll: FunctionReference<
+        "mutation",
+        "internal",
+        { sinceTs?: number },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      clearAll: FunctionReference<
+        "mutation",
+        "internal",
+        { before?: number },
+        null
+      >;
+      getStatus: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; names?: Array<string> },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      migrate: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          dryRun: boolean;
+          fnHandle: string;
+          name: string;
+          next?: Array<{ fnHandle: string; name: string }>;
+          oneBatchOnly?: boolean;
+          reset?: boolean;
+        },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
     };
   };
 };

--- a/apps/web/convex/convex.config.ts
+++ b/apps/web/convex/convex.config.ts
@@ -1,7 +1,9 @@
 import betterAuth from "@convex-dev/better-auth/convex.config";
+import migrations from "@convex-dev/migrations/convex.config";
 import { defineApp } from "convex/server";
 
 const app = defineApp();
 app.use(betterAuth);
+app.use(migrations);
 
 export default app;

--- a/apps/web/convex/lib/legacyMigration.test.ts
+++ b/apps/web/convex/lib/legacyMigration.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "vitest";
+import type { Doc, Id } from "../_generated/dataModel";
+import {
+  buildAreaConditionPatch,
+  buildGeneratedActivityLogEntries,
+  buildMigratedActivityLogFromProjectLog,
+  buildMigratedTask,
+  buildMigratedThread,
+  type LegacyAreaForMigration,
+} from "./legacyMigration";
+
+const areaId = "area1" as Id<"areas">;
+const projectId = "project1" as Id<"projects">;
+const itemId = "item1" as Id<"items">;
+const projectLogId = "projectLog1" as Id<"projectLogs">;
+const threadId = "thread1";
+const may20 = Date.UTC(2026, 4, 20);
+const jun1 = Date.UTC(2026, 5, 1);
+
+function makeArea(
+  overrides: Partial<LegacyAreaForMigration> = {},
+): LegacyAreaForMigration {
+  return {
+    _id: areaId,
+    _creationTime: 0,
+    userId: "user1",
+    name: "Health",
+    slug: "health",
+    healthStatus: "needs_attention",
+    order: 0,
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+function makeProject(
+  overrides: Partial<Doc<"projects">> = {},
+): Doc<"projects"> {
+  return {
+    _id: projectId,
+    _creationTime: 0,
+    userId: "user1",
+    name: "Book checkup",
+    slug: "book-checkup",
+    definitionOfDone: "Annual physical is complete",
+    areaId,
+    order: 2,
+    state: "open",
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeItem(overrides: Partial<Doc<"items">> = {}): Doc<"items"> {
+  return {
+    _id: itemId,
+    _creationTime: 0,
+    userId: "user1",
+    text: "Call clinic",
+    isCompleted: false,
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeProjectLog(
+  overrides: Partial<Doc<"projectLogs">> = {},
+): Doc<"projectLogs"> {
+  return {
+    _id: projectLogId,
+    _creationTime: 0,
+    userId: "user1",
+    projectId,
+    type: "note",
+    content: "Called clinic",
+    createdAt: 500,
+    ...overrides,
+  };
+}
+
+describe("legacy Area migration", () => {
+  it("backfills Condition from healthStatus", () => {
+    expect(buildAreaConditionPatch(makeArea())).toEqual({
+      condition: "needs_attention",
+    });
+  });
+
+  it("skips Areas whose Condition already matches healthStatus", () => {
+    expect(
+      buildAreaConditionPatch(makeArea({ condition: "needs_attention" })),
+    ).toBeNull();
+  });
+});
+
+describe("legacy Project to Thread migration", () => {
+  it.each([
+    ["open", "open"],
+    ["active", "open"],
+    ["completed", "resolved"],
+    ["dropped", "resolved"],
+  ] as const)("maps %s lifecycle state to %s", (legacyState, threadState) => {
+    expect(buildMigratedThread(makeProject({ state: legacyState })).state).toBe(
+      threadState,
+    );
+  });
+
+  it("maps title, Area, Summary, order, slug, and legacy id", () => {
+    expect(buildMigratedThread(makeProject())).toEqual({
+      userId: "user1",
+      title: "Book checkup",
+      slug: "book-checkup",
+      summary: "Annual physical is complete",
+      areaId,
+      order: 2,
+      state: "open",
+      legacyProjectId: projectId,
+      createdAt: 1000,
+    });
+  });
+
+  it("prefers existing nextMove over actionQueue[0]", () => {
+    const thread = buildMigratedThread(
+      makeProject({
+        nextMove: "Call clinic",
+        actionQueue: [{ id: "a1", text: "Open portal" }],
+      }),
+    );
+
+    expect(thread.nextMove).toBe("Call clinic");
+  });
+
+  it("uses actionQueue[0] as Next Move when nextMove is empty", () => {
+    const thread = buildMigratedThread(
+      makeProject({
+        actionQueue: [{ id: "a1", text: "Open portal" }],
+      }),
+    );
+
+    expect(thread.nextMove).toBe("Open portal");
+  });
+
+  it("uses waitingFollowUpDate as Follow-up when followUp is empty", () => {
+    const thread = buildMigratedThread(
+      makeProject({ waitingFollowUpDate: may20 }),
+    );
+
+    expect(thread.followUp).toBe(may20);
+  });
+
+  it("clears active Next Move and Follow-up from resolved Threads", () => {
+    const thread = buildMigratedThread(
+      makeProject({
+        state: "completed",
+        nextMove: "Call clinic",
+        followUp: may20,
+      }),
+    );
+
+    expect(thread.state).toBe("resolved");
+    expect(thread).not.toHaveProperty("nextMove");
+    expect(thread).not.toHaveProperty("followUp");
+  });
+
+  it("generates Activity Log entries for legacy-only Project fields", () => {
+    const logs = buildGeneratedActivityLogEntries(
+      makeProject({
+        state: "dropped",
+        status: "Blocked",
+        nextMove: "Call clinic",
+        followUp: may20,
+        actionQueue: [
+          { id: "a1", text: "Call clinic" },
+          { id: "a2", text: "Book appointment" },
+        ],
+        waitingOn: "Clinic",
+        waitingSince: may20,
+        waitingExpectedDate: jun1,
+        waitingFollowUpDate: jun1,
+        actionDate: may20,
+        targetDate: jun1,
+      }),
+    );
+
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "reference",
+          migrationSourceKey: "legacy:definitionOfDone",
+          newValue: "Annual physical is complete",
+        }),
+        expect.objectContaining({
+          type: "state_change",
+          migrationSourceKey: "legacy:state",
+          previousValue: "dropped",
+          newValue: "resolved",
+        }),
+        expect.objectContaining({
+          type: "status_change",
+          migrationSourceKey: "legacy:status",
+          newValue: "Blocked",
+        }),
+        expect.objectContaining({
+          type: "waiting_change",
+          migrationSourceKey: "legacy:waiting",
+          content:
+            "Legacy waiting context preserved: waiting on Clinic; waiting since May 20, 2026; expected Jun 1, 2026; waiting follow-up Jun 1, 2026",
+        }),
+        expect.objectContaining({
+          type: "reference",
+          migrationSourceKey: "legacy:actionDate",
+          newValue: "May 20, 2026",
+        }),
+        expect.objectContaining({
+          type: "reference",
+          migrationSourceKey: "legacy:targetDate",
+          newValue: "Jun 1, 2026",
+        }),
+        expect.objectContaining({
+          type: "next_action_change",
+          migrationSourceKey: "legacy:nextMove",
+          newValue: "Call clinic",
+        }),
+        expect.objectContaining({
+          type: "follow_up_change",
+          migrationSourceKey: "legacy:followUp",
+          newValue: "May 20, 2026",
+        }),
+        expect.objectContaining({
+          type: "next_action_change",
+          migrationSourceKey: "legacy:actionQueue:1",
+          newValue: "Book appointment",
+        }),
+      ]),
+    );
+  });
+});
+
+describe("legacy Item to Task migration", () => {
+  it("maps open Items to open Tasks with When", () => {
+    expect(buildMigratedTask(makeItem({ date: may20 }))).toEqual({
+      userId: "user1",
+      text: "Call clinic",
+      when: may20,
+      state: "open",
+      legacyItemId: itemId,
+      createdAt: 1000,
+    });
+  });
+
+  it("maps completed Items to done Tasks with completedAt", () => {
+    expect(
+      buildMigratedTask(makeItem({ isCompleted: true, completedAt: jun1 })),
+    ).toEqual({
+      userId: "user1",
+      text: "Call clinic",
+      state: "done",
+      completedAt: jun1,
+      legacyItemId: itemId,
+      createdAt: 1000,
+    });
+  });
+});
+
+describe("legacy Project log to Activity Log migration", () => {
+  it("preserves existing Project log fields and timestamp", () => {
+    expect(
+      buildMigratedActivityLogFromProjectLog(
+        makeProjectLog({
+          type: "status_change",
+          previousValue: "Blocked",
+          newValue: "Moving",
+        }),
+        threadId,
+      ),
+    ).toEqual({
+      userId: "user1",
+      threadId,
+      type: "status_change",
+      content: "Called clinic",
+      previousValue: "Blocked",
+      newValue: "Moving",
+      legacyProjectLogId: projectLogId,
+      legacyProjectId: projectId,
+      createdAt: 500,
+    });
+  });
+});

--- a/apps/web/convex/lib/legacyMigration.ts
+++ b/apps/web/convex/lib/legacyMigration.ts
@@ -1,0 +1,327 @@
+import type { Doc, Id } from "../_generated/dataModel";
+import type { ActivityLogEntryType } from "./activityLog";
+import type { Condition } from "./condition";
+import { toThreadLifecycleState } from "./types";
+
+export type LegacyAreaForMigration = Doc<"areas"> & {
+  condition?: Condition;
+};
+
+export type ThreadState = "open" | "resolved";
+export type TaskState = "open" | "done";
+
+export type MigratedThread = {
+  userId: string;
+  title: string;
+  slug?: string;
+  summary?: string;
+  areaId: Id<"areas">;
+  order: number;
+  state: ThreadState;
+  nextMove?: string;
+  followUp?: number;
+  legacyProjectId: Id<"projects">;
+  createdAt: number;
+};
+
+export type MigratedTask = {
+  userId: string;
+  text: string;
+  when?: number;
+  state: TaskState;
+  completedAt?: number;
+  legacyItemId: Id<"items">;
+  createdAt: number;
+};
+
+export type GeneratedActivityLogEntry = {
+  userId: string;
+  type: ActivityLogEntryType;
+  content: string;
+  previousValue?: string;
+  newValue?: string;
+  legacyProjectId: Id<"projects">;
+  migrationSourceKey: string;
+  createdAt: number;
+};
+
+export type MigratedActivityLogEntry = {
+  userId: string;
+  threadId: unknown;
+  type: ActivityLogEntryType;
+  content: string;
+  previousValue?: string;
+  newValue?: string;
+  legacyProjectLogId?: Id<"projectLogs">;
+  legacyProjectId?: Id<"projects">;
+  migrationSourceKey?: string;
+  createdAt: number;
+};
+
+type ActionQueueEntry = {
+  id: string;
+  text: string;
+};
+
+function cleanText(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function getActionQueue(project: Doc<"projects">): ActionQueueEntry[] {
+  return project.actionQueue ?? [];
+}
+
+function getNextMoveSource(
+  project: Doc<"projects">,
+):
+  | { text: string; source: "nextMove" }
+  | { text: string; source: "actionQueue"; index: number }
+  | null {
+  const nextMove = cleanText(project.nextMove);
+  if (nextMove) return { text: nextMove, source: "nextMove" };
+
+  const firstAction = cleanText(getActionQueue(project)[0]?.text);
+  if (firstAction)
+    return { text: firstAction, source: "actionQueue", index: 0 };
+
+  return null;
+}
+
+function getFollowUpSource(
+  project: Doc<"projects">,
+):
+  | { value: number; source: "followUp" }
+  | { value: number; source: "waitingFollowUpDate" }
+  | null {
+  if (project.followUp !== undefined) {
+    return { value: project.followUp, source: "followUp" };
+  }
+  if (project.waitingFollowUpDate !== undefined) {
+    return {
+      value: project.waitingFollowUpDate,
+      source: "waitingFollowUpDate",
+    };
+  }
+  return null;
+}
+
+export function buildAreaConditionPatch(
+  area: LegacyAreaForMigration,
+): { condition: Condition } | null {
+  if (area.condition === area.healthStatus) return null;
+  return { condition: area.healthStatus };
+}
+
+export function buildMigratedThread(project: Doc<"projects">): MigratedThread {
+  const state = toThreadLifecycleState(project.state);
+  const thread: MigratedThread = {
+    userId: project.userId,
+    title: project.name,
+    areaId: project.areaId,
+    order: project.order,
+    state,
+    legacyProjectId: project._id,
+    createdAt: project.createdAt,
+  };
+
+  if (project.slug) thread.slug = project.slug;
+
+  const summary = cleanText(project.definitionOfDone);
+  if (summary) thread.summary = summary;
+
+  if (state === "open") {
+    const nextMove = getNextMoveSource(project);
+    if (nextMove) thread.nextMove = nextMove.text;
+
+    const followUp = getFollowUpSource(project);
+    if (followUp) thread.followUp = followUp.value;
+  }
+
+  return thread;
+}
+
+export function buildMigratedTask(item: Doc<"items">): MigratedTask {
+  const task: MigratedTask = {
+    userId: item.userId,
+    text: item.text,
+    state: item.isCompleted ? "done" : "open",
+    legacyItemId: item._id,
+    createdAt: item.createdAt,
+  };
+
+  if (item.date !== undefined) task.when = item.date;
+  if (item.completedAt !== undefined) task.completedAt = item.completedAt;
+
+  return task;
+}
+
+export function buildMigratedActivityLogFromProjectLog(
+  projectLog: Doc<"projectLogs">,
+  threadId: unknown,
+): MigratedActivityLogEntry {
+  const entry: MigratedActivityLogEntry = {
+    userId: projectLog.userId,
+    threadId,
+    type: projectLog.type,
+    content: projectLog.content,
+    legacyProjectLogId: projectLog._id,
+    legacyProjectId: projectLog.projectId,
+    createdAt: projectLog.createdAt,
+  };
+
+  if (projectLog.previousValue !== undefined) {
+    entry.previousValue = projectLog.previousValue;
+  }
+  if (projectLog.newValue !== undefined) {
+    entry.newValue = projectLog.newValue;
+  }
+
+  return entry;
+}
+
+export function buildGeneratedActivityLogEntries(
+  project: Doc<"projects">,
+): GeneratedActivityLogEntry[] {
+  const entries: GeneratedActivityLogEntry[] = [];
+  const state = toThreadLifecycleState(project.state);
+  let offset = 0;
+
+  const push = (
+    entry: Omit<
+      GeneratedActivityLogEntry,
+      "userId" | "legacyProjectId" | "createdAt"
+    >,
+  ) => {
+    entries.push({
+      userId: project.userId,
+      legacyProjectId: project._id,
+      createdAt: project.createdAt + offset,
+      ...entry,
+    });
+    offset += 1;
+  };
+
+  const summary = cleanText(project.definitionOfDone);
+  if (summary) {
+    push({
+      type: "reference",
+      content: `Legacy Definition of Done became Thread summary: ${summary}`,
+      newValue: summary,
+      migrationSourceKey: "legacy:definitionOfDone",
+    });
+  }
+
+  if (project.state === "completed" || project.state === "dropped") {
+    push({
+      type: "state_change",
+      content: `Legacy Project state "${project.state}" became Resolved`,
+      previousValue: project.state,
+      newValue: "resolved",
+      migrationSourceKey: "legacy:state",
+    });
+  }
+
+  const status = cleanText(project.status);
+  if (status) {
+    push({
+      type: "status_change",
+      content: `Legacy status preserved: ${status}`,
+      newValue: status,
+      migrationSourceKey: "legacy:status",
+    });
+  }
+
+  const waitingParts: string[] = [];
+  const waitingOn = cleanText(project.waitingOn);
+  if (waitingOn) waitingParts.push(`waiting on ${waitingOn}`);
+  if (project.waitingSince !== undefined) {
+    waitingParts.push(`waiting since ${formatDate(project.waitingSince)}`);
+  }
+  if (project.waitingExpectedDate !== undefined) {
+    waitingParts.push(`expected ${formatDate(project.waitingExpectedDate)}`);
+  }
+  if (project.waitingFollowUpDate !== undefined) {
+    waitingParts.push(
+      `waiting follow-up ${formatDate(project.waitingFollowUpDate)}`,
+    );
+  }
+  if (waitingParts.length > 0) {
+    push({
+      type: "waiting_change",
+      content: `Legacy waiting context preserved: ${waitingParts.join("; ")}`,
+      newValue: waitingParts.join("; "),
+      migrationSourceKey: "legacy:waiting",
+    });
+  }
+
+  if (project.actionDate !== undefined) {
+    push({
+      type: "reference",
+      content: `Legacy action date preserved: ${formatDate(project.actionDate)}`,
+      newValue: formatDate(project.actionDate),
+      migrationSourceKey: "legacy:actionDate",
+    });
+  }
+
+  if (project.targetDate !== undefined) {
+    push({
+      type: "reference",
+      content: `Legacy target date preserved: ${formatDate(project.targetDate)}`,
+      newValue: formatDate(project.targetDate),
+      migrationSourceKey: "legacy:targetDate",
+    });
+  }
+
+  const nextMoveSource = getNextMoveSource(project);
+  if (state === "resolved" && nextMoveSource) {
+    push({
+      type: "next_action_change",
+      content: `Legacy Next Move preserved from resolved Thread: ${nextMoveSource.text}`,
+      newValue: nextMoveSource.text,
+      migrationSourceKey:
+        nextMoveSource.source === "nextMove"
+          ? "legacy:nextMove"
+          : `legacy:actionQueue:${nextMoveSource.index}`,
+    });
+  }
+
+  const followUpSource = getFollowUpSource(project);
+  if (state === "resolved" && followUpSource?.source === "followUp") {
+    push({
+      type: "follow_up_change",
+      content: `Legacy Follow-up preserved from resolved Thread: ${formatDate(
+        followUpSource.value,
+      )}`,
+      newValue: formatDate(followUpSource.value),
+      migrationSourceKey: "legacy:followUp",
+    });
+  }
+
+  const usedActionQueueIndex =
+    nextMoveSource?.source === "actionQueue" ? nextMoveSource.index : undefined;
+
+  getActionQueue(project).forEach((action, index) => {
+    if (index === usedActionQueueIndex) return;
+    const actionText = cleanText(action.text);
+    if (!actionText) return;
+
+    push({
+      type: "next_action_change",
+      content: `Legacy action queue entry preserved: ${actionText}`,
+      newValue: actionText,
+      migrationSourceKey: `legacy:actionQueue:${index}`,
+    });
+  });
+
+  return entries;
+}

--- a/apps/web/convex/lib/legacyMigrationRunners.test.ts
+++ b/apps/web/convex/lib/legacyMigrationRunners.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "vitest";
+import type { Doc, Id } from "../_generated/dataModel";
+import {
+  backfillAreaCondition,
+  copyItemToTask,
+  copyProjectLogToActivityLog,
+  copyProjectToThread,
+  type LegacyMigrationCtx,
+} from "./legacyMigrationRunners";
+
+const areaId = "area1" as Id<"areas">;
+const projectId = "project1" as Id<"projects">;
+const itemId = "item1" as Id<"items">;
+const projectLogId = "projectLog1" as Id<"projectLogs">;
+const threadId = "thread1";
+
+type TableRows = Record<string, Array<Record<string, unknown>>>;
+
+function makeProject(
+  overrides: Partial<Doc<"projects">> = {},
+): Doc<"projects"> {
+  return {
+    _id: projectId,
+    _creationTime: 0,
+    userId: "user1",
+    name: "Book checkup",
+    slug: "book-checkup",
+    definitionOfDone: "Annual physical is complete",
+    areaId,
+    order: 0,
+    state: "open",
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeItem(overrides: Partial<Doc<"items">> = {}): Doc<"items"> {
+  return {
+    _id: itemId,
+    _creationTime: 0,
+    userId: "user1",
+    text: "Call clinic",
+    isCompleted: false,
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeProjectLog(
+  overrides: Partial<Doc<"projectLogs">> = {},
+): Doc<"projectLogs"> {
+  return {
+    _id: projectLogId,
+    _creationTime: 0,
+    userId: "user1",
+    projectId,
+    type: "note",
+    content: "Called clinic",
+    createdAt: 500,
+    ...overrides,
+  };
+}
+
+function makeCtx(seed: TableRows = {}): {
+  ctx: LegacyMigrationCtx;
+  tables: TableRows;
+  inserted: Array<{ tableName: string; value: Record<string, unknown> }>;
+  patched: Array<{ id: unknown; patch: object }>;
+} {
+  const tables: TableRows = {
+    areas: [],
+    projects: [],
+    projectLogs: [],
+    items: [],
+    threads: [],
+    tasks: [],
+    activityLogs: [],
+    ...seed,
+  };
+  const inserted: Array<{ tableName: string; value: Record<string, unknown> }> =
+    [];
+  const patched: Array<{ id: unknown; patch: object }> = [];
+
+  const ctx: LegacyMigrationCtx = {
+    db: {
+      patch: async (id, patch) => {
+        patched.push({ id, patch });
+        for (const rows of Object.values(tables)) {
+          const row = rows.find((candidate) => candidate._id === id);
+          if (row) Object.assign(row, patch);
+        }
+      },
+      insert: async (tableName, value) => {
+        const id = `${tableName}${tables[tableName]?.length ?? 0}`;
+        const row = { _id: id, ...value };
+        tables[tableName] = [...(tables[tableName] ?? []), row];
+        inserted.push({ tableName, value: row });
+        return id;
+      },
+      query: (tableName) => ({
+        withIndex: (_indexName, build) => {
+          const filters: Array<{ field: string; value: unknown }> = [];
+          const q = {
+            eq: (field: string, value: unknown) => {
+              filters.push({ field, value });
+              return q;
+            },
+          };
+          build(q);
+          return {
+            unique: async () =>
+              tables[tableName]?.find((row) =>
+                filters.every(({ field, value }) => row[field] === value),
+              ) ?? null,
+          };
+        },
+      }),
+    },
+  };
+
+  return { ctx, tables, inserted, patched };
+}
+
+describe("legacy migration runners", () => {
+  it("patches missing Area Condition values", async () => {
+    const { ctx, patched } = makeCtx();
+
+    const result = await backfillAreaCondition(ctx, {
+      _id: areaId,
+      _creationTime: 0,
+      userId: "user1",
+      name: "Health",
+      healthStatus: "critical",
+      order: 0,
+      createdAt: 0,
+    });
+
+    expect(result).toEqual({ status: "patched" });
+    expect(patched).toEqual([{ id: areaId, patch: { condition: "critical" } }]);
+  });
+
+  it("inserts a missing Thread and generated continuity logs", async () => {
+    const { ctx, inserted } = makeCtx();
+
+    const result = await copyProjectToThread(ctx, makeProject());
+
+    expect(result).toEqual({ status: "inserted" });
+    expect(inserted[0]).toEqual({
+      tableName: "threads",
+      value: expect.objectContaining({
+        title: "Book checkup",
+        summary: "Annual physical is complete",
+        legacyProjectId: projectId,
+      }),
+    });
+    expect(inserted[1]).toEqual({
+      tableName: "activityLogs",
+      value: expect.objectContaining({
+        threadId: "threads0",
+        legacyProjectId: projectId,
+        migrationSourceKey: "legacy:definitionOfDone",
+      }),
+    });
+  });
+
+  it("skips an already migrated Thread by legacyProjectId", async () => {
+    const { ctx, inserted } = makeCtx({
+      threads: [{ _id: threadId, legacyProjectId: projectId }],
+      activityLogs: [
+        {
+          _id: "log1",
+          legacyProjectId: projectId,
+          migrationSourceKey: "legacy:definitionOfDone",
+        },
+      ],
+    });
+
+    const result = await copyProjectToThread(ctx, makeProject());
+
+    expect(result).toEqual({ status: "skipped", reason: "thread_exists" });
+    expect(inserted).toEqual([]);
+  });
+
+  it("copies existing Project logs to Activity Logs with original createdAt", async () => {
+    const { ctx, inserted } = makeCtx({
+      threads: [{ _id: threadId, legacyProjectId: projectId }],
+    });
+
+    const result = await copyProjectLogToActivityLog(
+      ctx,
+      makeProjectLog({ createdAt: 500 }),
+    );
+
+    expect(result).toEqual({ status: "inserted" });
+    expect(inserted).toEqual([
+      {
+        tableName: "activityLogs",
+        value: expect.objectContaining({
+          threadId,
+          legacyProjectLogId: projectLogId,
+          legacyProjectId: projectId,
+          createdAt: 500,
+        }),
+      },
+    ]);
+  });
+
+  it("skips Project logs already copied by legacyProjectLogId", async () => {
+    const { ctx, inserted } = makeCtx({
+      activityLogs: [{ _id: "log1", legacyProjectLogId: projectLogId }],
+      threads: [{ _id: threadId, legacyProjectId: projectId }],
+    });
+
+    const result = await copyProjectLogToActivityLog(ctx, makeProjectLog());
+
+    expect(result).toEqual({
+      status: "skipped",
+      reason: "activity_log_exists",
+    });
+    expect(inserted).toEqual([]);
+  });
+
+  it("inserts a missing Task from an Item", async () => {
+    const { ctx, inserted } = makeCtx();
+
+    const result = await copyItemToTask(
+      ctx,
+      makeItem({ date: 500, isCompleted: true, completedAt: 600 }),
+    );
+
+    expect(result).toEqual({ status: "inserted" });
+    expect(inserted).toEqual([
+      {
+        tableName: "tasks",
+        value: expect.objectContaining({
+          text: "Call clinic",
+          when: 500,
+          state: "done",
+          completedAt: 600,
+          legacyItemId: itemId,
+        }),
+      },
+    ]);
+  });
+
+  it("skips an already migrated Task by legacyItemId", async () => {
+    const { ctx, inserted } = makeCtx({
+      tasks: [{ _id: "task1", legacyItemId: itemId }],
+    });
+
+    const result = await copyItemToTask(ctx, makeItem());
+
+    expect(result).toEqual({ status: "skipped", reason: "task_exists" });
+    expect(inserted).toEqual([]);
+  });
+});

--- a/apps/web/convex/lib/legacyMigrationRunners.ts
+++ b/apps/web/convex/lib/legacyMigrationRunners.ts
@@ -1,0 +1,153 @@
+import type { Doc } from "../_generated/dataModel";
+import {
+  buildAreaConditionPatch,
+  buildGeneratedActivityLogEntries,
+  buildMigratedActivityLogFromProjectLog,
+  buildMigratedTask,
+  buildMigratedThread,
+  type GeneratedActivityLogEntry,
+  type LegacyAreaForMigration,
+} from "./legacyMigration";
+
+type IndexBuilder = {
+  eq: (field: string, value: unknown) => IndexBuilder;
+};
+
+type UniqueQuery = {
+  unique: () => Promise<Record<string, unknown> | null>;
+};
+
+type Query = {
+  withIndex: (
+    indexName: string,
+    build: (q: IndexBuilder) => IndexBuilder,
+  ) => UniqueQuery;
+};
+
+export type LegacyMigrationDb = {
+  get?: (id: unknown) => Promise<Record<string, unknown> | null>;
+  patch: (id: unknown, patch: object) => Promise<void>;
+  insert: (tableName: string, value: object) => Promise<unknown>;
+  query: (tableName: string) => Query;
+};
+
+export type LegacyMigrationCtx = {
+  db: LegacyMigrationDb;
+};
+
+export type MigrationStepResult =
+  | { status: "inserted" }
+  | { status: "patched" }
+  | { status: "skipped"; reason: string };
+
+async function findOneByIndex(
+  db: LegacyMigrationDb,
+  tableName: string,
+  indexName: string,
+  fields: Array<{ field: string; value: unknown }>,
+): Promise<Record<string, unknown> | null> {
+  return db
+    .query(tableName)
+    .withIndex(indexName, (q) =>
+      fields.reduce((query, { field, value }) => query.eq(field, value), q),
+    )
+    .unique();
+}
+
+async function insertGeneratedActivityLogIfMissing(
+  ctx: LegacyMigrationCtx,
+  threadId: unknown,
+  entry: GeneratedActivityLogEntry,
+): Promise<MigrationStepResult> {
+  const existing = await findOneByIndex(
+    ctx.db,
+    "activityLogs",
+    "by_legacy_project_source",
+    [
+      { field: "legacyProjectId", value: entry.legacyProjectId },
+      { field: "migrationSourceKey", value: entry.migrationSourceKey },
+    ],
+  );
+
+  if (existing) return { status: "skipped", reason: "activity_log_exists" };
+
+  await ctx.db.insert("activityLogs", {
+    ...entry,
+    threadId,
+  });
+  return { status: "inserted" };
+}
+
+export async function backfillAreaCondition(
+  ctx: LegacyMigrationCtx,
+  area: LegacyAreaForMigration,
+): Promise<MigrationStepResult> {
+  const patch = buildAreaConditionPatch(area);
+  if (!patch) return { status: "skipped", reason: "condition_current" };
+
+  await ctx.db.patch(area._id, patch);
+  return { status: "patched" };
+}
+
+export async function copyProjectToThread(
+  ctx: LegacyMigrationCtx,
+  project: Doc<"projects">,
+): Promise<MigrationStepResult> {
+  const existingThread = await findOneByIndex(
+    ctx.db,
+    "threads",
+    "by_legacy_project",
+    [{ field: "legacyProjectId", value: project._id }],
+  );
+
+  const threadId =
+    existingThread?._id ??
+    (await ctx.db.insert("threads", buildMigratedThread(project)));
+
+  const generatedLogs = buildGeneratedActivityLogEntries(project);
+  for (const entry of generatedLogs) {
+    await insertGeneratedActivityLogIfMissing(ctx, threadId, entry);
+  }
+
+  if (existingThread) return { status: "skipped", reason: "thread_exists" };
+  return { status: "inserted" };
+}
+
+export async function copyProjectLogToActivityLog(
+  ctx: LegacyMigrationCtx,
+  projectLog: Doc<"projectLogs">,
+): Promise<MigrationStepResult> {
+  const existingLog = await findOneByIndex(
+    ctx.db,
+    "activityLogs",
+    "by_legacy_project_log",
+    [{ field: "legacyProjectLogId", value: projectLog._id }],
+  );
+  if (existingLog) {
+    return { status: "skipped", reason: "activity_log_exists" };
+  }
+
+  const thread = await findOneByIndex(ctx.db, "threads", "by_legacy_project", [
+    { field: "legacyProjectId", value: projectLog.projectId },
+  ]);
+  if (!thread?._id) return { status: "skipped", reason: "thread_missing" };
+
+  await ctx.db.insert(
+    "activityLogs",
+    buildMigratedActivityLogFromProjectLog(projectLog, thread._id),
+  );
+  return { status: "inserted" };
+}
+
+export async function copyItemToTask(
+  ctx: LegacyMigrationCtx,
+  item: Doc<"items">,
+): Promise<MigrationStepResult> {
+  const existingTask = await findOneByIndex(ctx.db, "tasks", "by_legacy_item", [
+    { field: "legacyItemId", value: item._id },
+  ]);
+  if (existingTask) return { status: "skipped", reason: "task_exists" };
+
+  await ctx.db.insert("tasks", buildMigratedTask(item));
+  return { status: "inserted" };
+}

--- a/apps/web/convex/lib/validators.ts
+++ b/apps/web/convex/lib/validators.ts
@@ -1,8 +1,22 @@
 import { v } from "convex/values";
 import { CONDITIONS } from "./condition";
 
-export const healthStatusValidator = v.union(
+export const conditionValidator = v.union(
   v.literal(CONDITIONS[0]),
   v.literal(CONDITIONS[1]),
   v.literal(CONDITIONS[2]),
+);
+
+export const healthStatusValidator = conditionValidator;
+
+export const activityLogEntryTypeValidator = v.union(
+  v.literal("note"),
+  v.literal("status_change"),
+  v.literal("next_action_change"),
+  v.literal("state_change"),
+  v.literal("decision"),
+  v.literal("reference"),
+  v.literal("waiting_change"),
+  v.literal("follow_up_change"),
+  v.literal("area_move"),
 );

--- a/apps/web/convex/migrations.ts
+++ b/apps/web/convex/migrations.ts
@@ -1,0 +1,66 @@
+import { type MigrationStatus, Migrations } from "@convex-dev/migrations";
+import { components, internal } from "./_generated/api";
+import type { DataModel } from "./_generated/dataModel";
+import { internalMutation, internalQuery } from "./_generated/server";
+import {
+  backfillAreaCondition,
+  copyItemToTask,
+  copyProjectLogToActivityLog,
+  copyProjectToThread,
+  type LegacyMigrationCtx,
+} from "./lib/legacyMigrationRunners";
+
+export const migrations = new Migrations<DataModel>(components.migrations, {
+  internalMutation,
+  defaultBatchSize: 50,
+  migrationsLocationPrefix: "migrations:",
+});
+
+export const backfillAreaConditions = migrations.define({
+  table: "areas",
+  migrateOne: async (ctx, area) => {
+    await backfillAreaCondition(ctx as unknown as LegacyMigrationCtx, area);
+  },
+});
+
+export const copyProjectsToThreads = migrations.define({
+  table: "projects",
+  migrateOne: async (ctx, project) => {
+    await copyProjectToThread(ctx as unknown as LegacyMigrationCtx, project);
+  },
+});
+
+export const copyProjectLogsToActivityLogs = migrations.define({
+  table: "projectLogs",
+  migrateOne: async (ctx, projectLog) => {
+    await copyProjectLogToActivityLog(
+      ctx as unknown as LegacyMigrationCtx,
+      projectLog,
+    );
+  },
+});
+
+export const copyItemsToTasks = migrations.define({
+  table: "items",
+  migrateOne: async (ctx, item) => {
+    await copyItemToTask(ctx as unknown as LegacyMigrationCtx, item);
+  },
+});
+
+const allMigrations = [
+  internal.migrations.backfillAreaConditions,
+  internal.migrations.copyProjectsToThreads,
+  internal.migrations.copyProjectLogsToActivityLogs,
+  internal.migrations.copyItemsToTasks,
+];
+
+export const runAll = migrations.runner(allMigrations);
+
+export const checkStatus = internalQuery({
+  args: {},
+  handler: async (ctx): Promise<MigrationStatus[]> => {
+    return migrations.getStatus(ctx, {
+      migrations: allMigrations,
+    });
+  },
+});

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -1,6 +1,10 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-import { healthStatusValidator } from "./lib/validators";
+import {
+  activityLogEntryTypeValidator,
+  conditionValidator,
+  healthStatusValidator,
+} from "./lib/validators";
 
 export default defineSchema({
   areas: defineTable({
@@ -9,6 +13,7 @@ export default defineSchema({
     slug: v.optional(v.string()),
     standard: v.optional(v.string()),
     healthStatus: healthStatusValidator,
+    condition: v.optional(conditionValidator),
     order: v.number(),
     createdAt: v.number(),
   })
@@ -67,6 +72,40 @@ export default defineSchema({
     .index("by_user_created", ["userId", "createdAt"])
     .index("by_user_inbox", ["userId", "isCompleted", "createdAt"]),
 
+  threads: defineTable({
+    userId: v.string(),
+    title: v.string(),
+    slug: v.optional(v.string()),
+    summary: v.optional(v.string()),
+    areaId: v.id("areas"),
+    order: v.number(),
+    state: v.union(v.literal("open"), v.literal("resolved")),
+    nextMove: v.optional(v.string()),
+    followUp: v.optional(v.number()),
+    legacyProjectId: v.id("projects"),
+    createdAt: v.number(),
+  })
+    .index("by_user", ["userId"])
+    .index("by_user_order", ["userId", "order"])
+    .index("by_user_slug", ["userId", "slug"])
+    .index("by_user_state", ["userId", "state"])
+    .index("by_area", ["areaId"])
+    .index("by_legacy_project", ["legacyProjectId"]),
+
+  tasks: defineTable({
+    userId: v.string(),
+    text: v.string(),
+    when: v.optional(v.number()),
+    state: v.union(v.literal("open"), v.literal("done")),
+    completedAt: v.optional(v.number()),
+    legacyItemId: v.id("items"),
+    createdAt: v.number(),
+  })
+    .index("by_user", ["userId"])
+    .index("by_user_created", ["userId", "createdAt"])
+    .index("by_user_inbox", ["userId", "state", "createdAt"])
+    .index("by_legacy_item", ["legacyItemId"]),
+
   userSettings: defineTable({
     userId: v.string(),
     lastReviewDate: v.optional(v.number()),
@@ -75,20 +114,29 @@ export default defineSchema({
   projectLogs: defineTable({
     userId: v.string(),
     projectId: v.id("projects"),
-    type: v.union(
-      v.literal("note"),
-      v.literal("status_change"),
-      v.literal("next_action_change"),
-      v.literal("state_change"),
-      v.literal("decision"),
-      v.literal("reference"),
-      v.literal("waiting_change"),
-      v.literal("follow_up_change"),
-      v.literal("area_move"),
-    ),
+    type: activityLogEntryTypeValidator,
     content: v.string(),
     previousValue: v.optional(v.string()),
     newValue: v.optional(v.string()),
     createdAt: v.number(),
   }).index("by_project", ["projectId", "createdAt"]),
+
+  activityLogs: defineTable({
+    userId: v.string(),
+    threadId: v.id("threads"),
+    type: activityLogEntryTypeValidator,
+    content: v.string(),
+    previousValue: v.optional(v.string()),
+    newValue: v.optional(v.string()),
+    legacyProjectLogId: v.optional(v.id("projectLogs")),
+    legacyProjectId: v.optional(v.id("projects")),
+    migrationSourceKey: v.optional(v.string()),
+    createdAt: v.number(),
+  })
+    .index("by_thread", ["threadId", "createdAt"])
+    .index("by_legacy_project_log", ["legacyProjectLogId"])
+    .index("by_legacy_project_source", [
+      "legacyProjectId",
+      "migrationSourceKey",
+    ]),
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,13 +14,14 @@
     "convex": "convex dev"
   },
   "dependencies": {
-    "@vita-os/ui": "workspace:*",
     "@convex-dev/better-auth": "^0.10.10",
+    "@convex-dev/migrations": "^0.3.4",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/rubik": "^5.2.8",
+    "@vita-os/ui": "workspace:*",
     "better-auth": "1.4.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@convex-dev/better-auth": "^0.10.10",
+        "@convex-dev/migrations": "^0.3.4",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -196,6 +197,8 @@
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
     "@convex-dev/better-auth": ["@convex-dev/better-auth@0.10.10", "", { "dependencies": { "@better-auth/passkey": "1.4.9", "@better-fetch/fetch": "^1.1.18", "common-tags": "^1.8.2", "convex-helpers": "^0.1.95", "jose": "^6.1.0", "remeda": "^2.32.0", "semver": "^7.7.3", "type-fest": "^4.39.1", "zod": "^4.0.0" }, "peerDependencies": { "better-auth": "1.4.9", "convex": "^1.25.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-BpwQ2kph43O7hmtGQAJ+ie3KrjONp83659QDjKDdH+X8yIdGevgehaqS5GHB0iJo7zQTtvs687GnAeLZ4Xx3/w=="],
+
+    "@convex-dev/migrations": ["@convex-dev/migrations@0.3.4", "", { "peerDependencies": { "convex": "^1.24.8" } }, "sha512-fCUkc4hDzkZTgxicjV1WN4QfUdDDPPrMtvC7VgSLTGssg1B8pm+XlPC6NbZ2Aes38Xf5iiodX+y8VnU96narKQ=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.1", "", {}, "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ=="],
 


### PR DESCRIPTION
## Summary
- Add compatibility Convex schema for Area Condition, Threads, Tasks, and Activity Logs beside the legacy tables.
- Add online Convex migrations and mapping helpers for copying Project / Item data into the new persistence shape.
- Add migration tests and operator notes for dry-run, run, and status checks.

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`
- `bunx convex run migrations:runAll '{"dryRun": true}'`

Closes #172