### PR TITLE
Redesign thread detail as a responsive desktop pane

### DIFF
--- a/apps/web/src/features/threads/thread-detail/thread-detail-view.test.tsx
+++ b/apps/web/src/features/threads/thread-detail/thread-detail-view.test.tsx
@@ -12,16 +12,16 @@ import {
   within,
 } from "@/test/render-with-providers";
 
-import { ThreadDetailSheet } from "./thread-detail-sheet";
+import { ThreadDetailView } from "./thread-detail-view";
 
 const mocks = vi.hoisted(() => ({
-  isMobile: true,
+  showDesktopPane: false,
   navigate: vi.fn(),
   threadState: "open" as "open" | "resolved",
 }));
 
-vi.mock("@vita-os/ui/hooks/use-mobile", () => ({
-  useIsMobile: () => mocks.isMobile,
+vi.mock("@/hooks/use-thread-pane-viewport", () => ({
+  useThreadPaneViewport: () => mocks.showDesktopPane,
 }));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => ({
@@ -75,20 +75,21 @@ vi.mock("convex/react", () => ({
   },
 }));
 
-describe("ThreadDetailSheet", () => {
+function renderThreadDetail(threadSlug = "sister-s-front-teeth") {
+  return render(
+    <ThreadDetailView areaSlug="family-health" threadSlug={threadSlug} />,
+  );
+}
+
+describe("ThreadDetailView", () => {
   beforeEach(() => {
-    mocks.isMobile = true;
+    mocks.showDesktopPane = false;
     mocks.navigate.mockReset();
     mocks.threadState = "open";
   });
 
-  it("opens Thread detail as a near-full bottom drawer on mobile", async () => {
-    render(
-      <ThreadDetailSheet
-        areaSlug="family-health"
-        threadSlug="sister-s-front-teeth"
-      />,
-    );
+  it("opens Thread detail as a near-full bottom drawer below the pane breakpoint", async () => {
+    renderThreadDetail();
 
     const drawer = await screen.findByRole("dialog", {
       name: "Sister's front teeth",
@@ -99,17 +100,10 @@ describe("ThreadDetailSheet", () => {
     expect(screen.getByRole("button", { name: "Close thread" })).toBeVisible();
   });
 
-  it("leaves the mobile Thread route after its programmatic close animation", async () => {
-    render(
-      <ThreadDetailSheet
-        areaSlug="family-health"
-        threadSlug="sister-s-front-teeth"
-      />,
-    );
+  it("leaves the narrow Thread route after its close animation", async () => {
+    renderThreadDetail();
 
-    await screen.findByRole("dialog", {
-      name: "Sister's front teeth",
-    });
+    await screen.findByRole("dialog", { name: "Sister's front teeth" });
     fireEvent.click(screen.getByRole("button", { name: "Close thread" }));
 
     expect(mocks.navigate).not.toHaveBeenCalled();
@@ -123,19 +117,14 @@ describe("ThreadDetailSheet", () => {
     });
   });
 
-  it("opens a fresh shell when the Thread route changes", async () => {
-    const { rerender } = render(
-      <ThreadDetailSheet
-        areaSlug="family-health"
-        threadSlug="sister-s-front-teeth"
-      />,
-    );
+  it("opens a fresh Drawer shell when the Thread route changes", async () => {
+    const { rerender } = renderThreadDetail();
 
     await screen.findByRole("dialog", { name: "Sister's front teeth" });
     fireEvent.click(screen.getByRole("button", { name: "Close thread" }));
 
     rerender(
-      <ThreadDetailSheet areaSlug="family-health" threadSlug="moms-legs" />,
+      <ThreadDetailView areaSlug="family-health" threadSlug="moms-legs" />,
     );
 
     await waitFor(() => {
@@ -145,33 +134,22 @@ describe("ThreadDetailSheet", () => {
     });
   });
 
-  it("opens a responsive desktop sheet over a soft contextual backdrop", async () => {
-    mocks.isMobile = false;
+  it("renders a non-modal complementary pane without a Sheet backdrop", async () => {
+    mocks.showDesktopPane = true;
+    renderThreadDetail();
 
-    render(
-      <ThreadDetailSheet
-        areaSlug="family-health"
-        threadSlug="sister-s-front-teeth"
-      />,
-    );
-
-    const sheet = await screen.findByRole("dialog", {
+    const pane = await screen.findByRole("complementary", {
       name: "Sister's front teeth",
     });
-    const backdrop = document.querySelector('[data-slot="sheet-overlay"]');
 
-    expect(sheet).toHaveClass(
-      "data-[side=right]:w-[clamp(35rem,45vw,45rem)]",
-      "data-[side=right]:sm:max-w-none",
-      "data-open:animate-in",
-      "data-open:slide-in-from-right-full",
-      "data-closed:animate-out",
-      "data-closed:slide-out-to-right-full",
-    );
-    expect(backdrop).toHaveClass(
-      "bg-black/20",
-      "supports-backdrop-filter:backdrop-blur-none",
-    );
+    await waitFor(() => expect(pane).toHaveAttribute("data-state", "open"));
+    expect(pane).toHaveClass("fixed", "inset-y-0", "h-dvh");
+    expect(
+      document.querySelector('[data-slot="thread-detail-pane-space"]'),
+    ).toHaveClass("data-[state=open]:w-[clamp(28rem,34vw,34rem)]");
+    expect(document.querySelector('[data-slot="sheet-overlay"]')).toBeNull();
+    expect(screen.queryByRole("dialog")).toBeNull();
+
     const controls = screen.getByRole("group", { name: "Thread controls" });
     expect(
       within(controls).getByRole("button", { name: "Thread actions" }),
@@ -181,17 +159,55 @@ describe("ThreadDetailSheet", () => {
     ).toBeVisible();
   });
 
-  it("restores orientation before presenting attention and continuity", async () => {
-    mocks.isMobile = false;
+  it("leaves the desktop Thread route after the pane width transition", async () => {
+    mocks.showDesktopPane = true;
+    renderThreadDetail();
 
-    render(
-      <ThreadDetailSheet
-        areaSlug="family-health"
-        threadSlug="sister-s-front-teeth"
-      />,
+    await screen.findByRole("complementary", {
+      name: "Sister's front teeth",
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Close thread" }));
+
+    expect(mocks.navigate).not.toHaveBeenCalled();
+
+    const paneSpace = document.querySelector(
+      '[data-slot="thread-detail-pane-space"]',
+    );
+    expect(paneSpace).toHaveAttribute("data-state", "closed");
+    fireEvent.transitionEnd(paneSpace as Element, { propertyName: "width" });
+
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      to: "/$areaSlug",
+      params: { areaSlug: "family-health" },
+      replace: true,
+    });
+  });
+
+  it("keeps the desktop pane open when the Thread route changes", async () => {
+    mocks.showDesktopPane = true;
+    const { rerender } = renderThreadDetail();
+    const pane = await screen.findByRole("complementary", {
+      name: "Sister's front teeth",
+    });
+    await waitFor(() => expect(pane).toHaveAttribute("data-state", "open"));
+
+    rerender(
+      <ThreadDetailView areaSlug="family-health" threadSlug="moms-legs" />,
     );
 
-    await screen.findByRole("dialog", { name: "Sister's front teeth" });
+    expect(
+      screen.getByRole("complementary", { name: "Sister's front teeth" }),
+    ).toBe(pane);
+    expect(pane).toHaveAttribute("data-state", "open");
+  });
+
+  it("restores orientation before presenting attention and continuity", async () => {
+    mocks.showDesktopPane = true;
+    renderThreadDetail();
+
+    await screen.findByRole("complementary", {
+      name: "Sister's front teeth",
+    });
 
     const header = screen.getByRole("banner", { name: "Thread header" });
     const summary = screen.getByText("Waiting for the specialist's opinion.");
@@ -204,9 +220,7 @@ describe("ThreadDetailSheet", () => {
       within(header).getByRole("button", { name: "Family Health" }),
     ).toBeVisible();
     expect(
-      within(header).getByRole("button", {
-        name: "Sister's front teeth",
-      }),
+      within(header).getByRole("button", { name: "Sister's front teeth" }),
     ).toBeVisible();
     expect(
       within(header).getByRole("button", {
@@ -227,17 +241,13 @@ describe("ThreadDetailSheet", () => {
   });
 
   it("keeps a Resolved Thread oriented without active attention controls", async () => {
-    mocks.isMobile = false;
+    mocks.showDesktopPane = true;
     mocks.threadState = "resolved";
+    renderThreadDetail();
 
-    render(
-      <ThreadDetailSheet
-        areaSlug="family-health"
-        threadSlug="sister-s-front-teeth"
-      />,
-    );
-
-    await screen.findByRole("dialog", { name: "Sister's front teeth" });
+    await screen.findByRole("complementary", {
+      name: "Sister's front teeth",
+    });
 
     expect(screen.getByText("Resolved")).toBeVisible();
     expect(

--- a/apps/web/src/features/threads/thread-detail/thread-detail-view.tsx
+++ b/apps/web/src/features/threads/thread-detail/thread-detail-view.tsx
@@ -15,13 +15,6 @@ import {
   DrawerTitle,
 } from "@vita-os/ui/components/drawer";
 import { Separator } from "@vita-os/ui/components/separator";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetTitle,
-} from "@vita-os/ui/components/sheet";
-import { useIsMobile } from "@vita-os/ui/hooks/use-mobile";
 import { X } from "lucide-react";
 
 import { FollowUpSection } from "@/features/threads/components/follow-up-section";
@@ -34,49 +27,34 @@ import { ThreadLifecycleActionsSection } from "@/features/threads/components/thr
 import { ActivityLogSection } from "@/features/threads/components/thread-log-section";
 import { useDocumentTitle } from "@/hooks/use-document-title";
 import { useStableQuery } from "@/hooks/use-stable-query";
+import { useThreadPaneViewport } from "@/hooks/use-thread-pane-viewport";
 
 import { ThreadNotFound } from "./thread-not-found";
-import { useDeferredOverlayClose } from "./use-deferred-overlay-close";
+import { useDeferredRouteClose } from "./use-deferred-route-close";
 
-interface ThreadDetailSheetProps {
+interface ThreadDetailViewProps {
   areaSlug: string;
   threadSlug: string;
 }
 
-export function ThreadDetailSheet({
+export function ThreadDetailView({
   areaSlug,
   threadSlug,
-}: ThreadDetailSheetProps) {
-  return (
-    <ThreadDetailSheetInstance
-      key={`${areaSlug}/${threadSlug}`}
-      areaSlug={areaSlug}
-      threadSlug={threadSlug}
-    />
-  );
-}
-
-function ThreadDetailSheetInstance({
-  areaSlug,
-  threadSlug,
-}: ThreadDetailSheetProps) {
-  const isMobile = useIsMobile();
+}: ThreadDetailViewProps) {
+  const showDesktopPane = useThreadPaneViewport();
   const navigate = useNavigate();
   const area = useStableQuery(api.areas.getBySlug, { slug: areaSlug });
-  const thread = useStableQuery(api.threads.getBySlug, {
-    slug: threadSlug,
-  });
+  const thread = useStableQuery(api.threads.getBySlug, { slug: threadSlug });
 
   useDocumentTitle(thread?.title ?? "Thread");
 
-  const { open, requestClose, handleOpenChange, completeOpenChange } =
-    useDeferredOverlayClose(() => {
-      navigate({
-        to: "/$areaSlug",
-        params: { areaSlug },
-        replace: true,
-      });
+  const leaveThreadRoute = () => {
+    navigate({
+      to: "/$areaSlug",
+      params: { areaSlug },
+      replace: true,
     });
+  };
 
   const title = thread?.title ?? "Thread detail";
   const hasMatchingThread =
@@ -98,72 +76,131 @@ function ThreadDetailSheetInstance({
       />
     );
 
-  if (isMobile) {
+  if (!showDesktopPane) {
     return (
-      <Drawer
-        open={open}
-        direction="bottom"
-        onOpenChange={handleOpenChange}
-        onAnimationEnd={completeOpenChange}
+      <ThreadDetailDrawer
+        key={`${areaSlug}/${threadSlug}`}
+        title={title}
+        threadSlug={threadSlug}
+        showActions={hasMatchingThread}
+        onClosed={leaveThreadRoute}
       >
-        <DrawerContent
-          className="h-[90dvh] max-h-[90dvh] p-0 before:inset-0 before:rounded-t-4xl data-[vaul-drawer-direction=bottom]:max-h-[90dvh]"
-          onAnimationEndCapture={(event) => {
-            if (
-              event.target === event.currentTarget &&
-              event.currentTarget.dataset.state === "closed"
-            ) {
-              completeOpenChange(false);
-            }
-          }}
-        >
-          <DrawerTitle className="sr-only">{title}</DrawerTitle>
-          <DrawerDescription className="sr-only">
-            Review and update this Thread.
-          </DrawerDescription>
-          <ThreadOverlayControls
-            threadSlug={threadSlug}
-            showActions={hasMatchingThread}
-            onRequestClose={requestClose}
-          />
-          <div className="min-h-0 flex-1 overflow-y-auto px-5 pt-8 pb-[calc(2rem+env(safe-area-inset-bottom))]">
-            {content}
-          </div>
-        </DrawerContent>
-      </Drawer>
+        {content}
+      </ThreadDetailDrawer>
     );
   }
 
   return (
-    <Sheet
-      open={open}
-      onOpenChange={handleOpenChange}
-      onOpenChangeComplete={completeOpenChange}
+    <ThreadDetailPane
+      title={title}
+      threadSlug={threadSlug}
+      showActions={hasMatchingThread}
+      onClosed={leaveThreadRoute}
     >
-      <SheetContent
-        side="right"
-        showCloseButton={false}
-        overlayClassName="bg-black/20 supports-backdrop-filter:backdrop-blur-none data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0"
-        className="ease-[cubic-bezier(0.32,0.72,0,1)] data-open:animate-in data-open:slide-in-from-right-full data-closed:animate-out data-closed:slide-out-to-right-full data-[side=right]:w-[clamp(35rem,45vw,45rem)] data-[side=right]:sm:max-w-none"
-      >
-        <SheetTitle className="sr-only">{title}</SheetTitle>
-        <SheetDescription className="sr-only">
-          Review and update this Thread.
-        </SheetDescription>
-        <ThreadOverlayControls
-          threadSlug={threadSlug}
-          showActions={hasMatchingThread}
-          onRequestClose={requestClose}
-        />
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-8">
-          {content}
-        </div>
-      </SheetContent>
-    </Sheet>
+      {content}
+    </ThreadDetailPane>
   );
 }
 
-function ThreadOverlayControls({
+interface ThreadShellProps {
+  title: string;
+  threadSlug: string;
+  showActions: boolean;
+  onClosed: () => void;
+  children: React.ReactNode;
+}
+
+function ThreadDetailDrawer({
+  title,
+  threadSlug,
+  showActions,
+  onClosed,
+  children,
+}: ThreadShellProps) {
+  const { open, requestClose, handleOpenChange, completeOpenChange } =
+    useDeferredRouteClose(onClosed);
+
+  return (
+    <Drawer
+      open={open}
+      direction="bottom"
+      onOpenChange={handleOpenChange}
+      onAnimationEnd={completeOpenChange}
+    >
+      <DrawerContent
+        className="h-[90dvh] max-h-[90dvh] p-0 before:inset-0 before:rounded-t-4xl data-[vaul-drawer-direction=bottom]:max-h-[90dvh]"
+        onAnimationEndCapture={(event) => {
+          if (
+            event.target === event.currentTarget &&
+            event.currentTarget.dataset.state === "closed"
+          ) {
+            completeOpenChange(false);
+          }
+        }}
+      >
+        <DrawerTitle className="sr-only">{title}</DrawerTitle>
+        <DrawerDescription className="sr-only">
+          Review and update this Thread.
+        </DrawerDescription>
+        <ThreadControls
+          threadSlug={threadSlug}
+          showActions={showActions}
+          onRequestClose={requestClose}
+        />
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 pt-8 pb-[calc(2rem+env(safe-area-inset-bottom))]">
+          {children}
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+function ThreadDetailPane({
+  title,
+  threadSlug,
+  showActions,
+  onClosed,
+  children,
+}: ThreadShellProps) {
+  const { open, requestClose, completeOpenChange } =
+    useDeferredRouteClose(onClosed);
+
+  return (
+    <>
+      <div
+        data-slot="thread-detail-pane-space"
+        data-state={open ? "open" : "closed"}
+        className="relative w-0 min-w-0 shrink-0 transition-[width] duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] data-[state=open]:w-[clamp(28rem,34vw,34rem)] motion-reduce:transition-none"
+        onTransitionEnd={(event) => {
+          if (
+            event.target === event.currentTarget &&
+            event.propertyName === "width" &&
+            !open
+          ) {
+            completeOpenChange(false);
+          }
+        }}
+      />
+      <aside
+        aria-label={title}
+        data-slot="thread-detail-pane"
+        data-state={open ? "open" : "closed"}
+        className="fixed inset-y-0 right-0 z-30 flex h-dvh w-[clamp(28rem,34vw,34rem)] translate-x-full flex-col border-l bg-popover text-sm text-popover-foreground shadow-xl transition-transform duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] data-[state=open]:translate-x-0 motion-reduce:transition-none"
+      >
+        <ThreadControls
+          threadSlug={threadSlug}
+          showActions={showActions}
+          onRequestClose={requestClose}
+        />
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-8">
+          {children}
+        </div>
+      </aside>
+    </>
+  );
+}
+
+function ThreadControls({
   threadSlug,
   showActions,
   onRequestClose,
@@ -198,7 +235,9 @@ function ThreadOverlayControls({
   );
 }
 
-interface ThreadDetailContentProps extends ThreadDetailSheetProps {
+interface ThreadDetailContentProps {
+  areaSlug: string;
+  threadSlug: string;
   thread: Doc<"threads">;
 }
 
@@ -235,7 +274,7 @@ function ThreadDetailContent({
           aria-label="Thread attention"
           className="flex flex-col gap-5"
         >
-          <div className="grid gap-5 sm:grid-cols-2">
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(14rem,1fr))] gap-5">
             <NextMoveSection threadSlug={threadSlug} />
             <FollowUpSection threadSlug={threadSlug} />
           </div>

--- a/apps/web/src/features/threads/thread-detail/use-deferred-route-close.test.ts
+++ b/apps/web/src/features/threads/thread-detail/use-deferred-route-close.test.ts
@@ -1,9 +1,9 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { useDeferredOverlayClose } from "./use-deferred-overlay-close";
+import { useDeferredRouteClose } from "./use-deferred-route-close";
 
-describe("useDeferredOverlayClose", () => {
+describe("useDeferredRouteClose", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
@@ -20,7 +20,7 @@ describe("useDeferredOverlayClose", () => {
     );
     vi.stubGlobal("cancelAnimationFrame", vi.fn());
 
-    const { result } = renderHook(() => useDeferredOverlayClose(vi.fn()));
+    const { result } = renderHook(() => useDeferredRouteClose(vi.fn()));
 
     expect(result.current.open).toBe(false);
 
@@ -31,7 +31,7 @@ describe("useDeferredOverlayClose", () => {
 
   it("waits for the closing animation before leaving Thread detail", () => {
     const onClosed = vi.fn();
-    const { result } = renderHook(() => useDeferredOverlayClose(onClosed));
+    const { result } = renderHook(() => useDeferredRouteClose(onClosed));
 
     act(() => result.current.requestClose());
 
@@ -46,7 +46,7 @@ describe("useDeferredOverlayClose", () => {
   it("cannot strand the route when a primitive misses its completion callback", () => {
     vi.useFakeTimers();
     const onClosed = vi.fn();
-    const { result } = renderHook(() => useDeferredOverlayClose(onClosed));
+    const { result } = renderHook(() => useDeferredRouteClose(onClosed));
 
     act(() => result.current.requestClose());
     expect(onClosed).not.toHaveBeenCalled();

--- a/apps/web/src/features/threads/thread-detail/use-deferred-route-close.ts
+++ b/apps/web/src/features/threads/thread-detail/use-deferred-route-close.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 const EXIT_COMPLETION_FALLBACK_MS = 650;
 
-export function useDeferredOverlayClose(onClosed: () => void) {
+export function useDeferredRouteClose(onClosed: () => void) {
   const [open, setOpen] = useState(false);
   const closingRef = useRef(false);
   const completedRef = useRef(false);

--- a/apps/web/src/hooks/use-thread-pane-viewport.ts
+++ b/apps/web/src/hooks/use-thread-pane-viewport.ts
@@ -1,0 +1,25 @@
+import { useSyncExternalStore } from "react";
+
+export const THREAD_PANE_BREAKPOINT = 1280;
+
+const mediaQuery =
+  typeof window === "undefined"
+    ? null
+    : window.matchMedia(`(min-width: ${THREAD_PANE_BREAKPOINT}px)`);
+
+function subscribe(onChange: () => void) {
+  mediaQuery?.addEventListener("change", onChange);
+  return () => mediaQuery?.removeEventListener("change", onChange);
+}
+
+function getSnapshot() {
+  return mediaQuery?.matches ?? false;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+export function useThreadPaneViewport() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/apps/web/src/routes/_authenticated/$areaSlug/$threadSlug.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/$threadSlug.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { RouteErrorFallback } from "@/components/error-boundary";
-import { ThreadDetailSheet } from "@/features/threads/thread-detail/thread-detail-sheet";
+import { ThreadDetailView } from "@/features/threads/thread-detail/thread-detail-view";
 
 export const Route = createFileRoute("/_authenticated/$areaSlug/$threadSlug")({
   errorComponent: RouteErrorFallback,
@@ -10,5 +10,5 @@ export const Route = createFileRoute("/_authenticated/$areaSlug/$threadSlug")({
 
 function ThreadRoute() {
   const { areaSlug, threadSlug } = Route.useParams();
-  return <ThreadDetailSheet areaSlug={areaSlug} threadSlug={threadSlug} />;
+  return <ThreadDetailView areaSlug={areaSlug} threadSlug={threadSlug} />;
 }

--- a/apps/web/src/routes/_authenticated/$areaSlug/route.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/route.tsx
@@ -12,9 +12,14 @@ function AreaLayoutRoute() {
   const { areaSlug } = Route.useParams();
 
   return (
-    <>
-      <AreaDetailScreen areaSlug={areaSlug} />
+    <div
+      data-slot="area-thread-workspace"
+      className="flex min-h-[calc(100dvh-7rem)] min-w-0 items-start gap-4"
+    >
+      <div data-slot="area-content" className="min-w-0 flex-1">
+        <AreaDetailScreen areaSlug={areaSlug} />
+      </div>
       <Outlet />
-    </>
+    </div>
   );
 }

--- a/docs/adr/0004-area-thread-detail-layout.md
+++ b/docs/adr/0004-area-thread-detail-layout.md
@@ -1,0 +1,16 @@
+# Area and Thread detail layout
+
+On wide desktop viewports, opening a **Thread** from an **Area** should preserve the Area as context without covering it with a modal surface. Thread detail will use a full-height right rail that pushes the Area content into the remaining workspace. Below 1280px, Thread detail will continue to use the near-full-height bottom Drawer.
+
+## Considered Options
+
+- **Integrated pane below the app header**: keeps the Thread inside the page content region, but feels visually less decisive and depends on the Area route's vertical layout.
+- **Inset card inside the Area page**: clearly separates the Thread, but adds unnecessary framing and makes the working surface feel smaller.
+- **Full-height right rail**: creates a stable, professional workspace boundary and keeps Thread scrolling independent from the Area; selected after comparing all three treatments in the real Area route.
+
+## Consequences
+
+- Desktop Thread detail is a non-modal complementary region rather than a Sheet; the Area stays visible and interactive.
+- The rail reserves matching horizontal space so it pushes rather than covers Area content.
+- The rail width remains responsive between 28rem and 34rem, preserving useful Area width with the desktop sidebar open.
+- Mobile and narrower desktop layouts retain the bottom Drawer and its existing close behavior.


### PR DESCRIPTION
## Summary

- Replace the desktop modal Sheet with a full-height, non-modal right pane that preserves Area context.
- Keep narrower viewports using the near-full-height bottom Drawer.
- Add responsive pane sizing and route-aware close transitions.
- Rename thread detail components and deferred close utilities to reflect their broader responsibilities.
- Add ADR documenting the Area and Thread detail layout decision.

## Testing

- Updated thread detail and deferred route-close tests for Drawer and desktop pane behavior.
- Validated route changes, close animations, responsive rendering, and resolved-thread states.