### PR TITLE
feat(web): add async reliability to area and thread forms

### DIFF
--- a/apps/web/src/features/areas/area-form/area-form-dialog.test.tsx
+++ b/apps/web/src/features/areas/area-form/area-form-dialog.test.tsx
@@ -1,10 +1,8 @@
-import type { Doc, Id } from "@convex/_generated/dataModel";
-
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ThreadFormDialog } from "./thread-form-dialog";
+import { AreaFormDialog } from "./area-form-dialog";
 
 const toastMocks = vi.hoisted(() => ({
   success: vi.fn(),
@@ -15,18 +13,13 @@ vi.mock("@vita-os/ui/lib/toast", () => ({
   toast: toastMocks,
 }));
 
-const areas = [
-  {
-    _id: "area1" as Id<"areas">,
-    _creationTime: 0,
-    userId: "user1",
-    name: "Health",
-    slug: "health",
-    condition: "healthy",
-    order: 0,
-    createdAt: 0,
-  },
-] satisfies Doc<"areas">[];
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 beforeAll(() => {
   window.matchMedia =
@@ -43,66 +36,39 @@ beforeAll(() => {
     }));
 });
 
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
-
-describe("ThreadFormDialog", () => {
+describe("AreaFormDialog", () => {
   beforeEach(() => {
     toastMocks.success.mockClear();
     toastMocks.error.mockClear();
   });
 
-  it("uses Thread language and optional Summary on create", () => {
-    render(
-      <ThreadFormDialog
-        mode="create"
-        open
-        onOpenChange={vi.fn()}
-        areas={areas}
-        defaultAreaId={areas[0]._id}
-        onSubmit={vi.fn()}
-      />,
-    );
-
-    expect(
-      screen.getByRole("heading", { name: "New thread" }),
-    ).toBeInTheDocument();
-    expect(screen.getByLabelText(/Summary/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Create thread" }),
-    ).toBeInTheDocument();
-  });
-
-  it("prevents duplicate thread creates while saving", async () => {
+  it("prevents duplicate area creates while saving", async () => {
     const user = userEvent.setup();
     const pendingCreate = deferred();
     const onSubmit = vi.fn(() => pendingCreate.promise);
+    const onOpenChange = vi.fn();
 
     render(
-      <ThreadFormDialog
+      <AreaFormDialog
         mode="create"
         open
-        onOpenChange={vi.fn()}
-        areas={areas}
-        defaultAreaId={areas[0]._id}
+        onOpenChange={onOpenChange}
         onSubmit={onSubmit}
       />,
     );
 
-    await user.type(screen.getByLabelText("Title"), "Renew passport");
+    await user.type(screen.getByLabelText("Name"), "Health");
 
-    const createButton = screen.getByRole("button", { name: "Create thread" });
+    const createButton = screen.getByRole("button", { name: "Create area" });
     await user.click(createButton);
     await user.click(createButton);
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(createButton).toBeDisabled();
     expect(createButton).toHaveAttribute("aria-busy", "true");
+    expect(
+      screen.queryByRole("button", { name: "Close" }),
+    ).not.toBeInTheDocument();
 
     pendingCreate.resolve();
 
@@ -111,101 +77,92 @@ describe("ThreadFormDialog", () => {
     );
   });
 
-  it("prevents duplicate thread creates from repeated Enter submits while saving", async () => {
+  it("prevents duplicate area creates from repeated Enter submits while saving", async () => {
     const user = userEvent.setup();
     const pendingCreate = deferred();
     const onSubmit = vi.fn(() => pendingCreate.promise);
 
     render(
-      <ThreadFormDialog
+      <AreaFormDialog
         mode="create"
         open
         onOpenChange={vi.fn()}
-        areas={areas}
-        defaultAreaId={areas[0]._id}
         onSubmit={onSubmit}
       />,
     );
 
-    await user.type(screen.getByLabelText("Title"), "Renew passport");
+    await user.type(screen.getByLabelText("Name"), "Health");
     await user.keyboard("{Enter}");
     await user.keyboard("{Enter}");
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(
-      screen.getByRole("button", { name: "Create thread" }),
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Create area" })).toBeDisabled();
 
     pendingCreate.resolve();
 
     await waitFor(() =>
       expect(
-        screen.getByRole("button", { name: "Create thread" }),
+        screen.getByRole("button", { name: "Create area" }),
       ).toHaveAttribute("aria-busy", "false"),
     );
   });
 
-  it("shows a clear inline error when thread creation fails", async () => {
+  it("shows a clear inline error when area creation fails", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn(() =>
       Promise.reject(new Error("Database unavailable")),
     );
 
     render(
-      <ThreadFormDialog
+      <AreaFormDialog
         mode="create"
         open
         onOpenChange={vi.fn()}
-        areas={areas}
-        defaultAreaId={areas[0]._id}
         onSubmit={onSubmit}
       />,
     );
 
-    await user.type(screen.getByLabelText("Title"), "Renew passport");
-    await user.click(screen.getByRole("button", { name: "Create thread" }));
+    await user.type(screen.getByLabelText("Name"), "Health");
+    await user.click(screen.getByRole("button", { name: "Create area" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
-      "Thread was not saved. Database unavailable",
+      "Area was not saved. Database unavailable",
     );
     expect(toastMocks.error).not.toHaveBeenCalled();
   });
 
-  it("shows a structural success toast when thread creation succeeds", async () => {
+  it("shows a structural success toast when area creation succeeds", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn(async () => undefined);
 
     render(
-      <ThreadFormDialog
+      <AreaFormDialog
         mode="create"
         open
         onOpenChange={vi.fn()}
-        areas={areas}
-        defaultAreaId={areas[0]._id}
         onSubmit={onSubmit}
       />,
     );
 
-    await user.type(screen.getByLabelText("Title"), "Renew passport");
-    await user.click(screen.getByRole("button", { name: "Create thread" }));
+    await user.type(screen.getByLabelText("Name"), "Health");
+    await user.click(screen.getByRole("button", { name: "Create area" }));
 
     await waitFor(() =>
-      expect(toastMocks.success).toHaveBeenCalledWith("Thread created"),
+      expect(toastMocks.success).toHaveBeenCalledWith("Area created"),
     );
   });
 
-  it("prevents duplicate thread edits while saving without a success toast", async () => {
+  it("prevents duplicate area edits while saving without a success toast", async () => {
     const user = userEvent.setup();
     const pendingSave = deferred();
     const onSubmit = vi.fn(() => pendingSave.promise);
 
     render(
-      <ThreadFormDialog
+      <AreaFormDialog
         mode="edit"
         open
         onOpenChange={vi.fn()}
-        areas={areas}
-        initialValue={{ title: "Renew passport", areaId: areas[0]._id }}
+        initialValue={{ name: "Health", condition: "healthy" }}
         onSubmit={onSubmit}
       />,
     );
@@ -225,17 +182,16 @@ describe("ThreadFormDialog", () => {
     );
   });
 
-  it("shows a clear inline error when thread editing fails", async () => {
+  it("shows a clear inline error when area editing fails", async () => {
     const user = userEvent.setup();
-    const onSubmit = vi.fn(() => Promise.reject(new Error("Thread not found")));
+    const onSubmit = vi.fn(() => Promise.reject(new Error("Area not found")));
 
     render(
-      <ThreadFormDialog
+      <AreaFormDialog
         mode="edit"
         open
         onOpenChange={vi.fn()}
-        areas={areas}
-        initialValue={{ title: "Renew passport", areaId: areas[0]._id }}
+        initialValue={{ name: "Health", condition: "healthy" }}
         onSubmit={onSubmit}
       />,
     );
@@ -243,7 +199,7 @@ describe("ThreadFormDialog", () => {
     await user.click(screen.getByRole("button", { name: "Save changes" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
-      "Thread was not saved. Thread not found",
+      "Area was not saved. Area not found",
     );
     expect(toastMocks.error).not.toHaveBeenCalled();
   });

--- a/apps/web/src/features/areas/area-form/area-form-dialog.tsx
+++ b/apps/web/src/features/areas/area-form/area-form-dialog.tsx
@@ -23,6 +23,7 @@ import {
   SelectValue,
 } from "@vita-os/ui/components/select";
 import { Textarea } from "@vita-os/ui/components/textarea";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 import { useEffect, useState } from "react";
 
 import { StarterAreasSuggestions } from "@/features/areas/components/starter-areas-suggestions";
@@ -35,6 +36,14 @@ interface AreaFormDialogProps {
   onOpenChange: (open: boolean) => void;
   initialValue?: AreaFormValue;
   onSubmit: (value: AreaFormValue) => Promise<void> | void;
+}
+
+function getAreaSaveError(error: unknown) {
+  const detail =
+    error instanceof Error && error.message
+      ? error.message
+      : "Please try again.";
+  return `Area was not saved. ${detail}`;
 }
 
 export function AreaFormDialog({
@@ -57,16 +66,32 @@ export function AreaFormDialog({
     setCondition(initialValue?.condition ?? DEFAULT_CONDITION);
   }, [open, initialValue]);
 
+  const {
+    run: submitArea,
+    isPending,
+    error,
+  } = useGuardedAsyncAction(onSubmit, {
+    successMessage: mode === "create" ? "Area created" : undefined,
+    errorToast: false,
+    getErrorMessage: getAreaSaveError,
+  });
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (isPending && !nextOpen) return;
+    onOpenChange(nextOpen);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const trimmedName = name.trim();
-    if (!trimmedName) return;
+    if (!trimmedName || isPending) return;
 
-    await onSubmit({
+    const result = await submitArea({
       name: trimmedName,
       standard: standard.trim() || undefined,
       condition: condition,
     });
+    if (!result.ok) return;
 
     if (mode === "create") {
       setName("");
@@ -76,8 +101,8 @@ export function AreaFormDialog({
   };
 
   return (
-    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
-      <ResponsiveDialogContent>
+    <ResponsiveDialog open={open} onOpenChange={handleOpenChange}>
+      <ResponsiveDialogContent showCloseButton={!isPending}>
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>
             {mode === "edit" ? "Edit area" : "New area"}
@@ -102,6 +127,7 @@ export function AreaFormDialog({
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. Health, Career, Finances"
               autoFocus
+              disabled={isPending}
             />
           </div>
           <div className="space-y-2">
@@ -117,6 +143,7 @@ export function AreaFormDialog({
               onChange={(e) => setStandard(e.target.value)}
               placeholder="What does 'good enough' look like for this area?"
               rows={3}
+              disabled={isPending}
             />
             <p className="text-xs text-muted-foreground">
               The maintenance threshold, not an aspirational goal.
@@ -126,6 +153,7 @@ export function AreaFormDialog({
             <Label htmlFor="area-condition">Condition</Label>
             <Select
               value={condition}
+              disabled={isPending}
               onValueChange={(value) => {
                 if (isCondition(value)) setCondition(value);
               }}
@@ -150,15 +178,25 @@ export function AreaFormDialog({
               Your manual judgment on this area — not calculated from activity.
             </p>
           </div>
+          {error ? (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
           <ResponsiveDialogFooter>
             <Button
               type="button"
               variant="ghost"
               onClick={() => onOpenChange(false)}
+              disabled={isPending}
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={!name.trim()}>
+            <Button
+              type="submit"
+              disabled={!name.trim() || isPending}
+              aria-busy={isPending}
+            >
               {mode === "edit" ? "Save changes" : "Create area"}
             </Button>
           </ResponsiveDialogFooter>

--- a/apps/web/src/features/areas/components/area-picker.tsx
+++ b/apps/web/src/features/areas/components/area-picker.tsx
@@ -13,12 +13,14 @@ interface AreaPickerProps {
   areas: Doc<"areas">[];
   selectedAreaId: string | undefined;
   onSelect: (id: string) => void;
+  disabled?: boolean;
 }
 
 export function AreaPicker({
   areas,
   selectedAreaId,
   onSelect,
+  disabled = false,
 }: AreaPickerProps) {
   const [open, setOpen] = useState(false);
   const selected = areas.find((a) => a._id === selectedAreaId);
@@ -27,7 +29,12 @@ export function AreaPicker({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger
         render={
-          <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" />
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1.5 text-xs"
+            disabled={disabled}
+          />
         }
       >
         <Compass className="h-3 w-3" />

--- a/apps/web/src/features/dashboard/screens/dashboard-screen.tsx
+++ b/apps/web/src/features/dashboard/screens/dashboard-screen.tsx
@@ -1,4 +1,5 @@
 import { api } from "@convex/_generated/api";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useState } from "react";
 
@@ -9,7 +10,11 @@ import { RecentTasks } from "@/features/dashboard/components/recent-tasks";
 
 export function DashboardScreen() {
   const overview = useQuery(api.dashboard.overview);
-  const createStarterArea = useCreateStarterArea();
+  const createStarterAreaMutation = useCreateStarterArea();
+  const { run: createStarterArea } = useGuardedAsyncAction(
+    createStarterAreaMutation,
+    { successMessage: "Area created" },
+  );
   const [showCreateArea, setShowCreateArea] = useState(false);
 
   return (

--- a/apps/web/src/features/threads/thread-form/thread-form-dialog.tsx
+++ b/apps/web/src/features/threads/thread-form/thread-form-dialog.tsx
@@ -12,6 +12,7 @@ import {
   ResponsiveDialogTitle,
 } from "@vita-os/ui/components/responsive-dialog";
 import { Textarea } from "@vita-os/ui/components/textarea";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 import { useEffect, useState } from "react";
 
 import { AreaPicker } from "@/features/areas/components/area-picker";
@@ -26,6 +27,14 @@ interface ThreadFormDialogProps {
   defaultAreaId?: Id<"areas">;
   initialValue?: Partial<ThreadFormValue>;
   onSubmit: (value: ThreadFormValue) => Promise<void> | void;
+}
+
+function getThreadSaveError(error: unknown) {
+  const detail =
+    error instanceof Error && error.message
+      ? error.message
+      : "Please try again.";
+  return `Thread was not saved. ${detail}`;
 }
 
 export function ThreadFormDialog({
@@ -50,16 +59,32 @@ export function ThreadFormDialog({
     setAreaId(initialValue?.areaId ?? defaultAreaId);
   }, [open, initialValue, defaultAreaId]);
 
+  const {
+    run: submitThread,
+    isPending,
+    error,
+  } = useGuardedAsyncAction(onSubmit, {
+    successMessage: mode === "create" ? "Thread created" : undefined,
+    errorToast: false,
+    getErrorMessage: getThreadSaveError,
+  });
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (isPending && !nextOpen) return;
+    onOpenChange(nextOpen);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const trimmedTitle = title.trim();
-    if (!trimmedTitle || !areaId) return;
+    if (!trimmedTitle || !areaId || isPending) return;
 
-    await onSubmit({
+    const result = await submitThread({
       title: trimmedTitle,
       summary: summary.trim() || undefined,
       areaId: areaId as Id<"areas">,
     });
+    if (!result.ok) return;
 
     if (mode === "create") {
       setTitle("");
@@ -69,8 +94,8 @@ export function ThreadFormDialog({
   };
 
   return (
-    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
-      <ResponsiveDialogContent>
+    <ResponsiveDialog open={open} onOpenChange={handleOpenChange}>
+      <ResponsiveDialogContent showCloseButton={!isPending}>
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>
             {mode === "edit" ? "Edit thread" : "New thread"}
@@ -90,6 +115,7 @@ export function ThreadFormDialog({
               onChange={(e) => setTitle(e.target.value)}
               placeholder="e.g. Renew passport, File Q4 taxes"
               autoFocus
+              disabled={isPending}
             />
           </div>
           <div className="space-y-2">
@@ -105,6 +131,7 @@ export function ThreadFormDialog({
               onChange={(e) => setSummary(e.target.value)}
               placeholder="What is this thread about?"
               rows={2}
+              disabled={isPending}
             />
           </div>
           <div className="space-y-2">
@@ -113,17 +140,28 @@ export function ThreadFormDialog({
               areas={areas}
               selectedAreaId={areaId}
               onSelect={setAreaId}
+              disabled={isPending}
             />
           </div>
+          {error ? (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
           <ResponsiveDialogFooter>
             <Button
               type="button"
               variant="ghost"
               onClick={() => onOpenChange(false)}
+              disabled={isPending}
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={!title.trim() || !areaId}>
+            <Button
+              type="submit"
+              disabled={!title.trim() || !areaId || isPending}
+              aria-busy={isPending}
+            >
               {mode === "edit" ? "Save changes" : "Create thread"}
             </Button>
           </ResponsiveDialogFooter>


### PR DESCRIPTION
## Summary
- Wire `useGuardedAsyncAction` into Area and Thread create/edit dialogs to block duplicate submits (click and Enter), disable fields while saving, and prevent closing mid-save
- Show inline failure messages that make it clear the change did not save; toast on structural creates, stay quiet on edits
- Guard dashboard starter area creation with the shared hook and a success toast; existing single-flight behavior in `StarterAreasSuggestions` is unchanged
- Add focused component tests for duplicate prevention, Enter-submit blocking, inline errors, and success feedback

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`

Closes #185

Made with [Cursor](https://cursor.com)