### PR TITLE
feat(web): distinguish loading from empty states across data surfaces

### DIFF
--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -1,7 +1,6 @@
 import { api } from "@convex/_generated/api";
 import { conditionColors } from "@convex/lib/condition";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
-import { Badge } from "@vita-os/ui/components/badge";
 import {
   Collapsible,
   CollapsibleContent,
@@ -51,6 +50,8 @@ import { useCreateTask } from "@/features/tasks/use-create-task";
 import { CreateThreadDialog } from "@/features/threads/thread-form/create-thread-dialog";
 import { useAreaThreadTree } from "@/hooks/use-area-thread-tree";
 import { authClient } from "@/lib/auth-client";
+
+import { InboxTaskCountBadge } from "./inbox-task-count-badge";
 
 export function AppSidebar() {
   const { data: session } = authClient.useSession();
@@ -125,14 +126,7 @@ export function AppSidebar() {
                 >
                   <Inbox />
                   <span>Inbox</span>
-                  {taskCount !== undefined && taskCount > 0 && (
-                    <Badge
-                      variant="secondary"
-                      className="ml-auto h-5 min-w-5 justify-center px-1.5 text-[10px] tabular-nums"
-                    >
-                      {taskCount}
-                    </Badge>
-                  )}
+                  <InboxTaskCountBadge taskCount={taskCount} />
                 </SidebarMenuButton>
               </SidebarMenuItem>
             </SidebarMenu>

--- a/apps/web/src/components/layout/inbox-task-count-badge.test.tsx
+++ b/apps/web/src/components/layout/inbox-task-count-badge.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { InboxTaskCountBadge } from "./inbox-task-count-badge";
+
+describe("InboxTaskCountBadge", () => {
+  it("stays hidden while the task count is loading", () => {
+    const { container } = render(<InboxTaskCountBadge taskCount={undefined} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("stays hidden when there are no Open Tasks", () => {
+    const { container } = render(<InboxTaskCountBadge taskCount={0} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the Open Task count after it loads", () => {
+    render(<InboxTaskCountBadge taskCount={3} />);
+
+    expect(screen.getByText("3")).toBeVisible();
+  });
+});

--- a/apps/web/src/components/layout/inbox-task-count-badge.tsx
+++ b/apps/web/src/components/layout/inbox-task-count-badge.tsx
@@ -1,0 +1,18 @@
+import { Badge } from "@vita-os/ui/components/badge";
+
+interface InboxTaskCountBadgeProps {
+  taskCount: number | undefined;
+}
+
+export function InboxTaskCountBadge({ taskCount }: InboxTaskCountBadgeProps) {
+  if (taskCount === undefined || taskCount === 0) return null;
+
+  return (
+    <Badge
+      variant="secondary"
+      className="ml-auto h-5 min-w-5 justify-center px-1.5 text-[10px] tabular-nums"
+    >
+      {taskCount}
+    </Badge>
+  );
+}

--- a/apps/web/src/features/areas/components/area-threads-section.tsx
+++ b/apps/web/src/features/areas/components/area-threads-section.tsx
@@ -32,6 +32,7 @@ export function AreaThreadsSection({
     <AreaThreads
       areaSlug={areaSlug}
       threads={threads ?? []}
+      isLoading={threads === undefined}
       onCreateThread={onCreateThread}
       onRemoveThread={(threadId) => removeThread({ id: threadId })}
     />

--- a/apps/web/src/features/areas/components/area-threads-skeleton.tsx
+++ b/apps/web/src/features/areas/components/area-threads-skeleton.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@vita-os/ui/components/skeleton";
+
+export function AreaThreadsSkeleton() {
+  return (
+    <div
+      className="divide-y divide-border/50 rounded-xl border border-border-subtle bg-surface-2"
+      data-testid="area-threads-skeleton"
+    >
+      {Array.from({ length: 2 }).map((_, i) => (
+        <div key={i} className="px-4 py-4">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="mt-2 h-3 w-64" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/areas/components/area-threads.test.tsx
+++ b/apps/web/src/features/areas/components/area-threads.test.tsx
@@ -44,6 +44,23 @@ describe("AreaThreads", () => {
     expect(screen.getByText("Renew passport")).toBeInTheDocument();
   });
 
+  it("shows a loading skeleton while Threads are still loading", () => {
+    render(
+      <AreaThreads
+        areaSlug="admin"
+        threads={[]}
+        isLoading
+        onCreateThread={vi.fn()}
+        onRemoveThread={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("area-threads-skeleton")).toBeVisible();
+    expect(
+      screen.queryByText("No threads in this area yet."),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows an empty state that invites creating a thread", () => {
     render(
       <AreaThreads

--- a/apps/web/src/features/areas/components/area-threads.tsx
+++ b/apps/web/src/features/areas/components/area-threads.tsx
@@ -15,9 +15,12 @@ import {
 import { Button } from "@vita-os/ui/components/button";
 import { ArrowRight, FolderOpen, Plus, Trash2 } from "lucide-react";
 
+import { AreaThreadsSkeleton } from "./area-threads-skeleton";
+
 interface AreaThreadsProps {
   areaSlug: string;
   threads: Doc<"threads">[];
+  isLoading?: boolean;
   onCreateThread: () => void;
   onRemoveThread: (threadId: Id<"threads">) => void;
 }
@@ -25,6 +28,7 @@ interface AreaThreadsProps {
 export function AreaThreads({
   areaSlug,
   threads,
+  isLoading = false,
   onCreateThread,
   onRemoveThread,
 }: AreaThreadsProps) {
@@ -48,7 +52,9 @@ export function AreaThreads({
         </Button>
       </div>
 
-      {threads.length === 0 ? (
+      {isLoading ? (
+        <AreaThreadsSkeleton />
+      ) : threads.length === 0 ? (
         <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border/50 py-10 text-center">
           <FolderOpen className="mb-3 h-8 w-8 text-muted-foreground/60" />
           <p className="mb-4 max-w-xs text-sm text-muted-foreground">

--- a/apps/web/src/features/dashboard/components/dashboard-areas-section.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-areas-section.tsx
@@ -1,5 +1,7 @@
 import { type DashboardArea, DashboardAreas } from "./dashboard-areas";
 
+export type { DashboardArea };
+
 interface DashboardAreasSectionProps {
   areas: DashboardArea[];
   onCreateArea: () => void;

--- a/apps/web/src/features/dashboard/components/dashboard-overview-skeleton.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-overview-skeleton.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from "@vita-os/ui/components/skeleton";
+
+export function DashboardOverviewSkeleton() {
+  return (
+    <div className="space-y-10" data-testid="dashboard-overview-skeleton">
+      <section>
+        <div className="mb-4 flex items-center justify-between">
+          <Skeleton className="h-4 w-12" />
+          <Skeleton className="h-7 w-20 rounded-md" />
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-border-subtle bg-surface-2 p-5"
+            >
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="mt-2 h-3 w-16" />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <div className="mb-4 flex items-center gap-2.5">
+          <Skeleton className="h-6 w-6 rounded-md" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+        <div className="divide-y divide-border/50 rounded-xl border border-border-subtle bg-surface-2">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="px-4 py-3.5">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="mt-1.5 h-3 w-24" />
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/features/dashboard/components/dashboard-overview.test.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-overview.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DashboardOverview } from "./dashboard-overview";
+
+describe("DashboardOverview", () => {
+  it("does not show first-run Area setup while the overview query is loading", () => {
+    render(
+      <DashboardOverview
+        overview={undefined}
+        currentDate={Date.now()}
+        onCreateArea={vi.fn()}
+        onCreateStarterArea={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByText(/map your life domains as areas/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("dashboard-overview-skeleton")).toBeVisible();
+  });
+
+  it("shows first-run Area setup after overview loads with no Areas or attention Threads", () => {
+    render(
+      <DashboardOverview
+        overview={{ areas: [], attentionThreads: [] }}
+        currentDate={Date.now()}
+        onCreateArea={vi.fn()}
+        onCreateStarterArea={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/map your life domains as areas/i)).toBeVisible();
+    expect(
+      screen.queryByTestId("dashboard-overview-skeleton"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/dashboard/components/dashboard-overview.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-overview.tsx
@@ -1,0 +1,55 @@
+import { AttentionSection } from "@/features/dashboard/components/attention-section";
+import {
+  type DashboardArea,
+  DashboardAreasSection,
+} from "@/features/dashboard/components/dashboard-areas-section";
+import { DashboardOverviewSkeleton } from "@/features/dashboard/components/dashboard-overview-skeleton";
+
+import type { AttentionListTask } from "./attention-list";
+
+import { shouldShowAreaSetup } from "../screens/dashboard-screen-state";
+
+export interface DashboardOverviewData {
+  areas: DashboardArea[];
+  attentionThreads: AttentionListTask[];
+}
+
+interface DashboardOverviewProps {
+  overview: DashboardOverviewData | undefined;
+  currentDate: number;
+  onCreateArea: () => void;
+  onCreateStarterArea: (name: string) => Promise<unknown> | unknown;
+}
+
+export function DashboardOverview({
+  overview,
+  currentDate,
+  onCreateArea,
+  onCreateStarterArea,
+}: DashboardOverviewProps) {
+  if (overview === undefined) {
+    return <DashboardOverviewSkeleton />;
+  }
+
+  const showAreaSetup = shouldShowAreaSetup({
+    areaCount: overview.areas.length,
+    attentionThreadCount: overview.attentionThreads.length,
+  });
+
+  return (
+    <>
+      {showAreaSetup && (
+        <DashboardAreasSection
+          areas={overview.areas}
+          onCreateArea={onCreateArea}
+          onCreateStarterArea={onCreateStarterArea}
+        />
+      )}
+
+      <AttentionSection
+        currentDate={currentDate}
+        threads={overview.attentionThreads}
+      />
+    </>
+  );
+}

--- a/apps/web/src/features/dashboard/components/recent-tasks-list.test.tsx
+++ b/apps/web/src/features/dashboard/components/recent-tasks-list.test.tsx
@@ -43,6 +43,22 @@ describe("RecentTasksList", () => {
   const may18_2026 = new Date(2026, 4, 18, 12).getTime();
   const may19_2026 = new Date(2026, 4, 19, 12).getTime();
 
+  it("shows a loading skeleton while Tasks are still loading", () => {
+    render(<RecentTasksList tasks={[]} isLoading />);
+
+    expect(screen.getByTestId("recent-tasks-skeleton")).toBeVisible();
+    expect(screen.queryByText(/open tasks in inbox/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /view all tasks/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing after loading when there are no Open Tasks", () => {
+    const { container } = render(<RecentTasksList tasks={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it("surfaces Open Tasks with When today or earlier as due Tasks", () => {
     render(
       <RecentTasksList

--- a/apps/web/src/features/dashboard/components/recent-tasks-list.tsx
+++ b/apps/web/src/features/dashboard/components/recent-tasks-list.tsx
@@ -11,17 +11,25 @@ import { ArrowRight, Inbox } from "lucide-react";
 
 import { isTaskWhenDue } from "@/features/tasks/inbox";
 
+import { RecentTasksSkeleton } from "./recent-tasks-skeleton";
+
 const MAX_VISIBLE = 5;
 
 interface RecentTasksListProps {
   tasks: Doc<"tasks">[];
+  isLoading?: boolean;
   referenceDate?: number;
 }
 
 export function RecentTasksList({
   tasks,
+  isLoading = false,
   referenceDate = Date.now(),
 }: RecentTasksListProps) {
+  if (isLoading) {
+    return <RecentTasksSkeleton />;
+  }
+
   const activeTasks = tasks.filter((task) => task.state === "open");
   const dueTasks = activeTasks.filter((task) =>
     isTaskWhenDue(task.when, referenceDate),

--- a/apps/web/src/features/dashboard/components/recent-tasks-skeleton.tsx
+++ b/apps/web/src/features/dashboard/components/recent-tasks-skeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "@vita-os/ui/components/skeleton";
+
+export function RecentTasksSkeleton() {
+  return (
+    <section data-testid="recent-tasks-skeleton">
+      <div className="mb-4 flex items-center gap-2.5">
+        <Skeleton className="h-6 w-6 rounded-md" />
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-3 w-6" />
+      </div>
+      <div className="divide-y divide-border/50 rounded-xl border border-border-subtle bg-surface-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="px-4 py-3">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="mt-1.5 h-3 w-20" />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/dashboard/components/recent-tasks.tsx
+++ b/apps/web/src/features/dashboard/components/recent-tasks.tsx
@@ -6,5 +6,7 @@ import { RecentTasksList } from "./recent-tasks-list";
 export function RecentTasks() {
   const tasks = useQuery(api.tasks.list);
 
-  return <RecentTasksList tasks={tasks ?? []} />;
+  return (
+    <RecentTasksList tasks={tasks ?? []} isLoading={tasks === undefined} />
+  );
 }

--- a/apps/web/src/features/dashboard/screens/dashboard-screen.tsx
+++ b/apps/web/src/features/dashboard/screens/dashboard-screen.tsx
@@ -4,36 +4,24 @@ import { useState } from "react";
 
 import { CreateAreaDialog } from "@/features/areas/area-form/create-area-dialog";
 import { useCreateStarterArea } from "@/features/areas/area-form/use-create-area";
-import { AttentionSection } from "@/features/dashboard/components/attention-section";
-import { DashboardAreasSection } from "@/features/dashboard/components/dashboard-areas-section";
+import { DashboardOverview } from "@/features/dashboard/components/dashboard-overview";
 import { RecentTasks } from "@/features/dashboard/components/recent-tasks";
-
-import { shouldShowAreaSetup } from "./dashboard-screen-state";
 
 export function DashboardScreen() {
   const overview = useQuery(api.dashboard.overview);
   const createStarterArea = useCreateStarterArea();
   const [showCreateArea, setShowCreateArea] = useState(false);
-  const areas = overview?.areas ?? [];
-  const attentionThreads = overview?.attentionThreads ?? [];
-  const showAreaSetup = shouldShowAreaSetup({
-    areaCount: areas.length,
-    attentionThreadCount: attentionThreads.length,
-  });
 
   return (
     <div className="mx-auto max-w-4xl space-y-10">
       <h1 className="text-lg font-medium tracking-tight">Dashboard</h1>
 
-      {showAreaSetup && (
-        <DashboardAreasSection
-          areas={areas}
-          onCreateArea={() => setShowCreateArea(true)}
-          onCreateStarterArea={createStarterArea}
-        />
-      )}
-
-      <AttentionSection currentDate={Date.now()} threads={attentionThreads} />
+      <DashboardOverview
+        overview={overview}
+        currentDate={Date.now()}
+        onCreateArea={() => setShowCreateArea(true)}
+        onCreateStarterArea={createStarterArea}
+      />
 
       <RecentTasks />
 

--- a/apps/web/src/features/tasks/process-task/process-task-dialog.test.tsx
+++ b/apps/web/src/features/tasks/process-task/process-task-dialog.test.tsx
@@ -77,20 +77,34 @@ beforeAll(() => {
     }));
 });
 
-function renderDialog(onProcess = vi.fn()) {
+function renderDialog(
+  onProcess = vi.fn(),
+  options: { isLoading?: boolean; threads?: Doc<"threads">[] } = {},
+) {
   return render(
     <ProcessTaskDialog
       open
       onOpenChange={vi.fn()}
       task={task}
       areas={[healthArea, adminArea]}
-      threads={threads}
+      threads={options.threads ?? threads}
+      isLoading={options.isLoading}
       onProcess={onProcess}
     />,
   );
 }
 
 describe("ProcessTaskDialog", () => {
+  it("shows loading state instead of empty search results while destination data loads", async () => {
+    const user = userEvent.setup();
+    renderDialog(vi.fn(), { isLoading: true, threads: [] });
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(screen.getByText("Loading…")).toBeVisible();
+    expect(screen.queryByText("No threads yet")).not.toBeInTheDocument();
+  });
+
   it("shows the Task as context and filters Threads by search term", async () => {
     const user = userEvent.setup();
     renderDialog();

--- a/apps/web/src/features/tasks/process-task/thread-search-autocomplete.tsx
+++ b/apps/web/src/features/tasks/process-task/thread-search-autocomplete.tsx
@@ -108,7 +108,11 @@ export function ThreadSearchAutocomplete({
         showClear={!!value || inputValue.length > 0}
       />
       <ComboboxContent>
-        <ComboboxEmpty>No threads yet</ComboboxEmpty>
+        {isLoading ? (
+          <p className="px-2 py-3 text-sm text-muted-foreground">Loading…</p>
+        ) : (
+          <ComboboxEmpty>No threads yet</ComboboxEmpty>
+        )}
         <ComboboxList>
           {(choice: ThreadChoice) =>
             choice.kind === "create" ? (


### PR DESCRIPTION
## Summary
- Gate Dashboard overview on loaded Convex data with skeleton UI so first-run Area setup and attention sections do not flash while loading
- Add loading skeletons for Recent Tasks and Area Threads, and show loading text in process-task thread search instead of empty results
- Extract `InboxTaskCountBadge` so sidebar inbox counts stay hidden until the query resolves
- Add focused component tests for loading-vs-empty behavior across Dashboard, Recent Tasks, Area Threads, process-task search, and sidebar badge

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`

Closes #184

Made with [Cursor](https://cursor.com)