### PR TITLE
feat(areas): add customizable icons

### DIFF
--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type * as auth from "../auth.js";
 import type * as dashboard from "../dashboard.js";
 import type * as http from "../http.js";
 import type * as lib_activityLog from "../lib/activityLog.js";
+import type * as lib_areaIcons from "../lib/areaIcons.js";
 import type * as lib_areaThreads from "../lib/areaThreads.js";
 import type * as lib_condition from "../lib/condition.js";
 import type * as lib_dashboard from "../lib/dashboard.js";
@@ -40,6 +41,7 @@ declare const fullApi: ApiFromModules<{
   dashboard: typeof dashboard;
   http: typeof http;
   "lib/activityLog": typeof lib_activityLog;
+  "lib/areaIcons": typeof lib_areaIcons;
   "lib/areaThreads": typeof lib_areaThreads;
   "lib/condition": typeof lib_condition;
   "lib/dashboard": typeof lib_dashboard;

--- a/apps/web/convex/areas.ts
+++ b/apps/web/convex/areas.ts
@@ -6,7 +6,7 @@ import { getAuthUserId, getNextOrder, safeGetAuthUserId } from "./lib/helpers";
 import { nullsToUndefined } from "./lib/patch";
 import { generateSlug } from "./lib/slugs";
 import { validateAreaName } from "./lib/validation";
-import { conditionValidator } from "./lib/validators";
+import { areaIconValidator, conditionValidator } from "./lib/validators";
 
 export const list = query({
   args: {},
@@ -50,6 +50,7 @@ export const create = mutation({
     name: v.string(),
     standard: v.optional(v.string()),
     condition: conditionValidator,
+    icon: areaIconValidator,
   },
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
@@ -65,6 +66,7 @@ export const create = mutation({
       slug,
       standard: args.standard,
       condition: args.condition,
+      icon: args.icon,
       order: nextOrder,
       createdAt: Date.now(),
     });
@@ -79,6 +81,7 @@ export const update = mutation({
     name: v.optional(v.string()),
     standard: v.optional(v.union(v.string(), v.null())),
     condition: v.optional(conditionValidator),
+    icon: v.optional(areaIconValidator),
   },
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);

--- a/apps/web/convex/dashboard.ts
+++ b/apps/web/convex/dashboard.ts
@@ -3,13 +3,14 @@ import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { buildDashboardOverview } from "./lib/dashboard";
 import { getAuthUserId, safeGetAuthUserId } from "./lib/helpers";
-import { conditionValidator } from "./lib/validators";
+import { areaIconValidator, conditionValidator } from "./lib/validators";
 
 const dashboardAreaValidator = v.object({
   id: v.id("areas"),
   name: v.string(),
   slug: v.string(),
   condition: conditionValidator,
+  icon: v.optional(areaIconValidator),
   order: v.number(),
 });
 

--- a/apps/web/convex/lib/areaIcons.test.ts
+++ b/apps/web/convex/lib/areaIcons.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AREA_ICONS,
+  DEFAULT_AREA_ICON,
+  getAreaIcon,
+  isAreaIcon,
+} from "./areaIcons";
+
+describe("Area Icons", () => {
+  it("uses the complete, duplicate-free curated set", () => {
+    expect(AREA_ICONS).toEqual([
+      "Compass",
+      "HeartPulse",
+      "Dumbbell",
+      "Users",
+      "Home",
+      "BriefcaseBusiness",
+      "WalletCards",
+      "BookOpen",
+      "Utensils",
+      "Car",
+      "CalendarDays",
+      "Palette",
+      "Leaf",
+      "Shield",
+      "Plane",
+    ]);
+    expect(new Set(AREA_ICONS).size).toBe(AREA_ICONS.length);
+  });
+
+  it("defaults missing and unknown values to Compass", () => {
+    expect(DEFAULT_AREA_ICON).toBe("Compass");
+    expect(getAreaIcon()).toBe("Compass");
+    expect(getAreaIcon("Unknown")).toBe("Compass");
+  });
+
+  it("recognizes only allowed icon values", () => {
+    expect(isAreaIcon("HeartPulse")).toBe(true);
+    expect(isAreaIcon("Unknown")).toBe(false);
+    expect(isAreaIcon(undefined)).toBe(false);
+  });
+});

--- a/apps/web/convex/lib/areaIcons.ts
+++ b/apps/web/convex/lib/areaIcons.ts
@@ -42,6 +42,6 @@ export function isAreaIcon(value: unknown): value is AreaIcon {
   return typeof value === "string" && AREA_ICONS.includes(value as AreaIcon);
 }
 
-export function getAreaIcon(value: unknown): AreaIcon {
+export function getAreaIcon(value?: unknown): AreaIcon {
   return isAreaIcon(value) ? value : DEFAULT_AREA_ICON;
 }

--- a/apps/web/convex/lib/areaIcons.ts
+++ b/apps/web/convex/lib/areaIcons.ts
@@ -1,0 +1,47 @@
+export const AREA_ICONS = [
+  "Compass",
+  "HeartPulse",
+  "Dumbbell",
+  "Users",
+  "Home",
+  "BriefcaseBusiness",
+  "WalletCards",
+  "BookOpen",
+  "Utensils",
+  "Car",
+  "CalendarDays",
+  "Palette",
+  "Leaf",
+  "Shield",
+  "Plane",
+] as const;
+
+export type AreaIcon = (typeof AREA_ICONS)[number];
+
+export const DEFAULT_AREA_ICON: AreaIcon = "Compass";
+
+export const areaIconLabels: Record<AreaIcon, string> = {
+  Compass: "Compass",
+  HeartPulse: "Health",
+  Dumbbell: "Fitness",
+  Users: "Relationships",
+  Home: "Home",
+  BriefcaseBusiness: "Career",
+  WalletCards: "Finances",
+  BookOpen: "Learning",
+  Utensils: "Food",
+  Car: "Transport",
+  CalendarDays: "Planning",
+  Palette: "Creativity",
+  Leaf: "Nature",
+  Shield: "Security",
+  Plane: "Travel",
+};
+
+export function isAreaIcon(value: unknown): value is AreaIcon {
+  return typeof value === "string" && AREA_ICONS.includes(value as AreaIcon);
+}
+
+export function getAreaIcon(value: unknown): AreaIcon {
+  return isAreaIcon(value) ? value : DEFAULT_AREA_ICON;
+}

--- a/apps/web/convex/lib/dashboard.test.ts
+++ b/apps/web/convex/lib/dashboard.test.ts
@@ -89,6 +89,19 @@ describe("buildDashboardOverview", () => {
     expect(result.inbox.totalOpen).toBe(1);
   });
 
+  it("includes an Area Icon when one is stored", () => {
+    const result = buildDashboardOverview("user1", {
+      areas: [area("health", { icon: "HeartPulse" })],
+      threads: [],
+      tasks: [],
+      activityLogs: [],
+    });
+
+    expect(result.areas).toEqual([
+      expect.objectContaining({ id: "health", icon: "HeartPulse" }),
+    ]);
+  });
+
   it("orders dated Inbox Tasks first and undated Tasks newest first", () => {
     const result = buildDashboardOverview("user1", {
       areas: [],

--- a/apps/web/convex/lib/dashboard.ts
+++ b/apps/web/convex/lib/dashboard.ts
@@ -1,7 +1,9 @@
 import type { Doc, Id } from "../_generated/dataModel";
+import type { AreaIcon } from "./areaIcons";
 
 export interface DashboardArea {
   condition: Doc<"areas">["condition"];
+  icon?: AreaIcon;
   id: Id<"areas">;
   name: string;
   order: number;
@@ -53,6 +55,7 @@ export function buildDashboardOverview(
         name: area.name,
         slug: area.slug ?? area._id,
         condition: area.condition,
+        icon: area.icon,
         order: area.order,
       }),
     );

--- a/apps/web/convex/lib/validators.ts
+++ b/apps/web/convex/lib/validators.ts
@@ -1,6 +1,25 @@
 import { v } from "convex/values";
 
+import { AREA_ICONS } from "./areaIcons";
 import { CONDITIONS } from "./condition";
+
+export const areaIconValidator = v.union(
+  v.literal(AREA_ICONS[0]),
+  v.literal(AREA_ICONS[1]),
+  v.literal(AREA_ICONS[2]),
+  v.literal(AREA_ICONS[3]),
+  v.literal(AREA_ICONS[4]),
+  v.literal(AREA_ICONS[5]),
+  v.literal(AREA_ICONS[6]),
+  v.literal(AREA_ICONS[7]),
+  v.literal(AREA_ICONS[8]),
+  v.literal(AREA_ICONS[9]),
+  v.literal(AREA_ICONS[10]),
+  v.literal(AREA_ICONS[11]),
+  v.literal(AREA_ICONS[12]),
+  v.literal(AREA_ICONS[13]),
+  v.literal(AREA_ICONS[14]),
+);
 
 export const conditionValidator = v.union(
   v.literal(CONDITIONS[0]),

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 
 import {
   activityLogEntryTypeValidator,
+  areaIconValidator,
   conditionValidator,
 } from "./lib/validators";
 
@@ -13,6 +14,7 @@ export default defineSchema({
     slug: v.optional(v.string()),
     standard: v.optional(v.string()),
     condition: conditionValidator,
+    icon: v.optional(areaIconValidator),
     order: v.number(),
     createdAt: v.number(),
   })

--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -35,6 +35,7 @@ import {
 } from "lucide-react";
 
 import { CreateAreaDialog } from "@/features/areas/area-form/create-area-dialog";
+import { AreaIcon } from "@/features/areas/components/area-icon";
 import { useGlobalNewTaskShortcut } from "@/features/sidebar/use-global-new-task-shortcut";
 import { useSidebarDialogs } from "@/features/sidebar/use-sidebar-dialogs";
 import { NewTaskDialog } from "@/features/tasks/new-task/new-task-dialog";
@@ -137,6 +138,7 @@ export function AppSidebar() {
                       isActive={pathname === `/${areaSlug}`}
                       render={<Link to="/$areaSlug" params={{ areaSlug }} />}
                     >
+                      <AreaIcon icon={area.icon} className="size-4" />
                       <span>{area.name}</span>
                     </SidebarMenuButton>
                     <SidebarMenuAction

--- a/apps/web/src/components/layout/page-header.tsx
+++ b/apps/web/src/components/layout/page-header.tsx
@@ -16,6 +16,7 @@ interface PageHeaderProps {
   title: string;
   backLink?: PageHeaderBackLink;
   description?: string;
+  titleLeading?: ReactNode;
   titleAccessory?: ReactNode;
   actions?: ReactNode;
   className?: string;
@@ -25,6 +26,7 @@ export function PageHeader({
   title,
   backLink,
   description,
+  titleLeading,
   titleAccessory,
   actions,
   className,
@@ -42,7 +44,8 @@ export function PageHeader({
         </Link>
       )}
       <div className="flex items-center justify-between">
-        <div className="flex min-w-0 items-center gap-3">
+        <div className="flex min-w-0 items-center gap-1">
+          {titleLeading}
           <h1 className="truncate font-heading text-2xl font-semibold tracking-tight">
             {title}
           </h1>

--- a/apps/web/src/features/areas/area-form/area-form-dialog.test.tsx
+++ b/apps/web/src/features/areas/area-form/area-form-dialog.test.tsx
@@ -14,6 +14,76 @@ function deferred() {
 }
 
 describe("AreaFormDialog", () => {
+  it("starts new Areas with Compass and submits the selected icon", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn(async () => undefined);
+
+    render(
+      <AreaFormDialog
+        mode="create"
+        open
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Choose Area icon: Compass" }),
+    );
+    expect(screen.getByRole("button", { name: "Compass" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await user.click(screen.getByRole("button", { name: "Health" }));
+    await user.type(screen.getByLabelText("Name"), "Family Health");
+    await user.click(screen.getByRole("button", { name: "Create area" }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      name: "Family Health",
+      condition: "healthy",
+      icon: "HeartPulse",
+    });
+  });
+
+  it("does not change the selected icon when the Area name changes", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <AreaFormDialog
+        mode="create"
+        open
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Choose Area icon: Compass" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Finances" }));
+    await user.type(screen.getByLabelText("Name"), "Health");
+
+    expect(
+      screen.getByRole("button", { name: "Choose Area icon: WalletCards" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not expose icon editing in the general edit dialog", () => {
+    render(
+      <AreaFormDialog
+        mode="edit"
+        open
+        onOpenChange={vi.fn()}
+        initialValue={{ name: "Health", condition: "healthy", icon: "Compass" }}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /Choose Area icon/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("prevents duplicate area creates while saving", async () => {
     const user = userEvent.setup();
     const pendingCreate = deferred();
@@ -134,7 +204,7 @@ describe("AreaFormDialog", () => {
         mode="edit"
         open
         onOpenChange={vi.fn()}
-        initialValue={{ name: "Health", condition: "healthy" }}
+        initialValue={{ name: "Health", condition: "healthy", icon: "Compass" }}
         onSubmit={onSubmit}
       />,
     );
@@ -163,7 +233,7 @@ describe("AreaFormDialog", () => {
         mode="edit"
         open
         onOpenChange={vi.fn()}
-        initialValue={{ name: "Health", condition: "healthy" }}
+        initialValue={{ name: "Health", condition: "healthy", icon: "Compass" }}
         onSubmit={onSubmit}
       />,
     );

--- a/apps/web/src/features/areas/area-form/area-form-dialog.tsx
+++ b/apps/web/src/features/areas/area-form/area-form-dialog.tsx
@@ -1,4 +1,9 @@
 import {
+  DEFAULT_AREA_ICON,
+  getAreaIcon,
+  type AreaIcon as AreaIconName,
+} from "@convex/lib/areaIcons";
+import {
   CONDITION_OPTIONS,
   type Condition,
   DEFAULT_CONDITION,
@@ -7,6 +12,11 @@ import {
 import { Button } from "@vita-os/ui/components/button";
 import { Input } from "@vita-os/ui/components/input";
 import { Label } from "@vita-os/ui/components/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@vita-os/ui/components/popover";
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
@@ -24,6 +34,9 @@ import {
 } from "@vita-os/ui/components/select";
 import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 import { useEffect, useState } from "react";
+
+import { AreaIcon } from "@/features/areas/components/area-icon";
+import { AreaIconPicker } from "@/features/areas/components/area-icon-picker";
 
 import type { AreaFormValue } from "./types";
 
@@ -54,11 +67,17 @@ export function AreaFormDialog({
   const [condition, setCondition] = useState<Condition>(
     initialValue?.condition ?? DEFAULT_CONDITION,
   );
+  const [icon, setIcon] = useState<AreaIconName>(
+    getAreaIcon(initialValue?.icon),
+  );
+  const [iconPickerOpen, setIconPickerOpen] = useState(false);
 
   useEffect(() => {
     if (!open) return;
     setName(initialValue?.name ?? "");
     setCondition(initialValue?.condition ?? DEFAULT_CONDITION);
+    setIcon(getAreaIcon(initialValue?.icon));
+    setIconPickerOpen(false);
   }, [open, initialValue]);
 
   const {
@@ -84,12 +103,15 @@ export function AreaFormDialog({
     const result = await submitArea({
       name: trimmedName,
       condition: condition,
+      icon,
     });
     if (!result.ok) return;
 
     if (mode === "create") {
       setName("");
       setCondition(DEFAULT_CONDITION);
+      setIcon(DEFAULT_AREA_ICON);
+      setIconPickerOpen(false);
     }
   };
 
@@ -109,14 +131,44 @@ export function AreaFormDialog({
         <form onSubmit={handleSubmit} className="space-y-5">
           <div className="space-y-2">
             <Label htmlFor="area-name">Name</Label>
-            <Input
-              id="area-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="e.g. Health, Career, Finances"
-              autoFocus
-              disabled={isPending}
-            />
+            <div className="flex items-center gap-2">
+              {mode === "create" ? (
+                <Popover open={iconPickerOpen} onOpenChange={setIconPickerOpen}>
+                  <PopoverTrigger
+                    render={
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        className="shrink-0"
+                        aria-label={`Choose Area icon: ${icon}`}
+                        disabled={isPending}
+                      />
+                    }
+                  >
+                    <AreaIcon icon={icon} className="size-4" />
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-3" align="start">
+                    <AreaIconPicker
+                      selectedIcon={icon}
+                      onSelect={(selectedIcon) => {
+                        setIcon(selectedIcon);
+                        setIconPickerOpen(false);
+                      }}
+                      disabled={isPending}
+                    />
+                  </PopoverContent>
+                </Popover>
+              ) : null}
+              <Input
+                id="area-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Health, Career, Finances"
+                autoFocus
+                disabled={isPending}
+              />
+            </div>
           </div>
           <div className="space-y-2">
             <Label htmlFor="area-condition">Condition</Label>

--- a/apps/web/src/features/areas/area-form/edit-area-dialog.tsx
+++ b/apps/web/src/features/areas/area-form/edit-area-dialog.tsx
@@ -1,5 +1,7 @@
 import type { Doc } from "@convex/_generated/dataModel";
 
+import { getAreaIcon } from "@convex/lib/areaIcons";
+
 import { AreaFormDialog } from "./area-form-dialog";
 import { useUpdateArea } from "./use-update-area";
 
@@ -25,6 +27,7 @@ export function EditAreaDialog({
       initialValue={{
         name: area.name,
         condition: area.condition,
+        icon: getAreaIcon(area.icon),
       }}
       onSubmit={async (value) => {
         await updateArea(area, value);

--- a/apps/web/src/features/areas/area-form/types.ts
+++ b/apps/web/src/features/areas/area-form/types.ts
@@ -1,7 +1,9 @@
 import type { Doc } from "@convex/_generated/dataModel";
+import type { AreaIcon } from "@convex/lib/areaIcons";
 
 export type AreaFormValue = {
   name: string;
   standard?: string;
   condition: Doc<"areas">["condition"];
+  icon: AreaIcon;
 };

--- a/apps/web/src/features/areas/area-form/use-create-area.ts
+++ b/apps/web/src/features/areas/area-form/use-create-area.ts
@@ -17,5 +17,6 @@ export function useCreateArea() {
       name: value.name,
       standard: value.standard,
       condition: value.condition,
+      icon: value.icon,
     });
 }

--- a/apps/web/src/features/areas/components/area-card.tsx
+++ b/apps/web/src/features/areas/components/area-card.tsx
@@ -1,11 +1,12 @@
 import type { Doc } from "@convex/_generated/dataModel";
 
-import { conditionColors, conditionLabels } from "@convex/lib/condition";
 import { Link } from "@tanstack/react-router";
 import { cn } from "@vita-os/ui/lib/utils";
 import { CircleDot } from "lucide-react";
 
 import { flatListRowHoverClassName } from "@/lib/flat-surface";
+
+import { AreaIcon } from "./area-icon";
 
 interface AreaCardProps {
   area: Doc<"areas">;
@@ -21,11 +22,7 @@ export function AreaCard({ area, threadCount, attentionCount }: AreaCardProps) {
       className={cn("block py-4", flatListRowHoverClassName)}
     >
       <div className="flex items-center gap-2.5">
-        <span
-          className={`h-2.5 w-2.5 shrink-0 rounded-full ${conditionColors[area.condition]}`}
-          role="img"
-          aria-label={conditionLabels[area.condition]}
-        />
+        <AreaIcon icon={area.icon} className="size-4 shrink-0" />
         <p className="truncate font-medium">{area.name}</p>
       </div>
       <p className="mt-2 text-xs text-muted-foreground">

--- a/apps/web/src/features/areas/components/area-header-section.tsx
+++ b/apps/web/src/features/areas/components/area-header-section.tsx
@@ -1,4 +1,5 @@
 import type { Doc } from "@convex/_generated/dataModel";
+import type { AreaIcon } from "@convex/lib/areaIcons";
 
 import { api } from "@convex/_generated/api";
 import { useNavigate } from "@tanstack/react-router";
@@ -47,6 +48,11 @@ export function AreaHeaderSection({ areaSlug, onEdit }: AreaHeaderProps) {
     updateArea({ id: area._id, condition: value });
   };
 
+  const handleIconChange = async (icon: AreaIcon) => {
+    if (!area) return;
+    await updateArea({ id: area._id, icon });
+  };
+
   if (!area) return null;
 
   return (
@@ -56,6 +62,7 @@ export function AreaHeaderSection({ areaSlug, onEdit }: AreaHeaderProps) {
       onEdit={onEdit}
       onDelete={handleDelete}
       onConditionChange={handleConditionChange}
+      onIconChange={handleIconChange}
     />
   );
 }

--- a/apps/web/src/features/areas/components/area-header.test.tsx
+++ b/apps/web/src/features/areas/components/area-header.test.tsx
@@ -1,0 +1,87 @@
+import type { Doc } from "@convex/_generated/dataModel";
+import type { AreaIcon } from "@convex/lib/areaIcons";
+
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, waitFor } from "@/test/render-with-providers";
+
+import { AreaHeader } from "./area-header";
+
+const area = {
+  _id: "area1",
+  _creationTime: 1,
+  userId: "user1",
+  name: "Health",
+  icon: "Compass",
+  condition: "healthy",
+  order: 0,
+  createdAt: 1,
+} as Doc<"areas">;
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function renderHeader(onIconChange: (icon: AreaIcon) => Promise<void> | void) {
+  return render(
+    <AreaHeader
+      area={area}
+      threadCount={0}
+      onEdit={vi.fn()}
+      onDelete={vi.fn()}
+      onConditionChange={vi.fn()}
+      onIconChange={onIconChange}
+    />,
+  );
+}
+
+describe("AreaHeader icon picker", () => {
+  it("saves an icon once and closes after success", async () => {
+    const user = userEvent.setup();
+    const pendingSave = deferred();
+    const onIconChange = vi.fn(() => pendingSave.promise);
+    renderHeader(onIconChange);
+
+    await user.click(screen.getByRole("button", { name: "Change Area icon" }));
+    await user.click(screen.getByRole("button", { name: "Health" }));
+
+    expect(onIconChange).toHaveBeenCalledTimes(1);
+    expect(onIconChange).toHaveBeenCalledWith("HeartPulse");
+    expect(screen.getByRole("button", { name: "Health" })).toBeDisabled();
+
+    pendingSave.resolve();
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Health" }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("keeps the picker open when saving fails", async () => {
+    const user = userEvent.setup();
+    const pendingSave = deferred();
+    const onIconChange = vi.fn(() => pendingSave.promise);
+    const { feedback } = renderHeader(onIconChange);
+
+    await user.click(screen.getByRole("button", { name: "Change Area icon" }));
+    await user.click(screen.getByRole("button", { name: "Health" }));
+    pendingSave.reject(new Error("Database unavailable"));
+
+    await waitFor(() =>
+      expect(feedback.error).toHaveBeenCalledWith("Database unavailable"),
+    );
+    expect(screen.getByRole("button", { name: "Health" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Compass" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+});

--- a/apps/web/src/features/areas/components/area-header.test.tsx
+++ b/apps/web/src/features/areas/components/area-header.test.tsx
@@ -43,7 +43,7 @@ function renderHeader(onIconChange: (icon: AreaIcon) => Promise<void> | void) {
 }
 
 describe("AreaHeader icon picker", () => {
-  it("saves an icon once and closes after success", async () => {
+  it("closes immediately while saving the icon optimistically", async () => {
     const user = userEvent.setup();
     const pendingSave = deferred();
     const onIconChange = vi.fn(() => pendingSave.promise);
@@ -54,18 +54,23 @@ describe("AreaHeader icon picker", () => {
 
     expect(onIconChange).toHaveBeenCalledTimes(1);
     expect(onIconChange).toHaveBeenCalledWith("HeartPulse");
-    expect(screen.getByRole("button", { name: "Health" })).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "Health" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Change Area icon" }),
+    ).toBeDisabled();
 
     pendingSave.resolve();
 
     await waitFor(() =>
       expect(
-        screen.queryByRole("button", { name: "Health" }),
-      ).not.toBeInTheDocument(),
+        screen.getByRole("button", { name: "Change Area icon" }),
+      ).toBeEnabled(),
     );
   });
 
-  it("keeps the picker open when saving fails", async () => {
+  it("keeps the picker closed and reports a failed optimistic save", async () => {
     const user = userEvent.setup();
     const pendingSave = deferred();
     const onIconChange = vi.fn(() => pendingSave.promise);
@@ -78,10 +83,11 @@ describe("AreaHeader icon picker", () => {
     await waitFor(() =>
       expect(feedback.error).toHaveBeenCalledWith("Database unavailable"),
     );
-    expect(screen.getByRole("button", { name: "Health" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Compass" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    expect(
+      screen.queryByRole("button", { name: "Health" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Change Area icon" }),
+    ).toBeEnabled();
   });
 });

--- a/apps/web/src/features/areas/components/area-header.tsx
+++ b/apps/web/src/features/areas/components/area-header.tsx
@@ -1,11 +1,8 @@
 import type { Doc } from "@convex/_generated/dataModel";
+import type { AreaIcon as AreaIconName } from "@convex/lib/areaIcons";
 
-import {
-  CONDITION_OPTIONS,
-  conditionColors,
-  conditionLabels,
-  isCondition,
-} from "@convex/lib/condition";
+import { getAreaIcon } from "@convex/lib/areaIcons";
+import { CONDITION_OPTIONS, isCondition } from "@convex/lib/condition";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -19,16 +16,26 @@ import {
 } from "@vita-os/ui/components/alert-dialog";
 import { Button } from "@vita-os/ui/components/button";
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@vita-os/ui/components/popover";
+import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from "@vita-os/ui/components/select";
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 import { Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
 
 import { PageHeader } from "@/components/layout/page-header";
 import { cn } from "@/lib/utils";
+
+import { AreaIcon } from "./area-icon";
+import { AreaIconPicker } from "./area-icon-picker";
 
 interface AreaHeaderProps {
   area: Doc<"areas">;
@@ -36,6 +43,7 @@ interface AreaHeaderProps {
   onEdit: () => void;
   onDelete: () => void;
   onConditionChange: (value: Doc<"areas">["condition"]) => void;
+  onIconChange: (value: AreaIconName) => Promise<void> | void;
 }
 
 export function AreaHeader({
@@ -44,20 +52,55 @@ export function AreaHeader({
   onEdit,
   onDelete,
   onConditionChange,
+  onIconChange,
 }: AreaHeaderProps) {
+  const [iconPickerOpen, setIconPickerOpen] = useState(false);
+  const { run: saveIcon, isPending: isSavingIcon } =
+    useGuardedAsyncAction(onIconChange);
+  const selectedIcon = getAreaIcon(area.icon);
+
+  const handleIconSelect = async (icon: AreaIconName) => {
+    if (icon === selectedIcon) {
+      setIconPickerOpen(false);
+      return;
+    }
+
+    const result = await saveIcon(icon);
+    if (result.ok) setIconPickerOpen(false);
+  };
+
   return (
     <div>
       <PageHeader
         title={area.name}
         backLink={{ label: "Dashboard", to: "/" }}
-        titleAccessory={
-          <span
-            className={cn(
-              "h-2.5 w-2.5 shrink-0 rounded-full",
-              conditionColors[area.condition],
-            )}
-            aria-label={conditionLabels[area.condition]}
-          />
+        titleLeading={
+          <Popover
+            open={iconPickerOpen}
+            onOpenChange={(open) => {
+              if (!isSavingIcon) setIconPickerOpen(open);
+            }}
+          >
+            <PopoverTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Change Area icon"
+                  disabled={isSavingIcon}
+                />
+              }
+            >
+              <AreaIcon icon={selectedIcon} className="size-4" />
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-3" align="start">
+              <AreaIconPicker
+                selectedIcon={selectedIcon}
+                onSelect={(icon) => void handleIconSelect(icon)}
+                disabled={isSavingIcon}
+              />
+            </PopoverContent>
+          </Popover>
         }
         actions={
           <>

--- a/apps/web/src/features/areas/components/area-header.tsx
+++ b/apps/web/src/features/areas/components/area-header.tsx
@@ -65,8 +65,8 @@ export function AreaHeader({
       return;
     }
 
-    const result = await saveIcon(icon);
-    if (result.ok) setIconPickerOpen(false);
+    setIconPickerOpen(false);
+    await saveIcon(icon);
   };
 
   return (

--- a/apps/web/src/features/areas/components/area-icon-picker.tsx
+++ b/apps/web/src/features/areas/components/area-icon-picker.tsx
@@ -1,0 +1,45 @@
+import type { AreaIcon as AreaIconName } from "@convex/lib/areaIcons";
+
+import { AREA_ICONS, areaIconLabels } from "@convex/lib/areaIcons";
+
+import { cn } from "@/lib/utils";
+
+import { AreaIcon } from "./area-icon";
+
+interface AreaIconPickerProps {
+  selectedIcon: AreaIconName;
+  onSelect: (icon: AreaIconName) => void;
+  disabled?: boolean;
+}
+
+export function AreaIconPicker({
+  selectedIcon,
+  onSelect,
+  disabled = false,
+}: AreaIconPickerProps) {
+  return (
+    <div className="grid grid-cols-5 gap-2" aria-label="Area icon">
+      {AREA_ICONS.map((icon) => {
+        const selected = icon === selectedIcon;
+        return (
+          <button
+            key={icon}
+            type="button"
+            aria-label={areaIconLabels[icon]}
+            aria-pressed={selected}
+            title={areaIconLabels[icon]}
+            disabled={disabled}
+            onClick={() => onSelect(icon)}
+            className={cn(
+              "flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-3 hover:text-foreground disabled:pointer-events-none disabled:opacity-50",
+              selected &&
+                "bg-surface-3 text-foreground ring-1 ring-foreground/15",
+            )}
+          >
+            <AreaIcon icon={icon} className="size-4" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/areas/components/area-icon.tsx
+++ b/apps/web/src/features/areas/components/area-icon.tsx
@@ -1,0 +1,49 @@
+import type { AreaIcon as AreaIconName } from "@convex/lib/areaIcons";
+
+import { getAreaIcon } from "@convex/lib/areaIcons";
+import {
+  BookOpen,
+  BriefcaseBusiness,
+  CalendarDays,
+  Car,
+  Compass,
+  Dumbbell,
+  HeartPulse,
+  Home,
+  Leaf,
+  Palette,
+  Plane,
+  Shield,
+  Users,
+  Utensils,
+  WalletCards,
+  type LucideIcon,
+} from "lucide-react";
+
+const areaIconComponents: Record<AreaIconName, LucideIcon> = {
+  Compass,
+  HeartPulse,
+  Dumbbell,
+  Users,
+  Home,
+  BriefcaseBusiness,
+  WalletCards,
+  BookOpen,
+  Utensils,
+  Car,
+  CalendarDays,
+  Palette,
+  Leaf,
+  Shield,
+  Plane,
+};
+
+interface AreaIconProps {
+  icon?: unknown;
+  className?: string;
+}
+
+export function AreaIcon({ icon, className }: AreaIconProps) {
+  const Icon = areaIconComponents[getAreaIcon(icon)];
+  return <Icon className={className} aria-hidden="true" />;
+}

--- a/apps/web/src/features/areas/components/area-picker.tsx
+++ b/apps/web/src/features/areas/components/area-picker.tsx
@@ -6,8 +6,9 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@vita-os/ui/components/popover";
-import { Compass } from "lucide-react";
 import { useState } from "react";
+
+import { AreaIcon } from "./area-icon";
 
 interface AreaPickerProps {
   areas: Doc<"areas">[];
@@ -37,7 +38,7 @@ export function AreaPicker({
           />
         }
       >
-        <Compass className="h-3 w-3" />
+        <AreaIcon icon={selected?.icon} className="h-3 w-3" />
         {selected ? selected.name : "Area"}
       </PopoverTrigger>
       <PopoverContent className="w-48 p-1" align="start">
@@ -49,8 +50,9 @@ export function AreaPicker({
               onSelect(a._id);
               setOpen(false);
             }}
-            className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-surface-3"
+            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-surface-3"
           >
+            <AreaIcon icon={a.icon} className="size-3.5 shrink-0" />
             {a.name}
           </button>
         ))}

--- a/apps/web/src/features/areas/optimistic.test.ts
+++ b/apps/web/src/features/areas/optimistic.test.ts
@@ -12,6 +12,7 @@ describe("Area optimistic updates", () => {
           name: "Family Health",
           standard: "Appointments are current",
           condition: "healthy",
+          icon: "HeartPulse",
         },
         { id: "area1" as Id<"areas">, now: 123, order: 4 },
       ),
@@ -22,6 +23,7 @@ describe("Area optimistic updates", () => {
       name: "Family Health",
       standard: "Appointments are current",
       condition: "healthy",
+      icon: "HeartPulse",
       order: 4,
       createdAt: 123,
     });

--- a/apps/web/src/features/areas/optimistic.ts
+++ b/apps/web/src/features/areas/optimistic.ts
@@ -12,13 +12,16 @@ type CreateAreaArgs = {
   name: string;
   standard?: string;
   condition: Area["condition"];
+  icon: NonNullable<Area["icon"]>;
 };
 
 type NullablePatch<T> = {
   [K in keyof T]?: T[K] | null;
 };
 
-type AreaPatch = NullablePatch<Pick<Area, "name" | "standard" | "condition">>;
+type AreaPatch = NullablePatch<
+  Pick<Area, "name" | "standard" | "condition" | "icon">
+>;
 
 export function buildOptimisticArea(
   args: CreateAreaArgs,
@@ -31,6 +34,7 @@ export function buildOptimisticArea(
     name: args.name,
     standard: args.standard,
     condition: args.condition,
+    icon: args.icon,
     order: options.order,
     createdAt: options.now,
   };

--- a/apps/web/src/features/dashboard/components/dashboard-model.ts
+++ b/apps/web/src/features/dashboard/components/dashboard-model.ts
@@ -1,3 +1,4 @@
+import type { AreaIcon } from "@convex/lib/areaIcons";
 import type { Condition } from "@convex/lib/condition";
 
 import { addDays, format } from "date-fns";
@@ -6,6 +7,7 @@ export const DAY = 24 * 60 * 60 * 1000;
 
 export interface DashboardArea {
   condition: Condition;
+  icon?: AreaIcon;
   id: string;
   name: string;
   order: number;

--- a/apps/web/src/features/dashboard/components/dashboard-overview.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-overview.tsx
@@ -1,4 +1,4 @@
-import { conditionColors, type Condition } from "@convex/lib/condition";
+import { type Condition } from "@convex/lib/condition";
 import { Link } from "@tanstack/react-router";
 import { Badge } from "@vita-os/ui/components/badge";
 import { Button } from "@vita-os/ui/components/button";
@@ -27,6 +27,7 @@ import {
   MessagesSquare,
 } from "lucide-react";
 
+import { AreaIcon } from "@/features/areas/components/area-icon";
 import { flatListClassName } from "@/lib/flat-surface";
 
 import {
@@ -177,7 +178,10 @@ function AreaConditionMap({ areas }: { areas: DashboardArea[] }) {
                     params={{ areaSlug: area.slug }}
                     className="group flex min-w-0 flex-1 items-center justify-between gap-2 px-3 py-2.5 text-sm font-medium transition-colors hover:bg-muted/50"
                   >
-                    <span className="truncate">{area.name}</span>
+                    <span className="flex min-w-0 items-center gap-2 truncate">
+                      <AreaIcon icon={area.icon} className="size-4 shrink-0" />
+                      <span className="truncate">{area.name}</span>
+                    </span>
                     <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
                   </Link>
                 ))}
@@ -327,12 +331,7 @@ function DashboardThreadRow({
         <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
           <h3 className="text-sm font-medium">{thread.title}</h3>
           <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
-            <span
-              className={cn(
-                "size-1.5 rounded-full",
-                conditionColors[area.condition],
-              )}
-            />
+            <AreaIcon icon={area.icon} className="size-3 shrink-0" />
             {area.name}
           </span>
         </div>
@@ -480,12 +479,7 @@ function RecentActivity({
               className="block rounded-md px-1 py-2 transition-colors hover:bg-muted/50"
             >
               <div className="flex items-center gap-1.5">
-                <span
-                  className={cn(
-                    "size-1.5 shrink-0 rounded-full",
-                    conditionColors[area.condition],
-                  )}
-                />
+                <AreaIcon icon={area.icon} className="size-3.5 shrink-0" />
                 <p className="truncate text-sm font-medium">{thread.title}</p>
               </div>
               <p className="mt-0.5 truncate text-xs text-muted-foreground">
@@ -601,13 +595,7 @@ function PlanThreadLink({
     >
       <MessagesSquare className="size-3.5 shrink-0" />
       <span className="truncate">{thread.title}</span>
-      <span
-        className={cn(
-          "size-1.5 shrink-0 rounded-full",
-          conditionColors[area.condition],
-        )}
-        aria-label={`${conditionLabels[area.condition]} Area`}
-      />
+      <AreaIcon icon={area.icon} className="size-3.5 shrink-0" />
     </Link>
   );
 }

--- a/apps/web/src/features/tasks/process-task/process-task-dialog.tsx
+++ b/apps/web/src/features/tasks/process-task/process-task-dialog.tsx
@@ -24,6 +24,8 @@ import { useState } from "react";
 
 import type { ProcessTaskAction } from "@/features/tasks/use-process-task";
 
+import { AreaIcon } from "@/features/areas/components/area-icon";
+
 import {
   type ThreadChoice,
   ThreadSearchAutocomplete,
@@ -322,10 +324,11 @@ function AreaChoice({
               size="sm"
               onClick={() => onSelect(area._id)}
               className={cn(
-                "h-7 rounded-full px-3 text-xs font-medium",
+                "h-7 gap-1.5 rounded-full px-3 text-xs font-medium",
                 !isSelected && "bg-transparent",
               )}
             >
+              <AreaIcon icon={area.icon} className="size-3.5 shrink-0" />
               {area.name}
             </Button>
           );

--- a/apps/web/src/features/threads/components/thread-picker.tsx
+++ b/apps/web/src/features/threads/components/thread-picker.tsx
@@ -9,6 +9,8 @@ import {
 import { FolderOpen } from "lucide-react";
 import { useState } from "react";
 
+import { AreaIcon } from "@/features/areas/components/area-icon";
+
 interface ThreadPickerProps {
   threads: Doc<"threads">[];
   areas: Doc<"areas">[];
@@ -45,7 +47,8 @@ export function ThreadPicker({
       <PopoverContent className="w-56 p-1" align="start">
         {threadsByArea.map(({ area, threads: areaThreads }) => (
           <div key={area._id}>
-            <p className="px-2 py-1 text-xs font-medium text-muted-foreground">
+            <p className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-muted-foreground">
+              <AreaIcon icon={area.icon} className="size-3 shrink-0" />
               {area.name}
             </p>
             {areaThreads.map((p) => (


### PR DESCRIPTION
## Summary
- Add curated Area Icon selection, validation, persistence, and fallback behavior
- Display Area Icons across creation, headers, sidebar, Dashboard, cards, pickers, and Thread identity surfaces
- Keep Condition separate and add optimistic updates and focused coverage

## Verification
- `bunx tsc --noEmit -p convex/tsconfig.json`
- `bun run lint`
- `bun run build`
- `bun run test:run` (188 tests)

Closes #198