### PR TITLE
ci: add GitHub Actions verification workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.6
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint (check only)
+        run: bun run lint:check
+
+      - name: Build
+        run: bun run build
+
+      - name: Test
+        run: bun run test:run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,20 +13,6 @@ bun run build        # Type-check (tsc) then build for production
 
 If tests exist for the affected code, also run `bun run test:run`.
 
-## CI
-
-GitHub Actions runs on pull requests and pushes to `main` (see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)):
-
-```bash
-bun run lint:check   # Check-only; does not rewrite the checkout
-bun run build
-bun run test:run
-```
-
-CI uses `lint:check`, not `lint` or `format`, so it never auto-fixes files. Local verification may still use `bun run lint` when changes need auto-fix.
-
-CI v1 does not run Vite dev, Convex dev, Convex code generation, or Convex deploy. No ADR is required for this routine CI setup.
-
 ## Commands
 
 All commands use **bun** (not npm/yarn/pnpm). Run from the **repo root**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,20 @@ bun run build        # Type-check (tsc) then build for production
 
 If tests exist for the affected code, also run `bun run test:run`.
 
+## CI
+
+GitHub Actions runs on pull requests and pushes to `main` (see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)):
+
+```bash
+bun run lint:check   # Check-only; does not rewrite the checkout
+bun run build
+bun run test:run
+```
+
+CI uses `lint:check`, not `lint` or `format`, so it never auto-fixes files. Local verification may still use `bun run lint` when changes need auto-fix.
+
+CI v1 does not run Vite dev, Convex dev, Convex code generation, or Convex deploy. No ADR is required for this routine CI setup.
+
 ## Commands
 
 All commands use **bun** (not npm/yarn/pnpm). Run from the **repo root**:


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow for pull requests and pushes to `main`
- Run check-only lint, build, and tests with Bun 1.3.6 and frozen lockfile install
- Cache Bun global package cache; use current major action tags

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`

Closes #178

Made with [Cursor](https://cursor.com)