### PR TITLE
feat(web): add async reliability to inbox task actions

### DIFF
--- a/apps/web/src/features/inbox/screens/inbox-screen.tsx
+++ b/apps/web/src/features/inbox/screens/inbox-screen.tsx
@@ -1,8 +1,6 @@
 import type { Doc } from "@convex/_generated/dataModel";
 
 import { api } from "@convex/_generated/api";
-import { Link } from "@tanstack/react-router";
-import { Button } from "@vita-os/ui/components/button";
 import {
   Collapsible,
   CollapsibleContent,
@@ -17,19 +15,10 @@ import { PageHeader } from "@/components/layout/page-header";
 import { ProcessTaskDialogContainer } from "@/features/tasks/process-task/process-task-dialog-container";
 import { TaskRowContainer } from "@/features/tasks/task-row/task-row-container";
 
-interface ProcessingNotification {
-  action: "create_thread" | "add_activity_log_entry" | "set_next_move";
-  thread: Pick<Doc<"threads">, "title" | "slug">;
-  area: Doc<"areas"> | undefined;
-}
-
 export function InboxScreen() {
   const tasks = useQuery(api.tasks.list);
   const [processingTask, setProcessingTask] = useState<
     Doc<"tasks"> | undefined
-  >(undefined);
-  const [notification, setNotification] = useState<
-    ProcessingNotification | undefined
   >(undefined);
 
   if (tasks === undefined) {
@@ -93,57 +82,9 @@ export function InboxScreen() {
             if (!open) setProcessingTask(undefined);
           }}
           task={processingTask}
-          onProcessed={setNotification}
-        />
-      )}
-
-      {notification && (
-        <ProcessingToast
-          notification={notification}
-          onDismiss={() => setNotification(undefined)}
         />
       )}
     </div>
-  );
-}
-
-function ProcessingToast({
-  notification,
-  onDismiss,
-}: {
-  notification: ProcessingNotification;
-  onDismiss: () => void;
-}) {
-  const message =
-    notification.action === "create_thread"
-      ? "Created thread"
-      : notification.action === "set_next_move"
-        ? "Set Next Move"
-        : "Added Activity Log entry";
-
-  return (
-    <output className="fixed right-4 bottom-4 z-50 flex max-w-sm items-center gap-3 rounded-lg border border-border-subtle bg-popover px-4 py-3 text-sm text-popover-foreground shadow-lg">
-      <span className="min-w-0">
-        {message} in{" "}
-        {notification.area && notification.thread.slug ? (
-          <Link
-            to="/$areaSlug/$threadSlug"
-            params={{
-              areaSlug: notification.area.slug ?? notification.area._id,
-              threadSlug: notification.thread.slug,
-            }}
-            className="font-medium text-primary underline-offset-4 hover:underline"
-          >
-            {notification.thread.title}
-          </Link>
-        ) : (
-          <span className="font-medium">{notification.thread.title}</span>
-        )}
-      </span>
-      <Button type="button" variant="ghost" size="xs" onClick={onDismiss}>
-        Dismiss
-      </Button>
-    </output>
   );
 }
 

--- a/apps/web/src/features/tasks/process-task/process-task-dialog-container.tsx
+++ b/apps/web/src/features/tasks/process-task/process-task-dialog-container.tsx
@@ -3,8 +3,6 @@ import type { Doc } from "@convex/_generated/dataModel";
 import { api } from "@convex/_generated/api";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 
-import type { ProcessTaskAction } from "@/features/tasks/use-process-task";
-
 import { useProcessTask } from "@/features/tasks/use-process-task";
 
 import { ProcessTaskDialog } from "./process-task-dialog";
