### PR TITLE
fix(threads): guard thread detail actions

### DIFF
--- a/apps/web/src/features/threads/components/follow-up-section.tsx
+++ b/apps/web/src/features/threads/components/follow-up-section.tsx
@@ -1,4 +1,5 @@
 import { api } from "@convex/_generated/api";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 
 import { useUpdateThread } from "@/features/threads/use-update-thread";
 import { useStableQuery } from "@/hooks/use-stable-query";
@@ -15,14 +16,22 @@ export function FollowUpSection({ threadSlug }: FollowUpSectionProps) {
   });
   const updateThread = useUpdateThread(threadSlug);
 
+  const { run: saveFollowUp, isPending } = useGuardedAsyncAction(
+    async (followUp: number | null) => {
+      if (!thread) return;
+      await updateThread({ id: thread._id, followUp });
+    },
+    { errorToast: true },
+  );
+
   const handleSet = (date: number) => {
     if (!thread) return;
-    updateThread({ id: thread._id, followUp: date });
+    void saveFollowUp(date);
   };
 
   const handleClear = () => {
     if (!thread) return;
-    updateThread({ id: thread._id, followUp: null });
+    void saveFollowUp(null);
   };
 
   return (
@@ -30,6 +39,7 @@ export function FollowUpSection({ threadSlug }: FollowUpSectionProps) {
       followUp={thread?.followUp ?? undefined}
       onSet={handleSet}
       onClear={handleClear}
+      isPending={isPending}
     />
   );
 }

--- a/apps/web/src/features/threads/components/follow-up.tsx
+++ b/apps/web/src/features/threads/components/follow-up.tsx
@@ -5,9 +5,15 @@ interface FollowUpProps {
   followUp: number | undefined;
   onSet: (date: number) => void;
   onClear: () => void;
+  isPending?: boolean;
 }
 
-export function FollowUp({ followUp, onSet, onClear }: FollowUpProps) {
+export function FollowUp({
+  followUp,
+  onSet,
+  onClear,
+  isPending = false,
+}: FollowUpProps) {
   return (
     <div className="rounded-xl border border-border-subtle bg-surface-2 p-4">
       <div className="mb-3 flex items-center gap-2 text-xs font-medium text-muted-foreground">
@@ -25,6 +31,7 @@ export function FollowUp({ followUp, onSet, onClear }: FollowUpProps) {
           }
         }}
         placeholder="Add a follow-up..."
+        disabled={isPending}
       />
     </div>
   );

--- a/apps/web/src/features/threads/components/next-move-section.tsx
+++ b/apps/web/src/features/threads/components/next-move-section.tsx
@@ -1,4 +1,5 @@
 import { api } from "@convex/_generated/api";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 
 import { useCompleteNextMove } from "@/features/threads/use-complete-next-move";
 import { useUpdateThread } from "@/features/threads/use-update-thread";
