### PR TITLE
Refine dashboard tabs styling

### DIFF
--- a/apps/web/src/features/dashboard/components/dashboard-overview.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-overview.tsx
@@ -98,7 +98,7 @@ export function DashboardOverview({
       <AreaConditionMap areas={overview.areas} />
 
       <Tabs defaultValue="overview" className="gap-5">
-        <TabsList variant="line" aria-label="Dashboard view">
+        <TabsList aria-label="Dashboard view">
           <TabsTrigger value="overview">Overview</TabsTrigger>
           <TabsTrigger value="plan">Plan</TabsTrigger>
         </TabsList>

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -1,7 +1,6 @@
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import { cn } from "@vita-os/ui/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
-
-import { cn } from "../lib/utils";
 
 function Tabs({
   className,
@@ -58,7 +57,7 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
       className={cn(
         "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-2 rounded-full border border-transparent! px-3 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start group-data-vertical/tabs:rounded-2xl group-data-vertical/tabs:px-3 group-data-vertical/tabs:py-1.5 hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
-        "data-active:bg-surface-1 data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
         "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
         className,
       )}


### PR DESCRIPTION
## Summary
- Use the default tabs list styling in the dashboard overview
- Update active tabs to use the background color
- Switch the tabs utility import to the package alias

## Testing
- Not run (not requested)