### PR TITLE
feat(ui): add feedback provider

### DIFF
--- a/apps/web/src/features/areas/area-form/area-form-dialog.test.tsx
+++ b/apps/web/src/features/areas/area-form/area-form-dialog.test.tsx
@@ -1,17 +1,14 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  createFeedbackMock,
+  type FeedbackMock,
+  renderWithProviders,
+} from "@/test/render-with-providers";
+
 import { AreaFormDialog } from "./area-form-dialog";
-
-const toastMocks = vi.hoisted(() => ({
-  success: vi.fn(),
-  error: vi.fn(),
-}));
-
-vi.mock("@vita-os/ui/lib/toast", () => ({
-  toast: toastMocks,
-}));
 
 function deferred() {
   let resolve!: () => void;
@@ -37,10 +34,15 @@ beforeAll(() => {
 });
 
 describe("AreaFormDialog", () => {
+  let feedback: FeedbackMock;
+
   beforeEach(() => {
-    toastMocks.success.mockClear();
-    toastMocks.error.mockClear();
+    feedback = createFeedbackMock();
   });
+
+  function renderWithFeedback(ui: Parameters<typeof renderWithProviders>[0]) {
+    return renderWithProviders(ui, { feedback });
+  }
 
   it("prevents duplicate area creates while saving", async () => {
     const user = userEvent.setup();
@@ -48,7 +50,7 @@ describe("AreaFormDialog", () => {
     const onSubmit = vi.fn(() => pendingCreate.promise);
     const onOpenChange = vi.fn();
 
-    render(
+    renderWithFeedback(
       <AreaFormDialog
         mode="create"
         open
@@ -82,7 +84,7 @@ describe("AreaFormDialog", () => {
     const pendingCreate = deferred();
     const onSubmit = vi.fn(() => pendingCreate.promise);
 
-    render(
+    renderWithFeedback(
       <AreaFormDialog
         mode="create"
         open
@@ -113,7 +115,7 @@ describe("AreaFormDialog", () => {
       Promise.reject(new Error("Database unavailable")),
     );
 
-    render(
+    renderWithFeedback(
       <AreaFormDialog
         mode="create"
         open
@@ -128,14 +130,14 @@ describe("AreaFormDialog", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Area was not saved. Database unavailable",
     );
-    expect(toastMocks.error).not.toHaveBeenCalled();
+    expect(feedback.error).not.toHaveBeenCalled();
   });
 
   it("shows a structural success toast when area creation succeeds", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn(async () => undefined);
 
-    render(
+    renderWithFeedback(
       <AreaFormDialog
         mode="create"
         open
@@ -148,7 +150,7 @@ describe("AreaFormDialog", () => {
     await user.click(screen.getByRole("button", { name: "Create area" }));
 
     await waitFor(() =>
-      expect(toastMocks.success).toHaveBeenCalledWith("Area created"),
+      expect(feedback.success).toHaveBeenCalledWith("Area created"),
     );
   });
 
@@ -157,7 +159,7 @@ describe("AreaFormDialog", () => {
     const pendingSave = deferred();
     const onSubmit = vi.fn(() => pendingSave.promise);
 
-    render(
+    renderWithFeedback(
       <AreaFormDialog
         mode="edit"
         open
@@ -173,7 +175,7 @@ describe("AreaFormDialog", () => {
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(saveButton).toBeDisabled();
-    expect(toastMocks.success).not.toHaveBeenCalled();
+    expect(feedback.success).not.toHaveBeenCalled();
 
     pendingSave.resolve();
 
@@ -186,7 +188,7 @@ describe("AreaFormDialog", () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn(() => Promise.reject(new Error("Area not found")));
 
-    render(
+    renderWithFeedback(
       <AreaFormDialog
         mode="edit"
         open
@@ -201,6 +203,6 @@ describe("AreaFormDialog", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Area was not saved. Area not found",
     );
-    expect(toastMocks.error).not.toHaveBeenCalled();
+    expect(feedback.error).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/areas/area-form/area-form-dialog.test.tsx
+++ b/apps/web/src/features/areas/area-form/area-form-dialog.test.tsx
@@ -1,12 +1,7 @@
-import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import {
-  createFeedbackMock,
-  type FeedbackMock,
-  renderWithProviders,
-} from "@/test/render-with-providers";
+import { render, screen, waitFor } from "@/test/render-with-providers";
 
 import { AreaFormDialog } from "./area-form-dialog";
 
@@ -18,39 +13,14 @@ function deferred() {
   return { promise, resolve };
 }
 
-beforeAll(() => {
-  window.matchMedia =
-    window.matchMedia ??
-    vi.fn().mockImplementation((query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
-});
-
 describe("AreaFormDialog", () => {
-  let feedback: FeedbackMock;
-
-  beforeEach(() => {
-    feedback = createFeedbackMock();
-  });
-
-  function renderWithFeedback(ui: Parameters<typeof renderWithProviders>[0]) {
-    return renderWithProviders(ui, { feedback });
-  }
-
   it("prevents duplicate area creates while saving", async () => {
     const user = userEvent.setup();
     const pendingCreate = deferred();
     const onSubmit = vi.fn(() => pendingCreate.promise);
     const onOpenChange = vi.fn();
 
-    renderWithFeedback(
+    render(
       <AreaFormDialog
         mode="create"
         open
@@ -84,7 +54,7 @@ describe("AreaFormDialog", () => {
     const pendingCreate = deferred();
     const onSubmit = vi.fn(() => pendingCreate.promise);
 
-    renderWithFeedback(
+    render(
       <AreaFormDialog
         mode="create"
         open
@@ -115,7 +85,7 @@ describe("AreaFormDialog", () => {
       Promise.reject(new Error("Database unavailable")),
     );
 
-    renderWithFeedback(
+    const { feedback } = render(
       <AreaFormDialog
         mode="create"
         open
@@ -137,7 +107,7 @@ describe("AreaFormDialog", () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn(async () => undefined);
 
-    renderWithFeedback(
+    const { feedback } = render(
       <AreaFormDialog
         mode="create"
         open
@@ -159,7 +129,7 @@ describe("AreaFormDialog", () => {
     const pendingSave = deferred();
     const onSubmit = vi.fn(() => pendingSave.promise);
 
-    renderWithFeedback(
+    const { feedback } = render(
       <AreaFormDialog
         mode="edit"
         open
@@ -188,7 +158,7 @@ describe("AreaFormDialog", () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn(() => Promise.reject(new Error("Area not found")));
 
-    renderWithFeedback(
+    const { feedback } = render(
       <AreaFormDialog
         mode="edit"
         open

--- a/apps/web/src/features/shared/use-guarded-async-action.test.ts
+++ b/apps/web/src/features/shared/use-guarded-async-action.test.ts
@@ -1,15 +1,12 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, waitFor } from "@testing-library/react";
 import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const toastMocks = vi.hoisted(() => ({
-  success: vi.fn(),
-  error: vi.fn(),
-}));
-
-vi.mock("@vita-os/ui/lib/toast", () => ({
-  toast: toastMocks,
-}));
+import {
+  createFeedbackMock,
+  type FeedbackMock,
+  renderHookWithProviders,
+} from "@/test/render-with-providers";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -20,16 +17,20 @@ function deferred<T>() {
 }
 
 describe("useGuardedAsyncAction", () => {
+  let feedback: FeedbackMock;
+
   beforeEach(() => {
-    toastMocks.success.mockClear();
-    toastMocks.error.mockClear();
+    feedback = createFeedbackMock();
   });
 
   it("ignores duplicate runs while the action is pending", async () => {
     const pending = deferred<void>();
     const action = vi.fn(() => pending.promise);
 
-    const { result } = renderHook(() => useGuardedAsyncAction(action));
+    const { result } = renderHookWithProviders(
+      () => useGuardedAsyncAction(action),
+      { feedback },
+    );
 
     let first!: ReturnType<typeof result.current.run>;
     let second!: ReturnType<typeof result.current.run>;
@@ -54,8 +55,9 @@ describe("useGuardedAsyncAction", () => {
   it("shows a structural success toast when configured", async () => {
     const action = vi.fn(async () => "done");
 
-    const { result } = renderHook(() =>
-      useGuardedAsyncAction(action, { successMessage: "Task added" }),
+    const { result } = renderHookWithProviders(
+      () => useGuardedAsyncAction(action, { successMessage: "Task added" }),
+      { feedback },
     );
 
     let outcome!: Awaited<ReturnType<typeof result.current.run>>;
@@ -64,18 +66,59 @@ describe("useGuardedAsyncAction", () => {
     });
 
     expect(outcome).toEqual({ ok: true, value: "done" });
-    expect(toastMocks.success).toHaveBeenCalledWith("Task added");
+    expect(feedback.success).toHaveBeenCalledWith("Task added");
   });
 
   it("stays quiet on success when no success message is configured", async () => {
     const action = vi.fn(async () => "done");
 
-    const { result } = renderHook(() => useGuardedAsyncAction(action));
+    const { result } = renderHookWithProviders(
+      () => useGuardedAsyncAction(action),
+      { feedback },
+    );
 
     await act(async () => {
       await result.current.run();
     });
 
-    expect(toastMocks.success).not.toHaveBeenCalled();
+    expect(feedback.success).not.toHaveBeenCalled();
+  });
+
+  it("shows an error toast by default when the action fails", async () => {
+    const action = vi.fn(() => Promise.reject(new Error("Save failed")));
+
+    const { result } = renderHookWithProviders(
+      () => useGuardedAsyncAction(action),
+      { feedback },
+    );
+
+    let outcome!: Awaited<ReturnType<typeof result.current.run>>;
+    await act(async () => {
+      outcome = await result.current.run();
+    });
+
+    expect(outcome).toEqual({
+      ok: false,
+      skipped: false,
+      error: "Save failed",
+    });
+    expect(result.current.error).toBe("Save failed");
+    expect(feedback.error).toHaveBeenCalledWith("Save failed");
+  });
+
+  it("suppresses the error toast when errorToast is false", async () => {
+    const action = vi.fn(() => Promise.reject(new Error("Save failed")));
+
+    const { result } = renderHookWithProviders(
+      () => useGuardedAsyncAction(action, { errorToast: false }),
+      { feedback },
+    );
+
+    await act(async () => {
+      await result.current.run();
+    });
+
+    expect(result.current.error).toBe("Save failed");
+    expect(feedback.error).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/shared/use-guarded-async-action.test.ts
+++ b/apps/web/src/features/shared/use-guarded-async-action.test.ts
@@ -1,12 +1,7 @@
-import { act, waitFor } from "@testing-library/react";
 import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import {
-  createFeedbackMock,
-  type FeedbackMock,
-  renderHookWithProviders,
-} from "@/test/render-with-providers";
+import { act, renderHook, waitFor } from "@/test/render-with-providers";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -17,20 +12,11 @@ function deferred<T>() {
 }
 
 describe("useGuardedAsyncAction", () => {
-  let feedback: FeedbackMock;
-
-  beforeEach(() => {
-    feedback = createFeedbackMock();
-  });
-
   it("ignores duplicate runs while the action is pending", async () => {
     const pending = deferred<void>();
     const action = vi.fn(() => pending.promise);
 
-    const { result } = renderHookWithProviders(
-      () => useGuardedAsyncAction(action),
-      { feedback },
-    );
+    const { result } = renderHook(() => useGuardedAsyncAction(action));
 
     let first!: ReturnType<typeof result.current.run>;
     let second!: ReturnType<typeof result.current.run>;
@@ -55,9 +41,8 @@ describe("useGuardedAsyncAction", () => {
   it("shows a structural success toast when configured", async () => {
     const action = vi.fn(async () => "done");
 
-    const { result } = renderHookWithProviders(
-      () => useGuardedAsyncAction(action, { successMessage: "Task added" }),
-      { feedback },
+    const { result, feedback } = renderHook(() =>
+      useGuardedAsyncAction(action, { successMessage: "Task added" }),
     );
 
     let outcome!: Awaited<ReturnType<typeof result.current.run>>;
@@ -72,9 +57,8 @@ describe("useGuardedAsyncAction", () => {
   it("stays quiet on success when no success message is configured", async () => {
     const action = vi.fn(async () => "done");
 
-    const { result } = renderHookWithProviders(
-      () => useGuardedAsyncAction(action),
-      { feedback },
+    const { result, feedback } = renderHook(() =>
+      useGuardedAsyncAction(action),
     );
 
     await act(async () => {
@@ -87,9 +71,8 @@ describe("useGuardedAsyncAction", () => {
   it("shows an error toast by default when the action fails", async () => {
     const action = vi.fn(() => Promise.reject(new Error("Save failed")));
 
-    const { result } = renderHookWithProviders(
-      () => useGuardedAsyncAction(action),
-      { feedback },
+    const { result, feedback } = renderHook(() =>
+      useGuardedAsyncAction(action),
     );
 
     let outcome!: Awaited<ReturnType<typeof result.current.run>>;
@@ -109,9 +92,8 @@ describe("useGuardedAsyncAction", () => {
   it("suppresses the error toast when errorToast is false", async () => {
     const action = vi.fn(() => Promise.reject(new Error("Save failed")));
 
-    const { result } = renderHookWithProviders(
-      () => useGuardedAsyncAction(action, { errorToast: false }),
-      { feedback },
+    const { result, feedback } = renderHook(() =>
+      useGuardedAsyncAction(action, { errorToast: false }),
     );
 
     await act(async () => {

--- a/apps/web/src/features/tasks/new-task/new-task-dialog.test.tsx
+++ b/apps/web/src/features/tasks/new-task/new-task-dialog.test.tsx
@@ -1,17 +1,14 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  createFeedbackMock,
+  type FeedbackMock,
+  renderWithProviders,
+} from "@/test/render-with-providers";
+
 import { NewTaskDialog } from "./new-task-dialog";
-
-const toastMocks = vi.hoisted(() => ({
-  success: vi.fn(),
-  error: vi.fn(),
-}));
-
-vi.mock("@vita-os/ui/lib/toast", () => ({
-  toast: toastMocks,
-}));
 
 function deferred() {
   let resolve!: () => void;
@@ -39,10 +36,15 @@ beforeAll(() => {
 });
 
 describe("NewTaskDialog", () => {
+  let feedback: FeedbackMock;
+
   beforeEach(() => {
-    toastMocks.success.mockClear();
-    toastMocks.error.mockClear();
+    feedback = createFeedbackMock();
   });
+
+  function renderWithFeedback(ui: Parameters<typeof renderWithProviders>[0]) {
+    return renderWithProviders(ui, { feedback });
+  }
 
   it("prevents duplicate task creates while saving", async () => {
     const user = userEvent.setup();
@@ -50,7 +52,7 @@ describe("NewTaskDialog", () => {
     const onSubmit = vi.fn(() => pendingCreate.promise);
     const onOpenChange = vi.fn();
 
-    render(
+    renderWithFeedback(
       <NewTaskDialog open onOpenChange={onOpenChange} onSubmit={onSubmit} />,
     );
 
@@ -81,7 +83,9 @@ describe("NewTaskDialog", () => {
       Promise.reject(new Error("Could not save task")),
     );
 
-    render(<NewTaskDialog open onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+    renderWithFeedback(
+      <NewTaskDialog open onOpenChange={vi.fn()} onSubmit={onSubmit} />,
+    );
 
     await user.type(
       screen.getByPlaceholderText("What's on your mind?"),
@@ -92,14 +96,16 @@ describe("NewTaskDialog", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Could not save task",
     );
-    expect(toastMocks.error).not.toHaveBeenCalled();
+    expect(feedback.error).not.toHaveBeenCalled();
   });
 
   it("shows a structural success toast when task creation succeeds", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn(async () => undefined);
 
-    render(<NewTaskDialog open onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+    renderWithFeedback(
+      <NewTaskDialog open onOpenChange={vi.fn()} onSubmit={onSubmit} />,
+    );
 
     await user.type(
       screen.getByPlaceholderText("What's on your mind?"),
@@ -108,7 +114,7 @@ describe("NewTaskDialog", () => {
     await user.click(screen.getByRole("button", { name: "Add" }));
 
     await waitFor(() =>
-      expect(toastMocks.success).toHaveBeenCalledWith("Task added"),
+      expect(feedback.success).toHaveBeenCalledWith("Task added"),
     );
   });
 });

--- a/apps/web/src/features/tasks/new-task/new-task-dialog.test.tsx
+++ b/apps/web/src/features/tasks/new-task/new-task-dialog.test.tsx
@@ -1,12 +1,7 @@
-import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import {
-  createFeedbackMock,
-  type FeedbackMock,
-  renderWithProviders,
-} from "@/test/render-with-providers";
+import { render, screen, waitFor } from "@/test/render-with-providers";
 
 import { NewTaskDialog } from "./new-task-dialog";
 
@@ -20,39 +15,14 @@ function deferred() {
   return { promise, resolve, reject };
 }
 
-beforeAll(() => {
-  window.matchMedia =
-    window.matchMedia ??
-    vi.fn().mockImplementation((query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
-});
-
 describe("NewTaskDialog", () => {
-  let feedback: FeedbackMock;
-
-  beforeEach(() => {
-    feedback = createFeedbackMock();
-  });
-
-  function renderWithFeedback(ui: Parameters<typeof renderWithProviders>[0]) {
-    return renderWithProviders(ui, { feedback });
-  }
-
   it("prevents duplicate task creates while saving", async () => {
     const user = userEvent.setup();
     const pendingCreate = deferred();
     const onSubmit = vi.fn(() => pendingCreate.promise);
     const onOpenChange = vi.fn();
 
-    renderWithFeedback(
+    render(
       <NewTaskDialog open onOpenChange={onOpenChange} onSubmit={onSubmit} />,
     );
 
@@ -83,7 +53,7 @@ describe("NewTaskDialog", () => {
       Promise.reject(new Error("Could not save task")),
     );
 
-    renderWithFeedback(
+    const { feedback } = render(
       <NewTaskDialog open onOpenChange={vi.fn()} onSubmit={onSubmit} />,
     );
 
@@ -103,7 +73,7 @@ describe("NewTaskDialog", () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn(async () => undefined);
 
-    renderWithFeedback(
+    const { feedback } = render(
       <NewTaskDialog open onOpenChange={vi.fn()} onSubmit={onSubmit} />,
     );
 

--- a/apps/web/src/features/tasks/process-task/process-task-dialog.test.tsx
+++ b/apps/web/src/features/tasks/process-task/process-task-dialog.test.tsx
@@ -2,7 +2,7 @@ import type { Doc, Id } from "@convex/_generated/dataModel";
 
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { ProcessTaskDialog } from "./process-task-dialog";
 
@@ -61,21 +61,6 @@ const threads = [
     createdAt: 0,
   },
 ] satisfies Doc<"threads">[];
-
-beforeAll(() => {
-  window.matchMedia =
-    window.matchMedia ??
-    vi.fn().mockImplementation((query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
-});
 
 function renderDialog(
   onProcess = vi.fn(),

--- a/apps/web/src/features/threads/components/thread-area-section.test.tsx
+++ b/apps/web/src/features/threads/components/thread-area-section.test.tsx
@@ -2,7 +2,7 @@ import type { Doc, Id } from "@convex/_generated/dataModel";
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { ThreadAreaSection } from "./thread-area-section";
 
@@ -39,21 +39,6 @@ const thread = {
   order: 0,
   createdAt: 0,
 } satisfies Doc<"threads">;
-
-beforeAll(() => {
-  window.matchMedia =
-    window.matchMedia ??
-    vi.fn().mockImplementation((query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
-});
 
 describe("ThreadAreaSection", () => {
   it("lets the user move a thread to another area", async () => {

--- a/apps/web/src/features/threads/thread-form/thread-form-dialog.test.tsx
+++ b/apps/web/src/features/threads/thread-form/thread-form-dialog.test.tsx
@@ -1,19 +1,16 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  createFeedbackMock,
+  type FeedbackMock,
+  renderWithProviders,
+} from "@/test/render-with-providers";
+
 import { ThreadFormDialog } from "./thread-form-dialog";
-
-const toastMocks = vi.hoisted(() => ({
-  success: vi.fn(),
-  error: vi.fn(),
-}));
-
-vi.mock("@vita-os/ui/lib/toast", () => ({
-  toast: toastMocks,
-}));
 
 const areas = [
   {
@@ -52,13 +49,18 @@ function deferred() {
 }
 
 describe("ThreadFormDialog", () => {
+  let feedback: FeedbackMock;
+
   beforeEach(() => {
-    toastMocks.success.mockClear();
-    toastMocks.error.mockClear();
+    feedback = createFeedbackMock();
   });
 
+  function renderWithFeedback(ui: Parameters<typeof renderWithProviders>[0]) {
+    return renderWithProviders(ui, { feedback });
+  }
+
   it("uses Thread language and optional Summary on create", () => {
-    render(
+    renderWithFeedback(
       <ThreadFormDialog
         mode="create"
         open
@@ -83,7 +85,7 @@ describe("ThreadFormDialog", () => {
     const pendingCreate = deferred();
     const onSubmit = vi.fn(() => pendingCreate.promise);
 
-    render(
+    renderWithFeedback(
       <ThreadFormDialog
         mode="create"
         open
@@ -116,7 +118,7 @@ describe("ThreadFormDialog", () => {
     const pendingCreate = deferred();
     const onSubmit = vi.fn(() => pendingCreate.promise);
 
-    render(
+    renderWithFeedback(
       <ThreadFormDialog
         mode="create"
         open
@@ -151,7 +153,7 @@ describe("ThreadFormDialog", () => {
       Promise.reject(new Error("Database unavailable")),
     );
 
-    render(
+    renderWithFeedback(
       <ThreadFormDialog
         mode="create"
         open
@@ -168,14 +170,14 @@ describe("ThreadFormDialog", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Thread was not saved. Database unavailable",
     );
-    expect(toastMocks.error).not.toHaveBeenCalled();
+    expect(feedback.error).not.toHaveBeenCalled();
   });
 
   it("shows a structural success toast when thread creation succeeds", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn(async () => undefined);
 
-    render(
+    renderWithFeedback(
       <ThreadFormDialog
         mode="create"
         open
@@ -190,7 +192,7 @@ describe("ThreadFormDialog", () => {
     await user.click(screen.getByRole("button", { name: "Create thread" }));
 
     await waitFor(() =>
-      expect(toastMocks.success).toHaveBeenCalledWith("Thread created"),
+      expect(feedback.success).toHaveBeenCalledWith("Thread created"),
     );
   });
 
@@ -199,7 +201,7 @@ describe("ThreadFormDialog", () => {
     const pendingSave = deferred();
     const onSubmit = vi.fn(() => pendingSave.promise);
 
-    render(
+    renderWithFeedback(
       <ThreadFormDialog
         mode="edit"
         open
@@ -216,7 +218,7 @@ describe("ThreadFormDialog", () => {
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(saveButton).toBeDisabled();
-    expect(toastMocks.success).not.toHaveBeenCalled();
+    expect(feedback.success).not.toHaveBeenCalled();
 
     pendingSave.resolve();
 
@@ -229,7 +231,7 @@ describe("ThreadFormDialog", () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn(() => Promise.reject(new Error("Thread not found")));
 
-    render(
+    renderWithFeedback(
       <ThreadFormDialog
         mode="edit"
         open
@@ -245,6 +247,6 @@ describe("ThreadFormDialog", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Thread was not saved. Thread not found",
     );
-    expect(toastMocks.error).not.toHaveBeenCalled();
+    expect(feedback.error).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/threads/thread-form/thread-form-dialog.test.tsx
+++ b/apps/web/src/features/threads/thread-form/thread-form-dialog.test.tsx
@@ -1,14 +1,9 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
 
-import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import {
-  createFeedbackMock,
-  type FeedbackMock,
-  renderWithProviders,
-} from "@/test/render-with-providers";
+import { render, screen, waitFor } from "@/test/render-with-providers";
 
 import { ThreadFormDialog } from "./thread-form-dialog";
 
@@ -25,21 +20,6 @@ const areas = [
   },
 ] satisfies Doc<"areas">[];
 
-beforeAll(() => {
-  window.matchMedia =
-    window.matchMedia ??
-    vi.fn().mockImplementation((query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
-});
-
 function deferred() {
   let resolve!: () => void;
   const promise = new Promise<void>((resolvePromise) => {
@@ -49,18 +29,8 @@ function deferred() {
 }
 
 describe("ThreadFormDialog", () => {
-  let feedback: FeedbackMock;
-
-  beforeEach(() => {
-    feedback = createFeedbackMock();
-  });
-
-  function renderWithFeedback(ui: Parameters<typeof renderWithProviders>[0]) {
-    return renderWithProviders(ui, { feedback });
-  }
-
   it("uses Thread language and optional Summary on create", () => {
-    renderWithFeedback(
+    render(
       <ThreadFormDialog
         mode="create"
         open
@@ -85,7 +55,7 @@ describe("ThreadFormDialog", () => {
     const pendingCreate = deferred();
     const onSubmit = vi.fn(() => pendingCreate.promise);
 
-    renderWithFeedback(
+    render(
       <ThreadFormDialog
         mode="create"
         open
@@ -118,7 +88,7 @@ describe("ThreadFormDialog", () => {
     const pendingCreate = deferred();
     const onSubmit = vi.fn(() => pendingCreate.promise);
 
-    renderWithFeedback(
+    render(
       <ThreadFormDialog
         mode="create"
         open
@@ -153,7 +123,7 @@ describe("ThreadFormDialog", () => {
       Promise.reject(new Error("Database unavailable")),
     );
 
-    renderWithFeedback(
+    const { feedback } = render(
       <ThreadFormDialog
         mode="create"
         open
@@ -177,7 +147,7 @@ describe("ThreadFormDialog", () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn(async () => undefined);
 
-    renderWithFeedback(
+    const { feedback } = render(
       <ThreadFormDialog
         mode="create"
         open
@@ -201,7 +171,7 @@ describe("ThreadFormDialog", () => {
     const pendingSave = deferred();
     const onSubmit = vi.fn(() => pendingSave.promise);
 
-    renderWithFeedback(
+    const { feedback } = render(
       <ThreadFormDialog
         mode="edit"
         open
@@ -231,7 +201,7 @@ describe("ThreadFormDialog", () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn(() => Promise.reject(new Error("Thread not found")));
 
-    renderWithFeedback(
+    const { feedback } = render(
       <ThreadFormDialog
         mode="edit"
         open

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,7 @@
 import { ConvexBetterAuthProvider } from "@convex-dev/better-auth/react";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { Toaster } from "@vita-os/ui/components/sonner";
+import { FeedbackProvider } from "@vita-os/ui/lib/feedback";
 import { ConvexQueryCacheProvider } from "convex-helpers/react/cache";
 import { ConvexReactClient } from "convex/react";
 import { StrictMode } from "react";
@@ -33,8 +34,10 @@ createRoot(root).render(
   <StrictMode>
     <ConvexBetterAuthProvider client={convex} authClient={authClient}>
       <ConvexQueryCacheProvider expiration={300_000}>
-        <RouterProvider router={router} />
-        <Toaster />
+        <FeedbackProvider>
+          <RouterProvider router={router} />
+          <Toaster />
+        </FeedbackProvider>
       </ConvexQueryCacheProvider>
     </ConvexBetterAuthProvider>
   </StrictMode>,

--- a/apps/web/src/test/render-with-providers.tsx
+++ b/apps/web/src/test/render-with-providers.tsx
@@ -1,8 +1,8 @@
 import type { ReactElement, ReactNode } from "react";
 
 import {
-  render,
-  renderHook,
+  render as rtlRender,
+  renderHook as rtlRenderHook,
   type RenderHookOptions,
   type RenderOptions,
 } from "@testing-library/react";
@@ -37,28 +37,33 @@ function createWrapper(feedback: Feedback) {
   };
 }
 
-export function renderWithProviders(
+function customRender(
   ui: ReactElement,
   {
     feedback = createFeedbackMock(),
     ...options
   }: RenderWithProvidersOptions = {},
 ) {
-  return render(ui, {
+  const result = rtlRender(ui, {
     ...options,
     wrapper: createWrapper(feedback),
   });
+  return { ...result, feedback };
 }
 
-export function renderHookWithProviders<TResult, TProps>(
+function customRenderHook<TResult, TProps>(
   hook: (initialProps: TProps) => TResult,
   {
     feedback = createFeedbackMock(),
     ...options
   }: RenderHookWithProvidersOptions<TProps> = {},
 ) {
-  return renderHook(hook, {
+  const result = rtlRenderHook(hook, {
     ...options,
     wrapper: createWrapper(feedback),
   });
+  return { ...result, feedback };
 }
+
+export * from "@testing-library/react";
+export { customRender as render, customRenderHook as renderHook };

--- a/apps/web/src/test/render-with-providers.tsx
+++ b/apps/web/src/test/render-with-providers.tsx
@@ -1,0 +1,64 @@
+import type { ReactElement, ReactNode } from "react";
+
+import {
+  render,
+  renderHook,
+  type RenderHookOptions,
+  type RenderOptions,
+} from "@testing-library/react";
+import { FeedbackProvider, type Feedback } from "@vita-os/ui/lib/feedback";
+import { vi } from "vitest";
+
+export type FeedbackMock = Feedback;
+
+type ProviderOptions = {
+  feedback?: Feedback;
+};
+
+type RenderWithProvidersOptions = Omit<RenderOptions, "wrapper"> &
+  ProviderOptions;
+
+type RenderHookWithProvidersOptions<TProps> = Omit<
+  RenderHookOptions<TProps>,
+  "wrapper"
+> &
+  ProviderOptions;
+
+export function createFeedbackMock(): FeedbackMock {
+  return {
+    success: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function createWrapper(feedback: Feedback) {
+  return function Providers({ children }: { children: ReactNode }) {
+    return <FeedbackProvider feedback={feedback}>{children}</FeedbackProvider>;
+  };
+}
+
+export function renderWithProviders(
+  ui: ReactElement,
+  {
+    feedback = createFeedbackMock(),
+    ...options
+  }: RenderWithProvidersOptions = {},
+) {
+  return render(ui, {
+    ...options,
+    wrapper: createWrapper(feedback),
+  });
+}
+
+export function renderHookWithProviders<TResult, TProps>(
+  hook: (initialProps: TProps) => TResult,
+  {
+    feedback = createFeedbackMock(),
+    ...options
+  }: RenderHookWithProvidersOptions<TProps> = {},
+) {
+  return renderHook(hook, {
+    ...options,
+    wrapper: createWrapper(feedback),
+  });
+}

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,1 +1,15 @@
 import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+window.matchMedia =
+  window.matchMedia ??
+  vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));

--- a/packages/ui/src/hooks/use-guarded-async-action.ts
+++ b/packages/ui/src/hooks/use-guarded-async-action.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 
-import { toast } from "../lib/toast";
+import { useFeedback } from "../lib/feedback";
 
 export type GuardedAsyncFeedback = {
   /** Success toast for structural actions. Omit for quiet inline edits. */
@@ -26,6 +26,7 @@ export function useGuardedAsyncAction<TArgs extends unknown[], TResult>(
   action: (...args: TArgs) => Promise<TResult> | TResult,
   feedback: GuardedAsyncFeedback = {},
 ) {
+  const feedbackClient = useFeedback();
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const pendingRef = useRef(false);
@@ -51,14 +52,14 @@ export function useGuardedAsyncAction<TArgs extends unknown[], TResult>(
       try {
         const value = await action(...args);
         if (successMessage) {
-          toast.success(successMessage);
+          feedbackClient.success(successMessage);
         }
         return { ok: true, value };
       } catch (err) {
         const message = getErrorMessage(err);
         setError(message);
         if (errorToast) {
-          toast.error(message);
+          feedbackClient.error(message);
         }
         return { ok: false, skipped: false, error: message };
       } finally {
@@ -66,7 +67,7 @@ export function useGuardedAsyncAction<TArgs extends unknown[], TResult>(
         setIsPending(false);
       }
     },
-    [action, successMessage, errorToast, getErrorMessage],
+    [action, successMessage, errorToast, getErrorMessage, feedbackClient],
   );
 
   return { run, isPending, error, clearError };

--- a/packages/ui/src/lib/feedback.ts
+++ b/packages/ui/src/lib/feedback.ts
@@ -1,0 +1,38 @@
+import {
+  createContext,
+  createElement,
+  useContext,
+  type ReactNode,
+} from "react";
+
+import { toast } from "./toast";
+
+export type Feedback = {
+  success(message: string): void;
+  error(message: string): void;
+};
+
+const defaultFeedback: Feedback = {
+  success: (message) => toast.success(message),
+  error: (message) => toast.error(message),
+};
+
+const FeedbackContext = createContext<Feedback | null>(null);
+
+export function FeedbackProvider({
+  children,
+  feedback = defaultFeedback,
+}: {
+  children: ReactNode;
+  feedback?: Feedback;
+}) {
+  return createElement(FeedbackContext.Provider, { value: feedback }, children);
+}
+
+export function useFeedback() {
+  const feedback = useContext(FeedbackContext);
+  if (!feedback) {
+    throw new Error("useFeedback must be used within a FeedbackProvider");
+  }
+  return feedback;
+}


### PR DESCRIPTION
## Summary
- Add a narrow FeedbackProvider/useFeedback API in the UI package backed by the existing toast implementation
- Wire guarded async actions through feedback context instead of importing toast directly
- Add shared test provider helpers and migrate notification assertions away from toast module mocks

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`

Closes #191