@@ -17,19 +18,45 @@ export function NextMoveSection({ threadSlug }: NextMoveSectionProps) {
   const updateThread = useUpdateThread(threadSlug);
   const completeNextMove = useCompleteNextMove(threadSlug);
 
+  const { run: setNextMove, isPending: isSetPending } = useGuardedAsyncAction(
+    async (text: string) => {
+      if (!thread) return;
+      await updateThread({ id: thread._id, nextMove: text });
+    },
+    { errorToast: true },
+  );
+
+  const { run: clearNextMove, isPending: isClearPending } =
+    useGuardedAsyncAction(
+      async () => {
+        if (!thread) return;
+        await updateThread({ id: thread._id, nextMove: null });
+      },
+      { errorToast: true },
+    );
+
+  const { run: completeNextMoveOnce, isPending: isCompletePending } =
+    useGuardedAsyncAction(
+      async () => {
+        if (!thread) return;
+        await completeNextMove(thread._id);
+      },
+      { errorToast: true },
+    );
+
   const handleSet = (text: string) => {
     if (!thread) return;
-    updateThread({ id: thread._id, nextMove: text });
+    void setNextMove(text);
   };
 
   const handleClear = () => {
     if (!thread) return;
-    updateThread({ id: thread._id, nextMove: null });
+    void clearNextMove();
   };
 
   const handleComplete = () => {
     if (!thread) return;
-    completeNextMove(thread._id);
+    void completeNextMoveOnce();
   };
 
   return (
@@ -38,6 +65,11 @@ export function NextMoveSection({ threadSlug }: NextMoveSectionProps) {
       onSet={handleSet}
       onClear={handleClear}
       onComplete={handleComplete}
+      pending={{
+        set: isSetPending,
+        clear: isClearPending,
+        complete: isCompletePending,
+      }}
     />
   );
 }

--- a/apps/web/src/features/threads/components/next-move.test.tsx
+++ b/apps/web/src/features/threads/components/next-move.test.tsx
@@ -88,6 +88,39 @@ describe("NextMove", () => {
     expect(onClear).toHaveBeenCalled();
   });
 
+  it("keeps only pending next move actions disabled", () => {
+    render(
+      <NextMove
+        nextMove="Call the clinic"
+        onSet={vi.fn()}
+        onClear={vi.fn()}
+        onComplete={vi.fn()}
+        pending={{ clear: true }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Clear next move" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Complete next move" }),
+    ).not.toBeDisabled();
+  });
+
+  it("disables the add field while saving a next move", () => {
+    render(
+      <NextMove
+        nextMove={undefined}
+        onSet={vi.fn()}
+        onClear={vi.fn()}
+        onComplete={vi.fn()}
+        pending={{ set: true }}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("Add a next move...")).toBeDisabled();
+  });
+
   it("enters edit mode on click and saves with Enter", async () => {
     const user = userEvent.setup();
     const onSet = vi.fn();

--- a/apps/web/src/features/threads/components/next-move.tsx
+++ b/apps/web/src/features/threads/components/next-move.tsx
@@ -9,6 +9,11 @@ interface NextMoveProps {
   onSet: (text: string) => void;
   onClear: () => void;
   onComplete: () => void;
+  pending?: {
+    set?: boolean;
+    clear?: boolean;
+    complete?: boolean;
+  };
 }
 
 export function NextMove({
@@ -16,6 +21,7 @@ export function NextMove({
   onSet,
   onClear,
   onComplete,
+  pending,
 }: NextMoveProps) {
   const [addText, setAddText] = useState("");
 
@@ -39,6 +45,7 @@ export function NextMove({
           onSet={onSet}
           onClear={onClear}
           onComplete={onComplete}
+          pending={pending}
         />
       ) : (
         <div className="flex gap-2">
@@ -46,6 +53,7 @@ export function NextMove({
             type="text"
             value={addText}
             onChange={(e) => setAddText(e.target.value)}
+            disabled={pending?.set}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 e.preventDefault();
@@ -66,11 +74,17 @@ function NextMoveTask({
   onSet,
   onClear,
   onComplete,
+  pending,
 }: {
   text: string;
   onSet: (text: string) => void;
   onClear: () => void;
   onComplete: () => void;
+  pending?: {
+    set?: boolean;
+    clear?: boolean;
+    complete?: boolean;
+  };
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(text);
@@ -87,6 +101,7 @@ function NextMoveTask({
   }, [editing]);
 
   const commit = () => {
+    if (pending?.set) return;
     setEditing(false);
     const trimmed = draft.trim();
     if (trimmed && trimmed !== text) {
@@ -102,6 +117,8 @@ function NextMoveTask({
         variant="ghost"
         size="icon-xs"
         onClick={onComplete}
+        disabled={pending?.complete}
+        aria-busy={pending?.complete}
         className="rounded-full border border-green-500/40 text-green-600 hover:bg-green-500/10 hover:text-green-600"
         aria-label="Complete next move"
       >
@@ -114,6 +131,7 @@ function NextMoveTask({
           type="text"
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
+          disabled={pending?.set}
           onBlur={commit}
           onKeyDown={(e) => {
             if (e.key === "Enter") commit();
@@ -128,6 +146,7 @@ function NextMoveTask({
         <button
           type="button"
           onClick={() => setEditing(true)}
+          disabled={pending?.set}
           className={cn(
             "min-w-0 flex-1 cursor-text truncate rounded px-1 py-0.5 text-left text-sm font-medium transition-colors hover:bg-muted/50",
           )}
@@ -140,6 +159,8 @@ function NextMoveTask({
         variant="ghost"
         size="icon-xs"
         onClick={onClear}
+        disabled={pending?.clear}
+        aria-busy={pending?.clear}
         className="text-muted-foreground/40 opacity-0 hover:text-destructive group-hover:opacity-100"
         aria-label="Clear next move"
       >

--- a/apps/web/src/features/threads/components/thread-area-section-section.tsx
+++ b/apps/web/src/features/threads/components/thread-area-section-section.tsx
@@ -2,6 +2,7 @@ import type { Id } from "@convex/_generated/dataModel";
 
 import { api } from "@convex/_generated/api";
 import { useNavigate } from "@tanstack/react-router";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 
 import { ThreadAreaSection } from "@/features/threads/components/thread-area-section";
@@ -24,26 +25,41 @@ export function ThreadAreaSectionSection({
   const navigate = useNavigate();
   const updateThread = useUpdateThread(threadSlug);
 
+  const { run: moveThread, isPending: isMoving } = useGuardedAsyncAction(
+    async (areaId: Id<"areas">) => {
+      if (!areas || !thread || areaId === thread.areaId) return null;
+
+      await updateThread({ id: thread._id, areaId });
+      return areas.find((area) => area._id === areaId) ?? null;
+    },
+    { successMessage: "Thread moved", errorToast: true },
+  );
+
   if (!areas || !thread) return null;
 
-  const handleMove = async (areaId: Id<"areas">) => {
+  const handleMove = (areaId: Id<"areas">) => {
     if (areaId === thread.areaId) return;
 
-    await updateThread({ id: thread._id, areaId });
-    const targetArea = areas.find((area) => area._id === areaId);
-    if (!targetArea) return;
+    void moveThread(areaId).then((result) => {
+      if (!result.ok || !result.value) return;
 
-    const nextAreaSlug = targetArea.slug ?? targetArea._id;
-    if (nextAreaSlug !== areaSlug) {
-      navigate({
-        to: "/$areaSlug/$threadSlug",
-        params: { areaSlug: nextAreaSlug, threadSlug },
-        replace: true,
-      });
-    }
+      const nextAreaSlug = result.value.slug ?? result.value._id;
+      if (nextAreaSlug !== areaSlug) {
+        navigate({
+          to: "/$areaSlug/$threadSlug",
+          params: { areaSlug: nextAreaSlug, threadSlug },
+          replace: true,
+        });
+      }
+    });
   };
 
   return (
-    <ThreadAreaSection areas={areas} thread={thread} onMove={handleMove} />
+    <ThreadAreaSection
+      areas={areas}
+      thread={thread}
+      onMove={handleMove}
+      isMoving={isMoving}
+    />
   );
 }

--- a/apps/web/src/features/threads/components/thread-area-section.tsx
+++ b/apps/web/src/features/threads/components/thread-area-section.tsx
@@ -8,12 +8,14 @@ interface ThreadAreaSectionProps {
   areas: Doc<"areas">[];
   thread: Doc<"threads">;
   onMove: (areaId: Id<"areas">) => void;
+  isMoving?: boolean;
 }
 
 export function ThreadAreaSection({
   areas,
   thread,
   onMove,
+  isMoving = false,
 }: ThreadAreaSectionProps) {
   return (
     <div className="flex items-start gap-3">
@@ -26,6 +28,7 @@ export function ThreadAreaSection({
           areas={areas}
           selectedAreaId={thread.areaId}
           onSelect={(id) => onMove(id as Id<"areas">)}
+          disabled={isMoving}
         />
       </div>
     </div>

--- a/apps/web/src/features/threads/components/thread-lifecycle-actions-section.tsx
+++ b/apps/web/src/features/threads/components/thread-lifecycle-actions-section.tsx
@@ -1,5 +1,6 @@
 import { api } from "@convex/_generated/api";
 import { useNavigate } from "@tanstack/react-router";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 
 import { useRemoveThread } from "@/features/threads/use-remove-thread";
 import { useUpdateThread } from "@/features/threads/use-update-thread";
@@ -23,21 +24,55 @@ export function ThreadLifecycleActionsSection({
   const updateThread = useUpdateThread(threadSlug);
   const removeThread = useRemoveThread({ threadSlug });
 
+  const { run: resolveThread, isPending: isResolving } = useGuardedAsyncAction(
+    async (resolutionNote?: string) => {
+      if (!thread) return;
+      await updateThread({
+        id: thread._id,
+        state: "resolved",
+        resolutionNote,
+      });
+    },
+    { successMessage: "Thread resolved", errorToast: true },
+  );
+
+  const { run: reopenThread, isPending: isReopening } = useGuardedAsyncAction(
+    async () => {
+      if (!thread) return;
+      await updateThread({ id: thread._id, state: "open" });
+    },
+    { successMessage: "Thread reopened", errorToast: true },
+  );
+
+  const { run: deleteThread, isPending: isDeleting } = useGuardedAsyncAction(
+    async () => {
+      if (!thread) return;
+      await removeThread(thread._id);
+    },
+    { successMessage: "Thread deleted", errorToast: true },
+  );
+
   const handleResolve = (resolutionNote?: string) => {
     if (!thread) return;
-    updateThread({ id: thread._id, state: "resolved", resolutionNote });
-    navigate({ to: "/$areaSlug", params: { areaSlug } });
+    void resolveThread(resolutionNote).then((result) => {
+      if (result.ok) {
+        navigate({ to: "/$areaSlug", params: { areaSlug } });
+      }
+    });
   };
 
   const handleReopen = () => {
     if (!thread) return;
-    updateThread({ id: thread._id, state: "open" });
+    void reopenThread();
   };
 
-  const handleDelete = async () => {
+  const handleDelete = () => {
     if (!thread) return;
-    await removeThread(thread._id);
-    navigate({ to: "/$areaSlug", params: { areaSlug } });
+    void deleteThread().then((result) => {
+      if (result.ok) {
+        navigate({ to: "/$areaSlug", params: { areaSlug } });
+      }
+    });
   };
 
   if (!thread) return null;
@@ -48,6 +83,9 @@ export function ThreadLifecycleActionsSection({
       onResolve={handleResolve}
       onReopen={handleReopen}
       onDelete={handleDelete}
+      isResolving={isResolving}
+      isReopening={isReopening}
+      isDeleting={isDeleting}
     />
   );
 }

--- a/apps/web/src/features/threads/components/thread-lifecycle-actions.test.tsx
+++ b/apps/web/src/features/threads/components/thread-lifecycle-actions.test.tsx
@@ -65,4 +65,20 @@ describe("ThreadLifecycleActions", () => {
 
     expect(onReopen).toHaveBeenCalled();
   });
+
+  it("keeps representative thread actions disabled while pending", () => {
+    render(
+      <ThreadLifecycleActions
+        thread={makeThread({ state: "resolved" })}
+        onResolve={vi.fn()}
+        onReopen={vi.fn()}
+        onDelete={vi.fn()}
+        isReopening
+        isDeleting
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Reopen" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeDisabled();
+  });
 });

--- a/apps/web/src/features/threads/components/thread-lifecycle-actions.tsx
+++ b/apps/web/src/features/threads/components/thread-lifecycle-actions.tsx
@@ -21,6 +21,9 @@ interface ThreadLifecycleActionsProps {
   onResolve: (resolutionNote?: string) => void;
   onReopen: () => void;
   onDelete: () => void;
+  isResolving?: boolean;
+  isReopening?: boolean;
+  isDeleting?: boolean;
 }
 
 export function ThreadLifecycleActions({
@@ -28,6 +31,9 @@ export function ThreadLifecycleActions({
   onResolve,
   onReopen,
   onDelete,
+  isResolving = false,
+  isReopening = false,
+  isDeleting = false,
 }: ThreadLifecycleActionsProps) {
   const [resolutionNote, setResolutionNote] = useState("");
   const isResolved = thread.state === "resolved";
@@ -40,6 +46,8 @@ export function ThreadLifecycleActions({
           size="sm"
           className="gap-1.5"
           onClick={onReopen}
+          disabled={isReopening}
+          aria-busy={isReopening}
         >
           <RotateCcw className="h-3.5 w-3.5" />
           Reopen
@@ -47,7 +55,15 @@ export function ThreadLifecycleActions({
       ) : (
         <AlertDialog>
           <AlertDialogTrigger
-            render={<Button variant="outline" size="sm" className="gap-1.5" />}
+            render={
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5"
+                disabled={isResolving}
+                aria-busy={isResolving}
+              />
+            }
           >
             <CheckCircle2 className="h-3.5 w-3.5" />
             Resolve
@@ -77,6 +93,8 @@ export function ThreadLifecycleActions({
             <AlertDialogFooter>
               <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction
+                disabled={isResolving}
+                aria-busy={isResolving}
                 onClick={() => onResolve(resolutionNote.trim() || undefined)}
               >
                 Resolve thread
@@ -95,6 +113,8 @@ export function ThreadLifecycleActions({
               variant="ghost"
               size="sm"
               className="gap-1.5 text-muted-foreground hover:text-destructive"
+              disabled={isDeleting}
+              aria-busy={isDeleting}
             />
           }
         >
@@ -111,6 +131,8 @@ export function ThreadLifecycleActions({
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
+              disabled={isDeleting}
+              aria-busy={isDeleting}
               onClick={onDelete}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >

--- a/apps/web/src/features/threads/components/thread-log.test.tsx
+++ b/apps/web/src/features/threads/components/thread-log.test.tsx
@@ -1,12 +1,21 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
 
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, waitFor } from "@/test/render-with-providers";
 
 import { ActivityLog } from "./thread-log";
 
 const now = new Date("2026-05-19T12:00:00Z").getTime();
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 const note = {
   _id: "log1" as Id<"activityLogs">,
@@ -98,5 +107,28 @@ describe("ActivityLog", () => {
 
     expect(onAddNote).toHaveBeenCalledWith("Line one\nLine two");
     expect(noteInput).toHaveValue("");
+  });
+
+  it("prevents duplicate notes while submission is pending", async () => {
+    const user = userEvent.setup();
+    const pendingAdd = deferred();
+    const onAddNote = vi.fn(() => pendingAdd.promise);
+
+    render(<ActivityLog logs={[]} onAddNote={onAddNote} />);
+
+    const noteInput = screen.getByRole("textbox", {
+      name: "Activity log note",
+    });
+    await user.type(noteInput, "Called the clinic");
+    await user.keyboard("{Enter}{Enter}");
+
+    expect(onAddNote).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Add" })).toBeDisabled();
+    expect(noteInput).toBeDisabled();
+    expect(noteInput).toHaveValue("Called the clinic");
+
+    pendingAdd.resolve();
+
+    await waitFor(() => expect(noteInput).toHaveValue(""));
   });
 });

--- a/apps/web/src/features/threads/components/thread-log.tsx
+++ b/apps/web/src/features/threads/components/thread-log.tsx
@@ -3,6 +3,7 @@ import type { Doc } from "@convex/_generated/dataModel";
 import { Button } from "@vita-os/ui/components/button";
 import { Skeleton } from "@vita-os/ui/components/skeleton";
 import { Textarea } from "@vita-os/ui/components/textarea";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 import { formatDistanceToNow } from "date-fns";
 import { MessageSquare, Pen } from "lucide-react";
 import { type FormEvent, type KeyboardEvent, useState } from "react";
@@ -16,13 +17,18 @@ interface ActivityLogProps {
 
 export function ActivityLog({ logs, onAddNote }: ActivityLogProps) {
   const [noteText, setNoteText] = useState("");
+  const { run: addNote, isPending } = useGuardedAsyncAction(onAddNote, {
+    errorToast: true,
+  });
 
   const submitNote = async () => {
     const text = noteText.trim();
-    if (!text) return;
+    if (!text || isPending) return;
 
-    setNoteText("");
-    await onAddNote(text);
+    const result = await addNote(text);
+    if (result.ok) {
+      setNoteText("");
+    }
   };
 
   const handleAddNote = (event: FormEvent) => {
@@ -53,6 +59,7 @@ export function ActivityLog({ logs, onAddNote }: ActivityLogProps) {
         <Textarea
           value={noteText}
           onChange={(event) => setNoteText(event.target.value)}
+          disabled={isPending}
           aria-label="Activity log note"
           placeholder="Add to activity log..."
           className="min-h-9 bg-surface-2"
@@ -62,7 +69,8 @@ export function ActivityLog({ logs, onAddNote }: ActivityLogProps) {
         <Button
           type="submit"
           size="sm"
-          disabled={!noteText.trim()}
+          disabled={!noteText.trim() || isPending}
+          aria-busy={isPending}
           className="shrink-0"
         >
           Add

--- a/packages/ui/src/components/date-picker.tsx
+++ b/packages/ui/src/components/date-picker.tsx
@@ -12,6 +12,7 @@ interface DatePickerProps {
   onChange: (date: Date | undefined) => void;
   placeholder?: string;
   className?: string;
+  disabled?: boolean;
 }
 
 export function DatePicker({
@@ -19,17 +20,19 @@ export function DatePicker({
   onChange,
   placeholder = "Pick a date",
   className,
+  disabled = false,
 }: DatePickerProps) {
   const [open, setOpen] = useState(false);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={disabled ? undefined : setOpen}>
       <div className={cn("flex items-center gap-1", className)}>
         <PopoverTrigger
           render={
             <Button
               variant="ghost"
               size="sm"
+              disabled={disabled}
               className={cn(
                 "h-7 justify-start gap-1.5 px-2 text-xs font-normal",
                 !value && "text-muted-foreground",
@@ -45,6 +48,7 @@ export function DatePicker({
             variant="ghost"
             size="icon"
             className="h-5 w-5"
+            disabled={disabled}
             onClick={() => onChange(undefined)}
             aria-label="Clear date"
           >


### PR DESCRIPTION
## Summary
- Guard Thread detail resolve, reopen, delete, move, Next Move, Follow-up, and Activity Log note mutations against duplicate submissions.
- Keep pending state local to the relevant action controls and wait for successful delete/move/resolve mutations before navigating.
- Add focused tests for duplicate Activity Log note prevention and representative pending Thread actions.

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`

Closes #187