### PR TITLE
feat(web): add guarded async actions and task create toasts

### DIFF
--- a/apps/web/src/features/shared/use-guarded-async-action.test.ts
+++ b/apps/web/src/features/shared/use-guarded-async-action.test.ts
@@ -1,0 +1,81 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("@vita-os/ui/lib/toast", () => ({
+  toast: toastMocks,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("useGuardedAsyncAction", () => {
+  beforeEach(() => {
+    toastMocks.success.mockClear();
+    toastMocks.error.mockClear();
+  });
+
+  it("ignores duplicate runs while the action is pending", async () => {
+    const pending = deferred<void>();
+    const action = vi.fn(() => pending.promise);
+
+    const { result } = renderHook(() => useGuardedAsyncAction(action));
+
+    let first!: ReturnType<typeof result.current.run>;
+    let second!: ReturnType<typeof result.current.run>;
+    act(() => {
+      first = result.current.run();
+      second = result.current.run();
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+
+    await act(async () => {
+      pending.resolve(undefined);
+      await Promise.all([first, second]);
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a structural success toast when configured", async () => {
+    const action = vi.fn(async () => "done");
+
+    const { result } = renderHook(() =>
+      useGuardedAsyncAction(action, { successMessage: "Task added" }),
+    );
+
+    let outcome!: Awaited<ReturnType<typeof result.current.run>>;
+    await act(async () => {
+      outcome = await result.current.run();
+    });
+
+    expect(outcome).toEqual({ ok: true, value: "done" });
+    expect(toastMocks.success).toHaveBeenCalledWith("Task added");
+  });
+
+  it("stays quiet on success when no success message is configured", async () => {
+    const action = vi.fn(async () => "done");
+
+    const { result } = renderHook(() => useGuardedAsyncAction(action));
+
+    await act(async () => {
+      await result.current.run();
+    });
+
+    expect(toastMocks.success).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/tasks/new-task/new-task-dialog.test.tsx
+++ b/apps/web/src/features/tasks/new-task/new-task-dialog.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NewTaskDialog } from "./new-task-dialog";
+
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("@vita-os/ui/lib/toast", () => ({
+  toast: toastMocks,
+}));
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeAll(() => {
+  window.matchMedia =
+    window.matchMedia ??
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+});
+
+describe("NewTaskDialog", () => {
+  beforeEach(() => {
+    toastMocks.success.mockClear();
+    toastMocks.error.mockClear();
+  });
+
+  it("prevents duplicate task creates while saving", async () => {
+    const user = userEvent.setup();
+    const pendingCreate = deferred();
+    const onSubmit = vi.fn(() => pendingCreate.promise);
+    const onOpenChange = vi.fn();
+
+    render(
+      <NewTaskDialog open onOpenChange={onOpenChange} onSubmit={onSubmit} />,
+    );
+
+    const textarea = screen.getByPlaceholderText("What's on your mind?");
+    await user.type(textarea, "Buy milk");
+
+    const addButton = screen.getByRole("button", { name: "Add" });
+    await user.click(addButton);
+    await user.click(addButton);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(addButton).toBeDisabled();
+    expect(addButton).toHaveAttribute("aria-busy", "true");
+    expect(
+      screen.queryByRole("button", { name: "Close" }),
+    ).not.toBeInTheDocument();
+
+    pendingCreate.resolve();
+
+    await waitFor(() =>
+      expect(addButton).toHaveAttribute("aria-busy", "false"),
+    );
+  });
+
+  it("shows a clear inline error when task creation fails", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn(() =>
+      Promise.reject(new Error("Could not save task")),
+    );
+
+    render(<NewTaskDialog open onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+
+    await user.type(
+      screen.getByPlaceholderText("What's on your mind?"),
+      "Buy milk",
+    );
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Could not save task",
+    );
+    expect(toastMocks.error).not.toHaveBeenCalled();
+  });
+
+  it("shows a structural success toast when task creation succeeds", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn(async () => undefined);
+
+    render(<NewTaskDialog open onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+
+    await user.type(
+      screen.getByPlaceholderText("What's on your mind?"),
+      "Buy milk",
+    );
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    await waitFor(() =>
+      expect(toastMocks.success).toHaveBeenCalledWith("Task added"),
+    );
+  });
+});

--- a/apps/web/src/features/tasks/new-task/new-task-dialog.tsx
+++ b/apps/web/src/features/tasks/new-task/new-task-dialog.tsx
@@ -8,6 +8,7 @@ import {
   ResponsiveDialogTitle,
 } from "@vita-os/ui/components/responsive-dialog";
 import { Textarea } from "@vita-os/ui/components/textarea";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 import { useState } from "react";
 
 import type { CreateTaskValue } from "@/features/tasks/use-create-task";
@@ -26,19 +27,35 @@ export function NewTaskDialog({
   const [text, setText] = useState("");
   const [when, setWhen] = useState<Date | undefined>(undefined);
 
+  const {
+    run: submitTask,
+    isPending,
+    error,
+  } = useGuardedAsyncAction(onSubmit, {
+    successMessage: "Task added",
+    errorToast: false,
+  });
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (isPending && !nextOpen) return;
+    onOpenChange(nextOpen);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = text.trim();
-    if (!trimmed) return;
+    if (!trimmed || isPending) return;
 
-    await onSubmit({ text: trimmed, when: when?.getTime() });
+    const result = await submitTask({ text: trimmed, when: when?.getTime() });
+    if (!result.ok) return;
+
     setText("");
     setWhen(undefined);
   };
 
   return (
-    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
-      <ResponsiveDialogContent>
+    <ResponsiveDialog open={open} onOpenChange={handleOpenChange}>
+      <ResponsiveDialogContent showCloseButton={!isPending}>
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>New task</ResponsiveDialogTitle>
         </ResponsiveDialogHeader>
@@ -49,23 +66,34 @@ export function NewTaskDialog({
             placeholder="What's on your mind?"
             rows={3}
             autoFocus
+            disabled={isPending}
             onKeyDown={(e) => {
               if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
                 e.preventDefault();
-                handleSubmit(e);
+                void handleSubmit(e);
               }
             }}
           />
           <DatePicker value={when} onChange={setWhen} placeholder="Add When" />
+          {error ? (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
           <ResponsiveDialogFooter>
             <Button
               type="button"
               variant="ghost"
               onClick={() => onOpenChange(false)}
+              disabled={isPending}
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={!text.trim()}>
+            <Button
+              type="submit"
+              disabled={!text.trim() || isPending}
+              aria-busy={isPending}
+            >
               Add
             </Button>
           </ResponsiveDialogFooter>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,5 +1,6 @@
 import { ConvexBetterAuthProvider } from "@convex-dev/better-auth/react";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
+import { Toaster } from "@vita-os/ui/components/sonner";
 import { ConvexQueryCacheProvider } from "convex-helpers/react/cache";
 import { ConvexReactClient } from "convex/react";
 import { StrictMode } from "react";
@@ -33,6 +34,7 @@ createRoot(root).render(
     <ConvexBetterAuthProvider client={convex} authClient={authClient}>
       <ConvexQueryCacheProvider expiration={300_000}>
         <RouterProvider router={router} />
+        <Toaster />
       </ConvexQueryCacheProvider>
     </ConvexBetterAuthProvider>
   </StrictMode>,

--- a/bun.lock
+++ b/bun.lock
@@ -73,6 +73,7 @@
         "react-day-picker": "^10.0.0",
         "react-dom": "^19.2.4",
         "shadcn": "^4.7.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0",
         "vaul": "^1.1.2",
@@ -1387,6 +1388,8 @@
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,6 +23,7 @@
     "react-day-picker": "^10.0.0",
     "react-dom": "^19.2.4",
     "shadcn": "^4.7.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
     "vaul": "^1.1.2",

--- a/packages/ui/src/components/sonner.tsx
+++ b/packages/ui/src/components/sonner.tsx
@@ -1,0 +1,40 @@
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      theme="system"
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/packages/ui/src/hooks/use-guarded-async-action.ts
+++ b/packages/ui/src/hooks/use-guarded-async-action.ts
@@ -1,0 +1,73 @@
+import { useCallback, useRef, useState } from "react";
+
+import { toast } from "../lib/toast";
+
+export type GuardedAsyncFeedback = {
+  /** Success toast for structural actions. Omit for quiet inline edits. */
+  successMessage?: string;
+  /** Surface failures as toasts. Default true; set false for form inline errors. */
+  errorToast?: boolean;
+  getErrorMessage?: (error: unknown) => string;
+};
+
+export type GuardedAsyncResult<TResult> =
+  | { ok: true; value: TResult }
+  | { ok: false; skipped: true }
+  | { ok: false; skipped: false; error: string };
+
+function defaultErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return "Something went wrong. Please try again.";
+}
+
+export function useGuardedAsyncAction<TArgs extends unknown[], TResult>(
+  action: (...args: TArgs) => Promise<TResult> | TResult,
+  feedback: GuardedAsyncFeedback = {},
+) {
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pendingRef = useRef(false);
+
+  const {
+    successMessage,
+    errorToast = true,
+    getErrorMessage = defaultErrorMessage,
+  } = feedback;
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const run = useCallback(
+    async (...args: TArgs): Promise<GuardedAsyncResult<TResult>> => {
+      if (pendingRef.current) {
+        return { ok: false, skipped: true };
+      }
+
+      pendingRef.current = true;
+      setIsPending(true);
+      setError(null);
+
+      try {
+        const value = await action(...args);
+        if (successMessage) {
+          toast.success(successMessage);
+        }
+        return { ok: true, value };
+      } catch (err) {
+        const message = getErrorMessage(err);
+        setError(message);
+        if (errorToast) {
+          toast.error(message);
+        }
+        return { ok: false, skipped: false, error: message };
+      } finally {
+        pendingRef.current = false;
+        setIsPending(false);
+      }
+    },
+    [action, successMessage, errorToast, getErrorMessage],
+  );
+
+  return { run, isPending, error, clearError };
+}

--- a/packages/ui/src/lib/toast.ts
+++ b/packages/ui/src/lib/toast.ts
@@ -1,0 +1,1 @@
+export { toast } from "sonner";


### PR DESCRIPTION
## Summary
- Add `useGuardedAsyncAction` in `@vita-os/ui` for duplicate-submit prevention, pending/error state, and optional structural success toasts
- Wire shadcn Sonner through `packages/ui` and mount the Toaster in the web app root
- Integrate New Task creation with guarded submit, inline failure feedback, and a success toast
- Add focused tests for the shared guard and New Task dialog behavior

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`

Closes #183

Made with [Cursor](https://cursor.com)