### PR TITLE
Fix condition selects to display labels for stored values

### DIFF
--- a/apps/web/src/features/areas/area-form/area-form-dialog.test.tsx
+++ b/apps/web/src/features/areas/area-form/area-form-dialog.test.tsx
@@ -14,6 +14,25 @@ function deferred() {
 }
 
 describe("AreaFormDialog", () => {
+  it("shows the selected condition label instead of its stored value", () => {
+    render(
+      <AreaFormDialog
+        mode="edit"
+        open
+        onOpenChange={vi.fn()}
+        initialValue={{ name: "Health", condition: "needs_attention" }}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText("Condition")).toHaveTextContent(
+      "Needs attention",
+    );
+    expect(screen.getByLabelText("Condition")).not.toHaveTextContent(
+      "needs_attention",
+    );
+  });
+
   it("prevents duplicate area creates while saving", async () => {
     const user = userEvent.setup();
     const pendingCreate = deferred();

--- a/apps/web/src/features/areas/area-form/area-form-dialog.tsx
+++ b/apps/web/src/features/areas/area-form/area-form-dialog.tsx
@@ -18,6 +18,7 @@ import {
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -121,6 +122,7 @@ export function AreaFormDialog({
           <div className="space-y-2">
             <Label htmlFor="area-condition">Condition</Label>
             <Select
+              items={CONDITION_OPTIONS}
               value={condition}
               disabled={isPending}
               onValueChange={(value) => {
@@ -131,16 +133,18 @@ export function AreaFormDialog({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {CONDITION_OPTIONS.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    <span className="flex items-center gap-2">
-                      <span
-                        className={`h-2 w-2 rounded-full ${option.color}`}
-                      />
-                      {option.label}
-                    </span>
-                  </SelectItem>
-                ))}
+                <SelectGroup>
+                  {CONDITION_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      <span className="flex items-center gap-2">
+                        <span
+                          className={`h-2 w-2 rounded-full ${option.color}`}
+                        />
+                        {option.label}
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
               </SelectContent>
             </Select>
           </div>

--- a/apps/web/src/features/areas/components/area-header.tsx
+++ b/apps/web/src/features/areas/components/area-header.tsx
@@ -21,6 +21,7 @@ import { Button } from "@vita-os/ui/components/button";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -106,6 +107,7 @@ export function AreaHeader({
 
       <div className="flex items-center gap-3">
         <Select
+          items={CONDITION_OPTIONS}
           value={area.condition}
           onValueChange={(value) => {
             if (isCondition(value)) onConditionChange(value);
@@ -118,14 +120,18 @@ export function AreaHeader({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {CONDITION_OPTIONS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                <span className="flex items-center gap-2">
-                  <span className={cn("h-2 w-2 rounded-full", option.color)} />
-                  {option.label}
-                </span>
-              </SelectItem>
-            ))}
+            <SelectGroup>
+              {CONDITION_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  <span className="flex items-center gap-2">
+                    <span
+                      className={cn("h-2 w-2 rounded-full", option.color)}
+                    />
+                    {option.label}
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectGroup>
           </SelectContent>
         </Select>
         <span className="text-xs text-muted-foreground">

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -62,7 +62,7 @@ function SelectContent({
   sideOffset = 4,
   align = "center",
   alignOffset = 0,
-  alignItemWithTrigger = true,
+  alignItemWithTrigger = false,
   ...props
 }: SelectPrimitive.Popup.Props &
   Pick<
@@ -83,7 +83,7 @@ function SelectContent({
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
           className={cn(
-            "dark isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-3xl text-popover-foreground shadow-lg ring-1 ring-foreground/5 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!",
+            "dark isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-3xl text-popover-foreground shadow-lg ring-1 ring-foreground/5 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!",
             className,
           )}
           {...props}


### PR DESCRIPTION
## Summary
- Configure condition selects with option metadata so stored values render as user-facing labels.
- Disable trigger-width alignment and group condition items for consistent select rendering.
- Add regression coverage for the health condition label.

## Testing
- Not run (not requested)