@@ -13,21 +11,12 @@ interface ProcessTaskDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   task: Doc<"tasks">;
-  onProcessed?: (result: {
-    action: Extract<
-      ProcessTaskAction,
-      { type: "create_thread" | "add_activity_log_entry" | "set_next_move" }
-    >["type"];
-    thread: Pick<Doc<"threads">, "title" | "slug">;
-    area: Doc<"areas"> | undefined;
-  }) => void;
 }
 
 export function ProcessTaskDialogContainer({
   open,
   onOpenChange,
   task,
-  onProcessed,
 }: ProcessTaskDialogProps) {
   const processTask = useProcessTask();
   const areas = useQuery(api.areas.list, open ? {} : "skip");
@@ -45,30 +34,7 @@ export function ProcessTaskDialogContainer({
       threads={visibleThreads}
       isLoading={isLoading}
       onProcess={async (taskId, action) => {
-        const result = await processTask(taskId, action);
-        if (action.type === "create_thread" && result.type === "created") {
-          onProcessed?.({
-            action: action.type,
-            thread: { title: action.title, slug: result.slug },
-            area: visibleAreas.find((area) => area._id === action.areaId),
-          });
-        }
-        if (
-          action.type === "add_activity_log_entry" ||
-          action.type === "set_next_move"
-        ) {
-          const thread = visibleThreads.find(
-            (candidate) => candidate._id === action.threadId,
-          );
-          if (thread) {
-            onProcessed?.({
-              action: action.type,
-              thread,
-              area: visibleAreas.find((area) => area._id === thread.areaId),
-            });
-          }
-        }
-        onOpenChange(false);
+        await processTask(taskId, action);
       }}
     />
   );

--- a/apps/web/src/features/tasks/process-task/process-task-dialog.test.tsx
+++ b/apps/web/src/features/tasks/process-task/process-task-dialog.test.tsx
@@ -1,10 +1,19 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
 
-import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
+import { render, screen, within, waitFor } from "@/test/render-with-providers";
+
 import { ProcessTaskDialog } from "./process-task-dialog";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 const task = {
   _id: "task1" as Id<"tasks">,
@@ -199,5 +208,60 @@ describe("ProcessTaskDialog", () => {
       title: "Schedule dentist visit",
       areaId: healthArea._id,
     });
+  });
+
+  it("prevents duplicate process submissions while saving", async () => {
+    const user = userEvent.setup();
+    const pendingProcess = deferred();
+    const onProcess = vi.fn(() => pendingProcess.promise);
+    renderDialog(onProcess);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /book annual/i }));
+
+    const processButton = screen.getByRole("button", { name: /process/i });
+    await user.click(processButton);
+    await user.click(processButton);
+
+    expect(onProcess).toHaveBeenCalledTimes(1);
+    expect(processButton).toBeDisabled();
+    expect(processButton).toHaveAttribute("aria-busy", "true");
+
+    pendingProcess.resolve();
+
+    await waitFor(() =>
+      expect(processButton).toHaveAttribute("aria-busy", "false"),
+    );
+  });
+
+  it("shows an error toast when process submission fails", async () => {
+    const user = userEvent.setup();
+    const onProcess = vi.fn(() =>
+      Promise.reject(new Error("Could not process task")),
+    );
+
+    const { feedback } = renderDialog(onProcess);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /book annual/i }));
+    await user.click(screen.getByRole("button", { name: /process/i }));
+
+    expect(feedback.error).toHaveBeenCalledWith("Could not process task");
+  });
+
+  it("shows a structural success toast for Next Move outcomes", async () => {
+    const user = userEvent.setup();
+    const onProcess = vi.fn(async () => undefined);
+
+    const { feedback } = renderDialog(onProcess);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /book annual/i }));
+    await user.click(screen.getByRole("radio", { name: /next move/i }));
+    await user.click(screen.getByRole("button", { name: /process/i }));
+
+    expect(feedback.success).toHaveBeenCalledWith(
+      "Set Next Move · Book annual checkup",
+    );
   });
 });

--- a/apps/web/src/features/tasks/process-task/process-task-dialog.tsx
+++ b/apps/web/src/features/tasks/process-task/process-task-dialog.tsx
@@ -15,6 +15,8 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@vita-os/ui/components/responsive-dialog";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
+import { useFeedback } from "@vita-os/ui/lib/feedback";
 import { cn } from "@vita-os/ui/lib/utils";
 import { formatDistanceToNow } from "date-fns";
 import { ArrowRight, Check, FileText, Target } from "lucide-react";
