### PR TITLE
feat(auth): handle pending auth actions

### DIFF
--- a/apps/web/src/features/auth/auth-card-shell.tsx
+++ b/apps/web/src/features/auth/auth-card-shell.tsx
@@ -15,6 +15,8 @@ interface AuthCardShellProps {
   description: string;
   children: ReactNode;
   footer: ReactNode;
+  githubError?: string;
+  githubLoading?: boolean;
   onGitHub: () => void;
 }
 
@@ -23,6 +25,8 @@ export function AuthCardShell({
   description,
   children,
   footer,
+  githubError = "",
+  githubLoading = false,
   onGitHub,
 }: AuthCardShellProps) {
   return (
@@ -52,7 +56,18 @@ export function AuthCardShell({
               </span>
             </div>
           </div>
-          <Button variant="outline" className="w-full" onClick={onGitHub}>
+          {githubError && (
+            <p role="alert" className="mb-4 text-sm text-destructive">
+              {githubError}
+            </p>
+          )}
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={onGitHub}
+            disabled={githubLoading}
+            aria-busy={githubLoading}
+          >
             <svg
               className="mr-2 h-4 w-4"
               viewBox="0 0 24 24"
@@ -61,7 +76,7 @@ export function AuthCardShell({
             >
               <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z" />
             </svg>
-            Continue with GitHub
+            {githubLoading ? "Connecting to GitHub..." : "Continue with GitHub"}
           </Button>
         </CardContent>
         <CardFooter className="justify-center">{footer}</CardFooter>

--- a/apps/web/src/features/auth/auth-result.test.ts
+++ b/apps/web/src/features/auth/auth-result.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { getAuthErrorMessage } from "./auth-result";
+
+describe("getAuthErrorMessage", () => {
+  it("returns the client auth error message when one is present", () => {
+    expect(
+      getAuthErrorMessage({ error: { message: "Invalid credentials" } }),
+    ).toBe("Invalid credentials");
+  });
+
+  it("ignores successful or malformed auth results", () => {
+    expect(getAuthErrorMessage({ data: { user: { id: "user-1" } } })).toBe(
+      null,
+    );
+    expect(getAuthErrorMessage({ error: { message: "" } })).toBe(null);
+    expect(getAuthErrorMessage(null)).toBe(null);
+  });
+});

--- a/apps/web/src/features/auth/auth-result.ts
+++ b/apps/web/src/features/auth/auth-result.ts
@@ -1,0 +1,16 @@
+export function getAuthErrorMessage(result: unknown) {
+  if (
+    result &&
+    typeof result === "object" &&
+    "error" in result &&
+    result.error &&
+    typeof result.error === "object" &&
+    "message" in result.error &&
+    typeof result.error.message === "string" &&
+    result.error.message
+  ) {
+    return result.error.message;
+  }
+
+  return null;
+}

--- a/apps/web/src/features/auth/screens/sign-in-screen.tsx
+++ b/apps/web/src/features/auth/screens/sign-in-screen.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 
 import { SignInForm } from "@/features/auth/sign-in/sign-in-form";
 import { useGitHubSignIn } from "@/features/auth/use-github-sign-in";
@@ -7,25 +7,26 @@ import { useSignIn } from "@/features/auth/use-sign-in";
 export function SignInScreen() {
   const signIn = useSignIn();
   const signInWithGitHub = useGitHubSignIn();
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
+  const {
+    run: runSignIn,
+    isPending: isSigningIn,
+    error: signInError,
+  } = useGuardedAsyncAction(signIn, { errorToast: false });
+  const {
+    run: runGitHubSignIn,
+    isPending: isGitHubPending,
+    error: githubError,
+  } = useGuardedAsyncAction(signInWithGitHub, { errorToast: false });
 
   return (
     <SignInForm
-      error={error}
-      loading={loading}
-      onGitHub={() => void signInWithGitHub()}
+      error={signInError ?? ""}
+      githubError={githubError ?? ""}
+      githubLoading={isGitHubPending}
+      loading={isSigningIn}
+      onGitHub={() => void runGitHubSignIn()}
       onSubmit={async ({ email, password }) => {
-        setError("");
-        setLoading(true);
-        await signIn({
-          email,
-          password,
-          onError: (message) => {
-            setError(message);
-            setLoading(false);
-          },
-        });
+        await runSignIn({ email, password });
       }}
     />
   );

--- a/apps/web/src/features/auth/screens/sign-up-screen.tsx
+++ b/apps/web/src/features/auth/screens/sign-up-screen.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 
 import { SignUpForm } from "@/features/auth/sign-up/sign-up-form";
 import { useGitHubSignIn } from "@/features/auth/use-github-sign-in";
@@ -7,26 +7,26 @@ import { useSignUp } from "@/features/auth/use-sign-up";
 export function SignUpScreen() {
   const signUp = useSignUp();
   const signInWithGitHub = useGitHubSignIn();
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
+  const {
+    run: runSignUp,
+    isPending: isSigningUp,
+    error: signUpError,
+  } = useGuardedAsyncAction(signUp, { errorToast: false });
+  const {
+    run: runGitHubSignIn,
+    isPending: isGitHubPending,
+    error: githubError,
+  } = useGuardedAsyncAction(signInWithGitHub, { errorToast: false });
 
   return (
     <SignUpForm
-      error={error}
-      loading={loading}
-      onGitHub={() => void signInWithGitHub()}
+      error={signUpError ?? ""}
+      githubError={githubError ?? ""}
+      githubLoading={isGitHubPending}
+      loading={isSigningUp}
+      onGitHub={() => void runGitHubSignIn()}
       onSubmit={async ({ name, email, password }) => {
-        setError("");
-        setLoading(true);
-        await signUp({
-          name,
-          email,
-          password,
-          onError: (message) => {
-            setError(message);
-            setLoading(false);
-          },
-        });
+        await runSignUp({ name, email, password });
       }}
     />
   );

--- a/apps/web/src/features/auth/sign-in/sign-in-form.test.tsx
+++ b/apps/web/src/features/auth/sign-in/sign-in-form.test.tsx
@@ -1,0 +1,78 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@/test/render-with-providers";
+
+import { SignInForm } from "./sign-in-form";
+
+describe("SignInForm", () => {
+  it("submits the entered email and password", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <SignInForm
+        error=""
+        githubError=""
+        githubLoading={false}
+        loading={false}
+        onGitHub={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Email"), "rigo@example.com");
+    await user.type(screen.getByLabelText("Password"), "password-123");
+    await user.click(screen.getByRole("button", { name: "Sign In" }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      email: "rigo@example.com",
+      password: "password-123",
+    });
+  });
+
+  it("shows email and GitHub pending states", () => {
+    render(
+      <SignInForm
+        error=""
+        githubError=""
+        githubLoading
+        loading
+        onGitHub={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    const submitButton = screen.getByRole("button", { name: "Signing in..." });
+    expect(submitButton).toBeDisabled();
+    expect(submitButton).toHaveAttribute("aria-busy", "true");
+
+    const githubButton = screen.getByRole("button", {
+      name: "Connecting to GitHub...",
+    });
+    expect(githubButton).toBeDisabled();
+    expect(githubButton).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("shows inline email and GitHub failures", () => {
+    render(
+      <SignInForm
+        error="Invalid credentials"
+        githubError="GitHub is unavailable"
+        githubLoading={false}
+        loading={false}
+        onGitHub={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Invalid credentials")).toHaveAttribute(
+      "role",
+      "alert",
+    );
+    expect(screen.getByText("GitHub is unavailable")).toHaveAttribute(
+      "role",
+      "alert",
+    );
+  });
+});

--- a/apps/web/src/features/auth/sign-in/sign-in-form.tsx
+++ b/apps/web/src/features/auth/sign-in/sign-in-form.tsx
@@ -8,6 +8,8 @@ import { AuthCardShell } from "@/features/auth/auth-card-shell";
 
 interface SignInFormProps {
   error: string;
+  githubError: string;
+  githubLoading: boolean;
   loading: boolean;
   onSubmit: (value: { email: string; password: string }) => void;
   onGitHub: () => void;
@@ -15,6 +17,8 @@ interface SignInFormProps {
 
 export function SignInForm({
   error,
+  githubError,
+  githubLoading,
   loading,
   onSubmit,
   onGitHub,
@@ -31,6 +35,8 @@ export function SignInForm({
     <AuthCardShell
       title="Sign In"
       description="Sign in to your account to continue"
+      githubError={githubError}
+      githubLoading={githubLoading}
       onGitHub={onGitHub}
       footer={
         <p className="text-sm text-muted-foreground">
@@ -63,8 +69,17 @@ export function SignInForm({
             required
           />
         </div>
-        {error && <p className="text-sm text-destructive">{error}</p>}
-        <Button type="submit" className="w-full" disabled={loading}>
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={loading}
+          aria-busy={loading}
+        >
           {loading ? "Signing in..." : "Sign In"}
         </Button>
       </form>

--- a/apps/web/src/features/auth/sign-up/sign-up-form.test.tsx
+++ b/apps/web/src/features/auth/sign-up/sign-up-form.test.tsx
@@ -1,0 +1,82 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@/test/render-with-providers";
+
+import { SignUpForm } from "./sign-up-form";
+
+describe("SignUpForm", () => {
+  it("submits the entered name, email, and password", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <SignUpForm
+        error=""
+        githubError=""
+        githubLoading={false}
+        loading={false}
+        onGitHub={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Name"), "Rigo");
+    await user.type(screen.getByLabelText("Email"), "rigo@example.com");
+    await user.type(screen.getByLabelText("Password"), "password-123");
+    await user.click(screen.getByRole("button", { name: "Sign Up" }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      name: "Rigo",
+      email: "rigo@example.com",
+      password: "password-123",
+    });
+  });
+
+  it("shows email and GitHub pending states", () => {
+    render(
+      <SignUpForm
+        error=""
+        githubError=""
+        githubLoading
+        loading
+        onGitHub={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    const submitButton = screen.getByRole("button", {
+      name: "Creating account...",
+    });
+    expect(submitButton).toBeDisabled();
+    expect(submitButton).toHaveAttribute("aria-busy", "true");
+
+    const githubButton = screen.getByRole("button", {
+      name: "Connecting to GitHub...",
+    });
+    expect(githubButton).toBeDisabled();
+    expect(githubButton).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("shows inline email and GitHub failures", () => {
+    render(
+      <SignUpForm
+        error="Email is already in use"
+        githubError="GitHub is unavailable"
+        githubLoading={false}
+        loading={false}
+        onGitHub={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Email is already in use")).toHaveAttribute(
+      "role",
+      "alert",
+    );
+    expect(screen.getByText("GitHub is unavailable")).toHaveAttribute(
+      "role",
+      "alert",
+    );
+  });
+});

--- a/apps/web/src/features/auth/sign-up/sign-up-form.tsx
+++ b/apps/web/src/features/auth/sign-up/sign-up-form.tsx
@@ -8,6 +8,8 @@ import { AuthCardShell } from "@/features/auth/auth-card-shell";
 
 interface SignUpFormProps {
   error: string;
+  githubError: string;
+  githubLoading: boolean;
   loading: boolean;
   onSubmit: (value: { name: string; email: string; password: string }) => void;
   onGitHub: () => void;
@@ -15,6 +17,8 @@ interface SignUpFormProps {
 
 export function SignUpForm({
   error,
+  githubError,
+  githubLoading,
   loading,
   onSubmit,
   onGitHub,
@@ -32,6 +36,8 @@ export function SignUpForm({
     <AuthCardShell
       title="Sign Up"
       description="Create a new account to get started"
+      githubError={githubError}
+      githubLoading={githubLoading}
       onGitHub={onGitHub}
       footer={
         <p className="text-sm text-muted-foreground">
@@ -76,8 +82,17 @@ export function SignUpForm({
             required
           />
         </div>
-        {error && <p className="text-sm text-destructive">{error}</p>}
-        <Button type="submit" className="w-full" disabled={loading}>
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={loading}
+          aria-busy={loading}
+        >
           {loading ? "Creating account..." : "Sign Up"}
         </Button>
       </form>

--- a/apps/web/src/features/auth/use-github-sign-in.ts
+++ b/apps/web/src/features/auth/use-github-sign-in.ts
@@ -1,8 +1,15 @@
+import { getAuthErrorMessage } from "@/features/auth/auth-result";
 import { authClient } from "@/lib/auth-client";
 
 export function useGitHubSignIn() {
-  return () =>
-    authClient.signIn.social({
+  return async () => {
+    const result = await authClient.signIn.social({
       provider: "github",
     });
+
+    const errorMessage = getAuthErrorMessage(result);
+    if (errorMessage) {
+      throw new Error(errorMessage);
+    }
+  };
 }

--- a/apps/web/src/features/auth/use-sign-in.ts
+++ b/apps/web/src/features/auth/use-sign-in.ts
@@ -1,24 +1,26 @@
 import { useNavigate } from "@tanstack/react-router";
+import { useCallback } from "react";
 
+import { getAuthErrorMessage } from "@/features/auth/auth-result";
 import { authClient } from "@/lib/auth-client";
 
 export function useSignIn() {
   const navigate = useNavigate();
 
-  return (input: {
-    email: string;
-    password: string;
-    onError: (message: string) => void;
-  }) =>
-    authClient.signIn.email(
-      { email: input.email, password: input.password },
-      {
-        onSuccess: () => {
-          navigate({ to: "/" });
-        },
-        onError: (ctx) => {
-          input.onError(ctx.error.message ?? "Sign in failed");
-        },
-      },
-    );
+  return useCallback(
+    async (input: { email: string; password: string }) => {
+      const result = await authClient.signIn.email({
+        email: input.email,
+        password: input.password,
+      });
+      const errorMessage = getAuthErrorMessage(result);
+
+      if (errorMessage) {
+        throw new Error(errorMessage);
+      }
+
+      navigate({ to: "/" });
+    },
+    [navigate],
+  );
 }

--- a/apps/web/src/features/auth/use-sign-up.ts
+++ b/apps/web/src/features/auth/use-sign-up.ts
@@ -1,25 +1,27 @@
 import { useNavigate } from "@tanstack/react-router";
+import { useCallback } from "react";
 
+import { getAuthErrorMessage } from "@/features/auth/auth-result";
 import { authClient } from "@/lib/auth-client";
 
 export function useSignUp() {
   const navigate = useNavigate();
 
-  return (input: {
-    name: string;
-    email: string;
-    password: string;
-    onError: (message: string) => void;
-  }) =>
-    authClient.signUp.email(
-      { name: input.name, email: input.email, password: input.password },
-      {
-        onSuccess: () => {
-          navigate({ to: "/" });
-        },
-        onError: (ctx) => {
-          input.onError(ctx.error.message ?? "Sign up failed");
-        },
-      },
-    );
+  return useCallback(
+    async (input: { name: string; email: string; password: string }) => {
+      const result = await authClient.signUp.email({
+        name: input.name,
+        email: input.email,
+        password: input.password,
+      });
+      const errorMessage = getAuthErrorMessage(result);
+
+      if (errorMessage) {
+        throw new Error(errorMessage);
+      }
+
+      navigate({ to: "/" });
+    },
+    [navigate],
+  );
 }

--- a/apps/web/src/test/render-with-providers.tsx
+++ b/apps/web/src/test/render-with-providers.tsx
@@ -1,5 +1,9 @@
-import type { ReactElement, ReactNode } from "react";
-
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterContextProvider,
+} from "@tanstack/react-router";
 import {
   render as rtlRender,
   renderHook as rtlRenderHook,
@@ -7,6 +11,7 @@ import {
   type RenderOptions,
 } from "@testing-library/react";
 import { FeedbackProvider, type Feedback } from "@vita-os/ui/lib/feedback";
+import { useMemo, type ReactElement, type ReactNode } from "react";
 import { vi } from "vitest";
 
 export type FeedbackMock = Feedback;
@@ -33,7 +38,21 @@ export function createFeedbackMock(): FeedbackMock {
 
 function createWrapper(feedback: Feedback) {
   return function Providers({ children }: { children: ReactNode }) {
-    return <FeedbackProvider feedback={feedback}>{children}</FeedbackProvider>;
+    const router = useMemo(() => {
+      const rootRoute = createRootRoute();
+      return createRouter({
+        routeTree: rootRoute,
+        history: createMemoryHistory({ initialEntries: ["/"] }),
+      });
+    }, []);
+
+    return (
+      <FeedbackProvider feedback={feedback}>
+        <RouterContextProvider router={router}>
+          {children}
+        </RouterContextProvider>
+      </FeedbackProvider>
+    );
   };
 }
 


### PR DESCRIPTION
## Summary
- Apply guarded pending/error handling to email sign-in, email sign-up, and GitHub sign-in.
- Show disabled loading states and inline auth failures in unauthenticated auth forms.
- Add focused auth form/result tests and shared router context in the test render helper.

## Verification
- `bun run lint`
- `bun run build`
- `bun run test:run`

Closes #188