### PR TITLE
Redesign area detail layout and thread follow-up views

### DIFF
--- a/apps/web/src/features/areas/area-detail/area-detail-screen.tsx
+++ b/apps/web/src/features/areas/area-detail/area-detail-screen.tsx
@@ -31,10 +31,16 @@ export function AreaDetailScreen({ areaSlug }: AreaDetailScreenProps) {
   if (area === null) return <AreaNotFound />;
 
   return (
-    <div className="mx-auto max-w-3xl space-y-8">
-      <AreaHeaderSection areaSlug={areaSlug} onEdit={() => setShowEdit(true)} />
-
-      <AreaStandardCardSection areaSlug={areaSlug} />
+    <div className="mx-auto max-w-4xl space-y-8">
+      <div>
+        <AreaHeaderSection
+          areaSlug={areaSlug}
+          onEdit={() => setShowEdit(true)}
+        />
+        <div className="ml-9 min-h-8 max-w-2xl">
+          <AreaStandardCardSection areaSlug={areaSlug} />
+        </div>
+      </div>
 
       <AreaThreadsSection
         areaSlug={areaSlug}

--- a/apps/web/src/features/areas/components/area-header-section.tsx
+++ b/apps/web/src/features/areas/components/area-header-section.tsx
@@ -3,7 +3,6 @@ import type { AreaIcon } from "@convex/lib/areaIcons";
 
 import { api } from "@convex/_generated/api";
 import { useNavigate } from "@tanstack/react-router";
-import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useMutation } from "convex/react";
 
 import {
@@ -21,10 +20,6 @@ interface AreaHeaderProps {
 
 export function AreaHeaderSection({ areaSlug, onEdit }: AreaHeaderProps) {
   const area = useStableQuery(api.areas.getBySlug, { slug: areaSlug });
-  const threads = useQuery(
-    api.threads.listByArea,
-    area ? { areaId: area._id } : "skip",
-  );
   const navigate = useNavigate();
   const updateArea = useMutation(api.areas.update).withOptimisticUpdate(
     (localStore, args) => {
@@ -58,7 +53,6 @@ export function AreaHeaderSection({ areaSlug, onEdit }: AreaHeaderProps) {
   return (
     <AreaHeader
       area={area}
-      threadCount={threads?.length ?? 0}
       onEdit={onEdit}
       onDelete={handleDelete}
       onConditionChange={handleConditionChange}

--- a/apps/web/src/features/areas/components/area-header.test.tsx
+++ b/apps/web/src/features/areas/components/area-header.test.tsx
@@ -29,17 +29,23 @@ function deferred() {
   return { promise, resolve, reject };
 }
 
-function renderHeader(onIconChange: (icon: AreaIcon) => Promise<void> | void) {
-  return render(
+function renderHeader(
+  onIconChange: (icon: AreaIcon) => Promise<void> | void,
+  actions: { onEdit?: () => void; onDelete?: () => void } = {},
+) {
+  const onEdit = actions.onEdit ?? vi.fn();
+  const onDelete = actions.onDelete ?? vi.fn();
+  const result = render(
     <AreaHeader
       area={area}
-      threadCount={0}
-      onEdit={vi.fn()}
-      onDelete={vi.fn()}
+      onEdit={onEdit}
+      onDelete={onDelete}
       onConditionChange={vi.fn()}
       onIconChange={onIconChange}
     />,
   );
+
+  return { ...result, onEdit, onDelete };
 }
 
 describe("AreaHeader icon picker", () => {
@@ -89,5 +95,34 @@ describe("AreaHeader icon picker", () => {
     expect(
       screen.getByRole("button", { name: "Change Area icon" }),
     ).toBeEnabled();
+  });
+});
+
+describe("AreaHeader actions", () => {
+  it("moves Edit into the Area actions menu", async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    renderHeader(vi.fn(), { onEdit });
+
+    await user.click(screen.getByRole("button", { name: "Area actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Edit" }));
+
+    expect(onEdit).toHaveBeenCalledOnce();
+  });
+
+  it("confirms Delete from the Area actions menu", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    renderHeader(vi.fn(), { onDelete });
+
+    await user.click(screen.getByRole("button", { name: "Area actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Delete" }));
+
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(screen.getByText("Delete area?")).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Delete area" }));
+
+    expect(onDelete).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/features/areas/components/area-header.tsx
+++ b/apps/web/src/features/areas/components/area-header.tsx
@@ -12,9 +12,16 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from "@vita-os/ui/components/alert-dialog";
 import { Button } from "@vita-os/ui/components/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@vita-os/ui/components/dropdown-menu";
 import {
   Popover,
   PopoverContent,
@@ -29,7 +36,7 @@ import {
   SelectValue,
 } from "@vita-os/ui/components/select";
 import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
-import { Pencil, Trash2 } from "lucide-react";
+import { Ellipsis, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { PageHeader } from "@/components/layout/page-header";
@@ -40,7 +47,6 @@ import { AreaIconPicker } from "./area-icon-picker";
 
 interface AreaHeaderProps {
   area: Doc<"areas">;
-  threadCount: number;
   onEdit: () => void;
   onDelete: () => void;
   onConditionChange: (value: Doc<"areas">["condition"]) => void;
@@ -49,13 +55,13 @@ interface AreaHeaderProps {
 
 export function AreaHeader({
   area,
-  threadCount,
   onEdit,
   onDelete,
   onConditionChange,
   onIconChange,
 }: AreaHeaderProps) {
   const [iconPickerOpen, setIconPickerOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const { run: saveIcon, isPending: isSavingIcon } =
     useGuardedAsyncAction(onIconChange);
   const selectedIcon = getAreaIcon(area.icon);
@@ -70,9 +76,15 @@ export function AreaHeader({
     await saveIcon(icon);
   };
 
+  const handleDelete = () => {
+    onDelete();
+    setDeleteOpen(false);
+  };
+
   return (
     <div>
       <PageHeader
+        className="mb-0"
         title={area.name}
         titleLeading={
           <Popover
@@ -102,28 +114,79 @@ export function AreaHeader({
             </PopoverContent>
           </Popover>
         }
+        titleAccessory={
+          <Select
+            items={CONDITION_OPTIONS}
+            value={area.condition}
+            onValueChange={(value) => {
+              if (isCondition(value)) onConditionChange(value);
+            }}
+          >
+            <SelectTrigger
+              className="ml-1 h-7 w-auto gap-2 border-none bg-surface-3/60 px-3 text-xs"
+              aria-label="Area condition"
+            >
+              <span
+                className={cn(
+                  "size-1.5 rounded-full",
+                  CONDITION_OPTIONS.find(
+                    (option) => option.value === area.condition,
+                  )?.color,
+                )}
+              />
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {CONDITION_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    <span className="flex items-center gap-2">
+                      <span
+                        className={cn("h-2 w-2 rounded-full", option.color)}
+                      />
+                      {option.label}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        }
         actions={
           <>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              onClick={onEdit}
-              aria-label="Edit area"
-            >
-              <Pencil className="h-3.5 w-3.5" />
-            </Button>
-            <AlertDialog>
-              <AlertDialogTrigger
+            <DropdownMenu>
+              <DropdownMenuTrigger
                 render={
                   <Button
                     variant="ghost"
                     size="icon-sm"
-                    aria-label="Delete area"
+                    aria-label="Area actions"
                   />
                 }
               >
-                <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
-              </AlertDialogTrigger>
+                <Ellipsis />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuGroup>
+                  <DropdownMenuItem onClick={onEdit}>
+                    <Pencil />
+                    Edit
+                  </DropdownMenuItem>
+                </DropdownMenuGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuGroup>
+                  <DropdownMenuItem
+                    variant="destructive"
+                    onClick={() => setDeleteOpen(true)}
+                  >
+                    <Trash2 />
+                    Delete
+                  </DropdownMenuItem>
+                </DropdownMenuGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
               <AlertDialogContent>
                 <AlertDialogHeader>
                   <AlertDialogTitle>Delete area?</AlertDialogTitle>
@@ -135,10 +198,10 @@ export function AreaHeader({
                 <AlertDialogFooter>
                   <AlertDialogCancel>Cancel</AlertDialogCancel>
                   <AlertDialogAction
-                    onClick={onDelete}
-                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    variant="destructive"
+                    onClick={handleDelete}
                   >
-                    Delete
+                    Delete area
                   </AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>
@@ -146,40 +209,6 @@ export function AreaHeader({
           </>
         }
       />
-
-      <div className="flex items-center gap-3">
-        <Select
-          items={CONDITION_OPTIONS}
-          value={area.condition}
-          onValueChange={(value) => {
-            if (isCondition(value)) onConditionChange(value);
-          }}
-        >
-          <SelectTrigger
-            className="h-7 w-auto gap-2 border-none bg-surface-3/60 px-3 text-xs"
-            aria-label="Area condition"
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectGroup>
-              {CONDITION_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  <span className="flex items-center gap-2">
-                    <span
-                      className={cn("h-2 w-2 rounded-full", option.color)}
-                    />
-                    {option.label}
-                  </span>
-                </SelectItem>
-              ))}
-            </SelectGroup>
-          </SelectContent>
-        </Select>
-        <span className="text-xs text-muted-foreground">
-          {threadCount} {threadCount === 1 ? "thread" : "threads"}
-        </span>
-      </div>
     </div>
   );
 }

--- a/apps/web/src/features/areas/components/area-standard-card.tsx
+++ b/apps/web/src/features/areas/components/area-standard-card.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@vita-os/ui/components/button";
 import { useEffect, useState } from "react";
 
 import { EditableField } from "@/components/ui/editable-field";
@@ -26,38 +27,31 @@ export function AreaStandardCard({ standard, onSave }: AreaStandardCardProps) {
 
   if (!expanded) {
     return (
-      <button
-        type="button"
+      <Button
+        variant="secondary"
+        size="xs"
+        className="mt-1"
         onClick={() => {
           setExpanded(true);
           setStartEditing(true);
         }}
-        className="text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
-        Add standard
-      </button>
+        Add a Standard…
+      </Button>
     );
   }
 
   return (
-    <div className="space-y-1.5">
-      <h2 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-        Standard
-        <span className="ml-1 font-normal normal-case tracking-normal text-muted-foreground/70">
-          (optional)
-        </span>
-      </h2>
-      <EditableField
-        value={standard}
-        onSave={handleSave}
-        variant="textarea"
-        startEditing={startEditing}
-        placeholder="What does 'good enough' look like for this area?"
-        className="text-sm leading-relaxed"
-      />
-      <p className="mt-2 text-xs text-muted-foreground">
-        The maintenance threshold, not an aspirational goal.
-      </p>
-    </div>
+    <EditableField
+      value={standard}
+      onSave={handleSave}
+      variant="textarea"
+      startEditing={startEditing}
+      placeholder="What does 'good enough' look like for this Area?"
+      className="text-sm leading-relaxed"
+      displayClassName="text-muted-foreground"
+      textareaRows={2}
+      inputAriaLabel="Area Standard"
+    />
   );
 }

--- a/apps/web/src/features/areas/components/area-threads.test.tsx
+++ b/apps/web/src/features/areas/components/area-threads.test.tsx
@@ -10,6 +10,7 @@ vi.mock("@tanstack/react-router", () => ({
   Link: ({ children, to }: { children: ReactNode; to: string }) => (
     <a href={to}>{children}</a>
   ),
+  useLocation: () => ({ pathname: "/admin" }),
 }));
 
 const today = new Date(2026, 4, 20, 12).getTime();
@@ -36,11 +37,14 @@ function thread(
 }
 
 describe("AreaThreads", () => {
-  it("lists threads under the area with Thread language", () => {
+  it("separates scheduled and undated Threads", () => {
     render(
       <AreaThreads
         areaSlug="admin"
-        threads={[thread("renew-passport", "Renew passport")]}
+        threads={[
+          thread("call-clinic", "Call clinic", { followUp: tomorrow }),
+          thread("renew-passport", "Renew passport"),
+        ]}
         currentDate={today}
         onCreateThread={vi.fn()}
         onRemoveThread={vi.fn()}
@@ -48,11 +52,15 @@ describe("AreaThreads", () => {
     );
 
     expect(
-      screen.getByRole("heading", { name: "Threads" }),
+      screen.getByRole("heading", { name: "Follow-up schedule" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "New thread" }),
+      screen.getByRole("heading", { name: "No Follow-up" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "New Thread" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Call clinic")).toBeInTheDocument();
     expect(screen.getByText("Renew passport")).toBeInTheDocument();
   });
 
@@ -70,11 +78,11 @@ describe("AreaThreads", () => {
 
     expect(screen.getByTestId("area-threads-skeleton")).toBeVisible();
     expect(
-      screen.queryByText("No threads in this area yet."),
+      screen.queryByText("No Follow-ups scheduled in this Area."),
     ).not.toBeInTheDocument();
   });
 
-  it("shows an empty state that invites creating a thread", () => {
+  it("shows empty states for both schedule sections", () => {
     render(
       <AreaThreads
         areaSlug="admin"
@@ -86,14 +94,14 @@ describe("AreaThreads", () => {
     );
 
     expect(
-      screen.getByText("No threads in this area yet."),
+      screen.getByText("No Follow-ups scheduled in this Area."),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Create thread" }),
+      screen.getByText("Every open Thread has a Follow-up."),
     ).toBeInTheDocument();
   });
 
-  it("marks Threads with a due Follow-up and shows the date for scheduled ones", () => {
+  it("shows each scheduled date once and a Next Move line on every Thread", () => {
     render(
       <AreaThreads
         areaSlug="admin"
@@ -108,9 +116,10 @@ describe("AreaThreads", () => {
       />,
     );
 
-    expect(screen.getByText("Follow-up due")).toBeVisible();
-    expect(screen.getByText("May 21")).toBeVisible();
-    // Ready/open Threads carry no attention badge on the Area page.
-    expect(screen.getAllByText(/follow-up due|may 21/i)).toHaveLength(2);
+    expect(screen.getAllByText("May")).toHaveLength(2);
+    expect(screen.getByText("19")).toBeVisible();
+    expect(screen.getByText("21")).toBeVisible();
+    expect(screen.getByText("Scan them")).toBeVisible();
+    expect(screen.getAllByText("No next move")).toHaveLength(2);
   });
 });

--- a/apps/web/src/features/areas/components/area-threads.tsx
+++ b/apps/web/src/features/areas/components/area-threads.tsx
@@ -1,6 +1,7 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
+import type { LucideIcon } from "lucide-react";
 
-import { Link } from "@tanstack/react-router";
+import { Link, useLocation } from "@tanstack/react-router";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -12,23 +13,19 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@vita-os/ui/components/alert-dialog";
-import { Badge } from "@vita-os/ui/components/badge";
 import { Button } from "@vita-os/ui/components/button";
 import { cn } from "@vita-os/ui/lib/utils";
 import { format } from "date-fns";
 import {
   ArrowRight,
-  CalendarClock,
+  CalendarDays,
   FolderOpen,
   Plus,
   Trash2,
 } from "lucide-react";
 
-import { getThreadStatus } from "@/features/threads/derived-status";
-import {
-  flatListClassName,
-  flatListRowHoverClassName,
-} from "@/lib/flat-surface";
+import { compareThreadsByStatusUrgency } from "@/features/threads/derived-status";
+import { flatListClassName } from "@/lib/flat-surface";
 
 import { AreaThreadsSkeleton } from "./area-threads-skeleton";
 
@@ -49,176 +46,235 @@ export function AreaThreads({
   onCreateThread,
   onRemoveThread,
 }: AreaThreadsProps) {
+  const { pathname } = useLocation();
+  const isThreadOpen = pathname !== `/${areaSlug}`;
+  const scheduled = threads
+    .filter((thread) => thread.followUp != null)
+    .sort((a, b) => (a.followUp ?? 0) - (b.followUp ?? 0));
+  const undated = [...threads]
+    .filter((thread) => thread.followUp == null)
+    .sort((a, b) => compareThreadsByStatusUrgency(a, b, currentDate));
+
   return (
     <section>
-      <div className="mb-4 flex items-center justify-between">
-        <div className="flex items-center gap-2.5">
-          <div className="flex h-6 w-6 items-center justify-center rounded-md bg-surface-3">
-            <FolderOpen className="h-3.5 w-3.5 text-muted-foreground" />
-          </div>
-          <h2 className="text-sm font-medium">Threads</h2>
-        </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 gap-1.5 text-xs text-muted-foreground"
-          onClick={onCreateThread}
-        >
-          <Plus className="h-3.5 w-3.5" />
-          New thread
-        </Button>
-      </div>
-
-      {isLoading ? (
-        <AreaThreadsSkeleton />
-      ) : threads.length === 0 ? (
-        <div className="flex flex-col items-center gap-3 py-12 text-center">
-          <div className="flex h-9 w-9 items-center justify-center rounded-full bg-surface-3">
-            <FolderOpen className="h-4 w-4 text-muted-foreground" />
-          </div>
-          <p className="text-sm text-muted-foreground">
-            No threads in this area yet.
-          </p>
+      <SectionHeading
+        icon={CalendarDays}
+        title="Follow-up schedule"
+        count={scheduled.length}
+        action={
           <Button
             variant="ghost"
             size="sm"
+            className="h-7 gap-1.5 text-xs text-muted-foreground"
             onClick={onCreateThread}
-            className="gap-1.5 text-xs font-normal text-muted-foreground hover:text-foreground"
           >
-            <Plus className="h-3.5 w-3.5" />
-            Create thread
+            <Plus className="size-3.5" />
+            New Thread
           </Button>
+        }
+      />
+
+      {isLoading ? (
+        <div className="mt-3">
+          <AreaThreadsSkeleton />
         </div>
+      ) : scheduled.length === 0 ? (
+        <p className="mt-3 py-6 text-sm text-muted-foreground">
+          No Follow-ups scheduled in this Area.
+        </p>
       ) : (
-        <div className={flatListClassName}>
-          {threads.map((thread) => (
-            <AreaThreadRow
+        <div className="mt-3 divide-y divide-border/60 border-y border-border/70">
+          {scheduled.map((thread) => (
+            <ScheduledThreadRow
               key={thread._id}
               areaSlug={areaSlug}
               thread={thread}
-              currentDate={currentDate}
+              compact={isThreadOpen}
               onRemoveThread={onRemoveThread}
             />
           ))}
         </div>
       )}
+
+      <section className="mt-8">
+        <SectionHeading
+          icon={FolderOpen}
+          title="No Follow-up"
+          count={undated.length}
+        />
+        {!isLoading && undated.length === 0 ? (
+          <p className="mt-3 py-4 text-sm text-muted-foreground">
+            Every open Thread has a Follow-up.
+          </p>
+        ) : (
+          !isLoading && (
+            <div className={cn("mt-3", flatListClassName)}>
+              {undated.map((thread) => (
+                <UndatedThreadRow
+                  key={thread._id}
+                  areaSlug={areaSlug}
+                  thread={thread}
+                  onRemoveThread={onRemoveThread}
+                />
+              ))}
+            </div>
+          )
+        )}
+      </section>
     </section>
   );
 }
 
-function AreaThreadRow({
-  areaSlug,
-  thread,
-  currentDate,
-  onRemoveThread,
+function SectionHeading({
+  icon: Icon,
+  title,
+  count,
+  action,
 }: {
-  areaSlug: string;
-  thread: Doc<"threads">;
-  currentDate: number;
-  onRemoveThread: (threadId: Id<"threads">) => void;
+  icon: LucideIcon;
+  title: string;
+  count: number;
+  action?: React.ReactNode;
 }) {
-  const slug = thread.slug ?? thread._id;
-
   return (
-    <div className="group flex items-center">
-      <Link
-        to="/$areaSlug/$threadSlug"
-        params={{ areaSlug, threadSlug: slug }}
-        className={cn(
-          "flex min-w-0 flex-1 items-start gap-4 py-4",
-          flatListRowHoverClassName,
-        )}
-      >
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <p className="truncate text-sm font-medium">{thread.title}</p>
-            <AreaThreadAttentionBadge
-              thread={thread}
-              currentDate={currentDate}
-            />
-          </div>
-          <AreaThreadSubtitle thread={thread} />
-        </div>
-      </Link>
-      <AlertDialog>
-        <AlertDialogTrigger
-          render={
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="mr-2 opacity-0 transition-opacity group-hover:opacity-100"
-              aria-label="Delete thread"
-            />
-          }
-        >
-          <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
-        </AlertDialogTrigger>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete thread?</AlertDialogTitle>
-            <AlertDialogDescription>
-              &ldquo;{thread.title}&rdquo; will be permanently removed.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => onRemoveThread(thread._id)}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex items-center gap-2">
+        <Icon className="size-3.5 text-muted-foreground" />
+        <h2 className="text-sm font-semibold">{title}</h2>
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {count}
+        </span>
+      </div>
+      {action}
     </div>
   );
 }
 
-function AreaThreadAttentionBadge({
+function ScheduledThreadRow({
+  areaSlug,
   thread,
-  currentDate,
+  compact,
+  onRemoveThread,
 }: {
+  areaSlug: string;
   thread: Doc<"threads">;
-  currentDate: number;
+  compact: boolean;
+  onRemoveThread: (threadId: Id<"threads">) => void;
 }) {
-  const status = getThreadStatus(thread, currentDate);
+  const followUp = thread.followUp;
+  if (!followUp) return null;
 
-  if (status === "follow_up_due") {
-    return (
-      <Badge
-        variant="outline"
-        className="shrink-0 gap-1 border-amber-500/40 text-[10px] text-amber-600 dark:text-amber-400"
+  return (
+    <div className="group flex items-center rounded-md transition-colors hover:bg-muted/50">
+      <Link
+        to="/$areaSlug/$threadSlug"
+        params={{ areaSlug, threadSlug: thread.slug ?? thread._id }}
+        className={cn(
+          "grid min-w-0 flex-1 items-center gap-4 px-2 py-3",
+          compact
+            ? "grid-cols-[3.5rem_minmax(0,1fr)]"
+            : "grid-cols-[5rem_minmax(0,1fr)]",
+        )}
       >
-        <CalendarClock className="h-3 w-3" />
-        Follow-up due
-      </Badge>
-    );
-  }
-
-  if (status === "scheduled" && thread.followUp != null) {
-    return (
-      <span className="flex shrink-0 items-center gap-1 text-[10px] text-muted-foreground">
-        <CalendarClock className="h-3 w-3" />
-        {format(new Date(thread.followUp), "MMM d")}
-      </span>
-    );
-  }
-
-  return null;
+        <time
+          dateTime={new Date(followUp).toISOString()}
+          className="flex flex-col text-muted-foreground"
+        >
+          <span className="text-[10px] font-medium uppercase tracking-wider">
+            {format(new Date(followUp), "MMM")}
+          </span>
+          <span className="text-lg font-semibold leading-none text-foreground">
+            {format(new Date(followUp), "d")}
+          </span>
+        </time>
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-medium">{thread.title}</h3>
+          <ThreadNextMove thread={thread} />
+        </div>
+      </Link>
+      <ThreadDeleteAction thread={thread} onRemoveThread={onRemoveThread} />
+    </div>
+  );
 }
 
-function AreaThreadSubtitle({ thread }: { thread: Doc<"threads"> }) {
-  const nextAction = thread.nextMove;
+function UndatedThreadRow({
+  areaSlug,
+  thread,
+  onRemoveThread,
+}: {
+  areaSlug: string;
+  thread: Doc<"threads">;
+  onRemoveThread: (threadId: Id<"threads">) => void;
+}) {
+  return (
+    <div className="group flex items-center rounded-md transition-colors hover:bg-muted/50">
+      <Link
+        to="/$areaSlug/$threadSlug"
+        params={{ areaSlug, threadSlug: thread.slug ?? thread._id }}
+        className="min-w-0 flex-1 px-2 py-3"
+      >
+        <h3 className="truncate text-sm font-medium">{thread.title}</h3>
+        <ThreadNextMove thread={thread} />
+      </Link>
+      <ThreadDeleteAction thread={thread} onRemoveThread={onRemoveThread} />
+    </div>
+  );
+}
 
-  if (nextAction) {
-    return (
-      <p className="mt-1 flex items-center gap-1.5 truncate text-xs text-muted-foreground">
-        <ArrowRight className="h-3 w-3 shrink-0" />
-        {nextAction}
-      </p>
-    );
-  }
+function ThreadNextMove({ thread }: { thread: Doc<"threads"> }) {
+  const nextMove = thread.nextMove?.trim();
 
-  return null;
+  return (
+    <p
+      className={cn(
+        "mt-1 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground",
+        !nextMove && "text-muted-foreground/60",
+      )}
+    >
+      <ArrowRight className="size-3 shrink-0" />
+      <span className="truncate">{nextMove || "No next move"}</span>
+    </p>
+  );
+}
+
+function ThreadDeleteAction({
+  thread,
+  onRemoveThread,
+}: {
+  thread: Doc<"threads">;
+  onRemoveThread: (threadId: Id<"threads">) => void;
+}) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="mr-2 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+            aria-label="Delete thread"
+          />
+        }
+      >
+        <Trash2 className="size-3.5 text-muted-foreground" />
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete thread?</AlertDialogTitle>
+          <AlertDialogDescription>
+            &ldquo;{thread.title}&rdquo; will be permanently removed.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => onRemoveThread(thread._id)}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
 }


### PR DESCRIPTION
## Summary

- Rework the area header with inline condition controls and an actions menu for editing and deleting.
- Redesign the area standard section with a compact editable field and add-standard button.
- Split area threads into scheduled and undated follow-up sections with dates, next-move details, sorting, and updated empty states.
- Update component tests for the new actions and thread organization.

## Testing

- Updated area header and thread component tests for the redesigned interactions and states.
- Not run (not requested)