@@ -42,6 +44,24 @@ interface ProcessTaskDialogProps {
   ) => void | Promise<void>;
 }
 
+function getProcessSuccessMessage(
+  action: ProcessTaskAction,
+  threads: Doc<"threads">[],
+): string {
+  if (action.type === "create_thread") {
+    return `Created thread · ${action.title}`;
+  }
+
+  const thread = threads.find((candidate) => candidate._id === action.threadId);
+  const threadTitle = thread?.title ?? "thread";
+
+  if (action.type === "set_next_move") {
+    return `Set Next Move · ${threadTitle}`;
+  }
+
+  return `Added Activity Log entry · ${threadTitle}`;
+}
+
 export function ProcessTaskDialog({
   open,
   onOpenChange,
@@ -51,6 +71,7 @@ export function ProcessTaskDialog({
   isLoading = false,
   onProcess,
 }: ProcessTaskDialogProps) {
+  const feedback = useFeedback();
   const [choice, setChoice] = useState<ThreadChoice | null>(null);
   const [inputValue, setInputValue] = useState("");
   const [mode, setMode] = useState<ProcessingMode>("add_activity_log_entry");
@@ -58,7 +79,13 @@ export function ProcessTaskDialog({
     title: string;
   } | null>(null);
   const [createAreaId, setCreateAreaId] = useState<string | undefined>();
-  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { run: submitProcess, isPending } = useGuardedAsyncAction(
+    async (action: ProcessTaskAction) => {
+      await onProcess(task._id, action);
+    },
+    { errorToast: true },
+  );
 
   const isCreating = creationDraft !== null;
   const createTitle = creationDraft?.title ?? "";
@@ -67,6 +94,11 @@ export function ProcessTaskDialog({
   const canSubmit =
     !!selectedThread ||
     (isCreating && createTitle.trim().length > 0 && !!createAreaId);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (isPending && !nextOpen) return;
+    onOpenChange(nextOpen);
+  };
 
   const resetCreationFields = () => {
     setCreateAreaId(undefined);
@@ -127,31 +159,37 @@ export function ProcessTaskDialog({
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (!canSubmit) return;
+    if (!canSubmit || isPending) return;
 
-    setIsSubmitting(true);
-    try {
-      if (isCreating) {
-        await onProcess(task._id, {
-          type: "create_thread",
-          title: createTitle.trim(),
-          areaId: createAreaId as Id<"areas">,
-        });
-      } else if (selectedThread) {
-        await onProcess(task._id, {
-          type: mode,
-          threadId: selectedThread._id,
-        });
-      }
+    let action: ProcessTaskAction | undefined;
+    if (isCreating) {
+      action = {
+        type: "create_thread",
+        title: createTitle.trim(),
+        areaId: createAreaId as Id<"areas">,
+      };
+    } else if (selectedThread) {
+      action = {
+        type: mode,
+        threadId: selectedThread._id,
+      };
+    }
+
+    if (!action) return;
+
+    const result = await submitProcess(action);
+    if (result.ok) {
+      feedback.success(getProcessSuccessMessage(action, threads));
       onOpenChange(false);
-    } finally {
-      setIsSubmitting(false);
     }
   };
 
   return (
-    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
-      <ResponsiveDialogContent className="sm:max-w-lg">
+    <ResponsiveDialog open={open} onOpenChange={handleOpenChange}>
+      <ResponsiveDialogContent
+        className="sm:max-w-lg"
+        showCloseButton={!isPending}
+      >
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>Process task</ResponsiveDialogTitle>
         </ResponsiveDialogHeader>
@@ -208,11 +246,16 @@ export function ProcessTaskDialog({
             <Button
               type="button"
               variant="ghost"
-              onClick={() => onOpenChange(false)}
+              onClick={() => handleOpenChange(false)}
+              disabled={isPending}
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={!canSubmit || isSubmitting}>
+            <Button
+              type="submit"
+              disabled={!canSubmit || isPending}
+              aria-busy={isPending}
+            >
               Process
               <ArrowRight className="h-4 w-4" />
             </Button>

--- a/apps/web/src/features/tasks/task-row/task-row-container.tsx
+++ b/apps/web/src/features/tasks/task-row/task-row-container.tsx
@@ -1,10 +1,6 @@
 import type { Doc } from "@convex/_generated/dataModel";
 
-import { useCompleteTask } from "@/features/tasks/use-complete-task";
-import { useRemoveTask } from "@/features/tasks/use-remove-task";
-import { useUncompleteTask } from "@/features/tasks/use-uncomplete-task";
-import { useUpdateTaskText } from "@/features/tasks/use-update-task-text";
-import { useUpdateTaskWhen } from "@/features/tasks/use-update-task-when";
+import { useTaskRowActions } from "@/features/tasks/task-row/use-task-row-actions";
 
 import { TaskRow } from "./task-row";
 
@@ -14,24 +10,29 @@ interface TaskRowProps {
 }
 
 export function TaskRowContainer({ task, onProcess }: TaskRowProps) {
-  const completeTask = useCompleteTask();
-  const uncompleteTask = useUncompleteTask();
-  const removeTask = useRemoveTask();
-  const updateTaskText = useUpdateTaskText();
-  const updateTaskWhen = useUpdateTaskWhen();
+  const {
+    handleToggleComplete,
+    isTogglePending,
+    handleRemove,
+    isDiscardPending,
+    handleUpdateText,
+    isSavingText,
+    handleUpdateWhen,
+    isWhenPending,
+  } = useTaskRowActions(task);
 
   return (
     <TaskRow
       task={task}
-      onToggleComplete={() =>
-        task.state === "done"
-          ? uncompleteTask(task._id)
-          : completeTask(task._id)
-      }
-      onRemove={() => removeTask(task._id)}
-      onUpdateText={(text) => updateTaskText(task._id, text)}
-      onUpdateWhen={(when) => updateTaskWhen(task._id, when)}
+      onToggleComplete={handleToggleComplete}
+      onRemove={handleRemove}
+      onUpdateText={handleUpdateText}
+      onUpdateWhen={handleUpdateWhen}
       onProcess={onProcess ? () => onProcess(task) : undefined}
+      isTogglePending={isTogglePending}
+      isDiscardPending={isDiscardPending}
+      isSavingText={isSavingText}
+      isWhenPending={isWhenPending}
     />
   );
 }

--- a/apps/web/src/features/tasks/task-row/task-row.test.tsx
+++ b/apps/web/src/features/tasks/task-row/task-row.test.tsx
@@ -1,0 +1,67 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+
+import { fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@/test/render-with-providers";
+
+import { TaskRow } from "./task-row";
+
+const task = {
+  _id: "task1" as Id<"tasks">,
+  _creationTime: 0,
+  userId: "user1",
+  text: "Buy milk",
+  state: "open",
+  createdAt: Date.now(),
+} satisfies Doc<"tasks">;
+
+describe("TaskRow", () => {
+  it("disables the complete checkbox while a toggle is pending", async () => {
+    const user = userEvent.setup();
+    const onToggleComplete = vi.fn();
+
+    render(
+      <TaskRow
+        task={task}
+        onToggleComplete={onToggleComplete}
+        onRemove={vi.fn()}
+        onUpdateText={vi.fn()}
+        onUpdateWhen={vi.fn()}
+        isTogglePending
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Mark task done" });
+    expect(checkbox).toHaveAttribute("aria-disabled", "true");
+    expect(checkbox).toHaveAttribute("aria-busy", "true");
+
+    await user.click(checkbox);
+    expect(onToggleComplete).not.toHaveBeenCalled();
+  });
+
+  it("saves edited text once when pressing Enter then blurring", async () => {
+    const user = userEvent.setup();
+    const onUpdateText = vi.fn();
+
+    render(
+      <TaskRow
+        task={task}
+        onToggleComplete={vi.fn()}
+        onRemove={vi.fn()}
+        onUpdateText={onUpdateText}
+        onUpdateWhen={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: task.text }));
+    const input = screen.getByRole("textbox", { name: "Edit task text" });
+    fireEvent.change(input, { target: { value: "Buy oat milk" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.blur(input);
+
+    expect(onUpdateText).toHaveBeenCalledTimes(1);
+    expect(onUpdateText).toHaveBeenCalledWith("Buy oat milk");
+  });
+});

--- a/apps/web/src/features/tasks/task-row/task-row.tsx
+++ b/apps/web/src/features/tasks/task-row/task-row.tsx
@@ -35,11 +35,15 @@ import { isTaskWhenEmphasized } from "@/features/tasks/inbox";
 
 interface TaskRowProps {
   task: Doc<"tasks">;
-  onToggleComplete: () => void;
-  onRemove: () => void;
-  onUpdateText: (text: string) => void;
-  onUpdateWhen: (when: number | undefined) => void;
+  onToggleComplete: () => void | Promise<void>;
+  onRemove: () => void | Promise<void>;
+  onUpdateText: (text: string) => void | Promise<void>;
+  onUpdateWhen: (when: number | undefined) => void | Promise<void>;
   onProcess?: () => void;
+  isTogglePending?: boolean;
+  isDiscardPending?: boolean;
+  isSavingText?: boolean;
+  isWhenPending?: boolean;
 }
 
 export function TaskRow({
@@ -49,11 +53,16 @@ export function TaskRow({
   onUpdateText,
   onUpdateWhen,
   onProcess,
+  isTogglePending = false,
+  isDiscardPending = false,
+  isSavingText = false,
+  isWhenPending = false,
 }: TaskRowProps) {
   const [isEditingText, setIsEditingText] = useState(false);
   const [draftText, setDraftText] = useState(task.text);
   const [isWhenOpen, setIsWhenOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const saveCommittedRef = useRef(false);
 
   useEffect(() => {
     if (isEditingText) {
@@ -84,11 +93,18 @@ export function TaskRow({
   const whenIsEmphasized = isTaskWhenEmphasized(task, now);
 
   const saveText = () => {
+    if (saveCommittedRef.current || isSavingText) {
+      return;
+    }
+
     const nextText = draftText.trim();
     setIsEditingText(false);
 
     if (nextText && nextText !== task.text) {
-      onUpdateText(nextText);
+      saveCommittedRef.current = true;
+      void Promise.resolve(onUpdateText(nextText)).finally(() => {
+        saveCommittedRef.current = false;
+      });
     } else {
       setDraftText(task.text);
     }
@@ -104,7 +120,13 @@ export function TaskRow({
       <ItemMedia>
         <Checkbox
           checked={isDone}
-          onCheckedChange={onToggleComplete}
+          onCheckedChange={() => {
+            if (!isTogglePending) {
+              void onToggleComplete();
+            }
+          }}
+          disabled={isTogglePending}
+          aria-busy={isTogglePending}
           aria-label={isDone ? "Mark task open" : "Mark task done"}
         />
       </ItemMedia>
@@ -116,6 +138,8 @@ export function TaskRow({
               value={draftText}
               onChange={(event) => setDraftText(event.target.value)}
               onBlur={saveText}
+              disabled={isSavingText}
+              aria-busy={isSavingText}
               onKeyDown={(event) => {
                 if (event.key === "Enter") {
                   event.preventDefault();
@@ -177,7 +201,13 @@ export function TaskRow({
                 <AlertDialogFooter>
                   <AlertDialogCancel>Cancel</AlertDialogCancel>
                   <AlertDialogAction
-                    onClick={onRemove}
+                    onClick={() => {
+                      if (!isDiscardPending) {
+                        void onRemove();
+                      }
+                    }}
+                    disabled={isDiscardPending}
+                    aria-busy={isDiscardPending}
                     className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                   >
                     Discard
@@ -194,6 +224,8 @@ export function TaskRow({
                 <Button
                   variant="ghost"
                   size="xs"
+                  disabled={isWhenPending}
+                  aria-busy={isWhenPending}
                   className={
                     whenIsEmphasized
                       ? "h-6 rounded-md border border-primary/20 bg-primary/5 px-1.5 text-primary/80 hover:bg-primary/10 hover:text-primary"
@@ -211,9 +243,10 @@ export function TaskRow({
               <Calendar
                 mode="single"
                 selected={taskWhen}
+                disabled={isWhenPending}
                 onSelect={(date) => {
-                  if (!date) return;
-                  onUpdateWhen(date.getTime());
+                  if (!date || isWhenPending) return;
+                  void onUpdateWhen(date.getTime());
                   setIsWhenOpen(false);
                 }}
               />
@@ -224,8 +257,11 @@ export function TaskRow({
                     variant="ghost"
                     size="sm"
                     className="w-full justify-start text-muted-foreground"
+                    disabled={isWhenPending}
+                    aria-busy={isWhenPending}
                     onClick={() => {
-                      onUpdateWhen(undefined);
+                      if (isWhenPending) return;
+                      void onUpdateWhen(undefined);
                       setIsWhenOpen(false);
                     }}
                   >

--- a/apps/web/src/features/tasks/task-row/use-task-row-actions.test.ts
+++ b/apps/web/src/features/tasks/task-row/use-task-row-actions.test.ts
@@ -1,0 +1,238 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { act, renderHook, waitFor } from "@/test/render-with-providers";
+
+import { useTaskRowActions } from "./use-task-row-actions";
+
+const mocks = vi.hoisted(() => ({
+  completeTask: vi.fn(),
+  uncompleteTask: vi.fn(),
+  removeTask: vi.fn(),
+  updateTaskText: vi.fn(),
+  updateTaskWhen: vi.fn(),
+}));
+
+vi.mock("@/features/tasks/use-complete-task", () => ({
+  useCompleteTask: () => mocks.completeTask,
+}));
+
+vi.mock("@/features/tasks/use-uncomplete-task", () => ({
+  useUncompleteTask: () => mocks.uncompleteTask,
+}));
+
+vi.mock("@/features/tasks/use-remove-task", () => ({
+  useRemoveTask: () => mocks.removeTask,
+}));
+
+vi.mock("@/features/tasks/use-update-task-text", () => ({
+  useUpdateTaskText: () => mocks.updateTaskText,
+}));
+
+vi.mock("@/features/tasks/use-update-task-when", () => ({
+  useUpdateTaskWhen: () => mocks.updateTaskWhen,
+}));
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+const openTask = {
+  _id: "task1" as Id<"tasks">,
+  _creationTime: 0,
+  userId: "user1",
+  text: "Buy milk",
+  state: "open",
+  createdAt: Date.now(),
+} satisfies Doc<"tasks">;
+
+const doneTask = {
+  ...openTask,
+  state: "done",
+  completedAt: Date.now(),
+} satisfies Doc<"tasks">;
+
+describe("useTaskRowActions", () => {
+  beforeEach(() => {
+    mocks.completeTask.mockReset();
+    mocks.uncompleteTask.mockReset();
+    mocks.removeTask.mockReset();
+    mocks.updateTaskText.mockReset();
+    mocks.updateTaskWhen.mockReset();
+  });
+
+  it("ignores duplicate complete toggles while pending", async () => {
+    const pendingComplete = deferred();
+    mocks.completeTask.mockImplementation(() => pendingComplete.promise);
+
+    const { result } = renderHook(() => useTaskRowActions(openTask));
+
+    act(() => {
+      result.current.handleToggleComplete();
+      result.current.handleToggleComplete();
+    });
+
+    expect(mocks.completeTask).toHaveBeenCalledTimes(1);
+    expect(result.current.isTogglePending).toBe(true);
+
+    await act(async () => {
+      pendingComplete.resolve();
+      await pendingComplete.promise;
+    });
+
+    await waitFor(() => expect(result.current.isTogglePending).toBe(false));
+    expect(mocks.completeTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores duplicate reopen toggles while pending", async () => {
+    const pendingReopen = deferred();
+    mocks.uncompleteTask.mockImplementation(() => pendingReopen.promise);
+
+    const { result } = renderHook(() => useTaskRowActions(doneTask));
+
+    act(() => {
+      result.current.handleToggleComplete();
+      result.current.handleToggleComplete();
+    });
+
+    expect(mocks.uncompleteTask).toHaveBeenCalledTimes(1);
+    expect(result.current.isTogglePending).toBe(true);
+
+    await act(async () => {
+      pendingReopen.resolve();
+      await pendingReopen.promise;
+    });
+
+    await waitFor(() => expect(result.current.isTogglePending).toBe(false));
+    expect(mocks.uncompleteTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores duplicate discard actions while pending", async () => {
+    const pendingRemove = deferred();
+    mocks.removeTask.mockImplementation(() => pendingRemove.promise);
+
+    const { result } = renderHook(() => useTaskRowActions(openTask));
+
+    act(() => {
+      result.current.handleRemove();
+      result.current.handleRemove();
+    });
+
+    expect(mocks.removeTask).toHaveBeenCalledTimes(1);
+    expect(result.current.isDiscardPending).toBe(true);
+
+    await act(async () => {
+      pendingRemove.resolve();
+      await pendingRemove.promise;
+    });
+
+    await waitFor(() => expect(result.current.isDiscardPending).toBe(false));
+    expect(mocks.removeTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error toast when discard fails", async () => {
+    mocks.removeTask.mockRejectedValue(new Error("Could not discard task"));
+
+    const { result, feedback } = renderHook(() => useTaskRowActions(openTask));
+
+    act(() => {
+      result.current.handleRemove();
+    });
+
+    await waitFor(() =>
+      expect(feedback.error).toHaveBeenCalledWith("Could not discard task"),
+    );
+  });
+
+  it("shows a success toast when discard succeeds", async () => {
+    mocks.removeTask.mockResolvedValue(undefined);
+
+    const { result, feedback } = renderHook(() => useTaskRowActions(openTask));
+
+    act(() => {
+      result.current.handleRemove();
+    });
+
+    await waitFor(() =>
+      expect(feedback.success).toHaveBeenCalledWith("Task discarded"),
+    );
+  });
+
+  it("ignores duplicate text saves while pending", async () => {
+    const pendingSave = deferred();
+    mocks.updateTaskText.mockImplementation(() => pendingSave.promise);
+
+    const { result } = renderHook(() => useTaskRowActions(openTask));
+
+    act(() => {
+      void result.current.handleUpdateText("Buy oat milk");
+      void result.current.handleUpdateText("Buy oat milk");
+    });
+
+    expect(mocks.updateTaskText).toHaveBeenCalledTimes(1);
+    expect(result.current.isSavingText).toBe(true);
+
+    await act(async () => {
+      pendingSave.resolve();
+      await pendingSave.promise;
+    });
+
+    await waitFor(() => expect(result.current.isSavingText).toBe(false));
+    expect(mocks.updateTaskText).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays quiet on successful text saves", async () => {
+    mocks.updateTaskText.mockResolvedValue(undefined);
+
+    const { result, feedback } = renderHook(() => useTaskRowActions(openTask));
+
+    act(() => {
+      result.current.handleUpdateText("Buy oat milk");
+    });
+
+    await waitFor(() => expect(result.current.isSavingText).toBe(false));
+    expect(feedback.success).not.toHaveBeenCalled();
+  });
+
+  it("ignores duplicate When updates while pending", async () => {
+    const pendingWhen = deferred();
+    mocks.updateTaskWhen.mockImplementation(() => pendingWhen.promise);
+
+    const { result } = renderHook(() => useTaskRowActions(openTask));
+
+    act(() => {
+      void result.current.handleUpdateWhen(Date.now());
+      void result.current.handleUpdateWhen(Date.now());
+    });
+
+    expect(mocks.updateTaskWhen).toHaveBeenCalledTimes(1);
+    expect(result.current.isWhenPending).toBe(true);
+
+    await act(async () => {
+      pendingWhen.resolve();
+      await pendingWhen.promise;
+    });
+
+    await waitFor(() => expect(result.current.isWhenPending).toBe(false));
+    expect(mocks.updateTaskWhen).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error toast when When update fails", async () => {
+    mocks.updateTaskWhen.mockRejectedValue(new Error("Could not update When"));
+
+    const { result, feedback } = renderHook(() => useTaskRowActions(openTask));
+
+    act(() => {
+      result.current.handleUpdateWhen(Date.now());
+    });
+
+    await waitFor(() =>
+      expect(feedback.error).toHaveBeenCalledWith("Could not update When"),
+    );
+  });
+});

--- a/apps/web/src/features/tasks/task-row/use-task-row-actions.ts
+++ b/apps/web/src/features/tasks/task-row/use-task-row-actions.ts
@@ -1,0 +1,82 @@
+import type { Doc } from "@convex/_generated/dataModel";
+
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
+import { useFeedback } from "@vita-os/ui/lib/feedback";
+import { useCallback } from "react";
+
+import { useCompleteTask } from "@/features/tasks/use-complete-task";
+import { useRemoveTask } from "@/features/tasks/use-remove-task";
+import { useUncompleteTask } from "@/features/tasks/use-uncomplete-task";
+import { useUpdateTaskText } from "@/features/tasks/use-update-task-text";
+import { useUpdateTaskWhen } from "@/features/tasks/use-update-task-when";
+
+export function useTaskRowActions(task: Doc<"tasks">) {
+  const feedback = useFeedback();
+  const completeTask = useCompleteTask();
+  const uncompleteTask = useUncompleteTask();
+  const removeTask = useRemoveTask();
+  const updateTaskText = useUpdateTaskText();
+  const updateTaskWhen = useUpdateTaskWhen();
+
+  const { run: toggleComplete, isPending: isTogglePending } =
+    useGuardedAsyncAction(
+      async (intent: "complete" | "reopen") => {
+        if (intent === "reopen") {
+          await uncompleteTask(task._id);
+        } else {
+          await completeTask(task._id);
+        }
+      },
+      { errorToast: true },
+    );
+
+  const handleToggleComplete = useCallback(() => {
+    const intent = task.state === "done" ? "reopen" : "complete";
+    void toggleComplete(intent).then((result) => {
+      if (result.ok) {
+        feedback.success(
+          intent === "complete" ? "Task completed" : "Task reopened",
+        );
+      }
+    });
+  }, [feedback, task.state, toggleComplete]);
+
+  const { run: discardTask, isPending: isDiscardPending } =
+    useGuardedAsyncAction(
+      async () => {
+        await removeTask(task._id);
+      },
+      { successMessage: "Task discarded", errorToast: true },
+    );
+
+  const { run: saveTaskText, isPending: isSavingText } = useGuardedAsyncAction(
+    async (text: string) => {
+      await updateTaskText(task._id, text);
+    },
+    { errorToast: true },
+  );
+
+  const { run: saveTaskWhen, isPending: isWhenPending } = useGuardedAsyncAction(
+    async (when: number | undefined) => {
+      await updateTaskWhen(task._id, when);
+    },
+    { errorToast: true },
+  );
+
+  return {
+    handleToggleComplete,
+    isTogglePending,
+    handleRemove: () => {
+      void discardTask();
+    },
+    isDiscardPending,
+    handleUpdateText: (text: string) => {
+      void saveTaskText(text);
+    },
+    isSavingText,
+    handleUpdateWhen: (when: number | undefined) => {
+      void saveTaskWhen(when);
+    },
+    isWhenPending,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `useTaskRowActions` with per-action guarded async for complete/reopen, discard, text edit, and When updates
- Wire pending UI on task rows and Sonner feedback for structural actions and failures
- Guard Process Task submission with duplicate prevention and outcome-specific success toasts; remove custom ProcessingToast

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`

Closes #186

Made with [Cursor](https://cursor.com)