### PR TITLE
fix(ci): add Node 24 for oxlint TypeScript config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.6


### PR DESCRIPTION
## Summary
- Add `actions/setup-node@v6` with Node 24 to the CI workflow
- Ensures oxlint can load `oxlint.config.ts` on GitHub Actions runners

## Verification
- `bun run lint`
- `bun run build`


Made with [Cursor](https://cursor.com)