### PR TITLE
Redesign the inbox with date-based task sections

### DIFF
--- a/apps/web/src/features/inbox/components/inbox-task-list.tsx
+++ b/apps/web/src/features/inbox/components/inbox-task-list.tsx
@@ -1,11 +1,21 @@
 import type { Doc } from "@convex/_generated/dataModel";
+import type { LucideIcon } from "lucide-react";
 
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@vita-os/ui/components/collapsible";
-import { ChevronRight, Inbox } from "lucide-react";
+import { cn } from "@vita-os/ui/lib/utils";
+import { format, isBefore, isToday, startOfDay } from "date-fns";
+import {
+  CalendarClock,
+  CheckCircle2,
+  ChevronRight,
+  CircleDot,
+  Clock3,
+  Inbox,
+} from "lucide-react";
 
 import { TaskRow } from "@/features/tasks/task-row/task-row";
 import { useTaskRowActions } from "@/features/tasks/task-row/use-task-row-actions";
@@ -17,48 +27,169 @@ interface InboxTaskListProps {
 }
 
 export function InboxTaskList({ tasks, onProcess }: InboxTaskListProps) {
-  if (tasks.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <Inbox className="mb-3 h-8 w-8 text-muted-foreground" />
-        <p className="text-sm text-muted-foreground">
-          Inbox zero — nothing to process
-        </p>
-      </div>
-    );
-  }
-
-  const openTasks = tasks.filter((task) => task.state === "open");
-  const doneTasks = tasks.filter((task) => task.state === "done");
+  const open = tasks.filter((task) => task.state === "open");
+  const done = tasks.filter((task) => task.state === "done");
+  const today = startOfDay(new Date());
+  const overdue = open.filter(
+    (task) => task.when !== undefined && isBefore(task.when, today),
+  );
+  const dueToday = open.filter(
+    (task) => task.when !== undefined && isToday(task.when),
+  );
+  const upcoming = open.filter(
+    (task) =>
+      task.when !== undefined &&
+      !isBefore(task.when, today) &&
+      !isToday(task.when),
+  );
+  const unscheduled = open.filter((task) => task.when === undefined);
 
   return (
-    <div className="space-y-1">
-      {openTasks.length > 0 && (
-        <div className={flatListClassName}>
-          {openTasks.map((task) => (
-            <InboxTaskRow key={task._id} task={task} onProcess={onProcess} />
-          ))}
+    <div className="mx-auto max-w-4xl pt-2 pb-16">
+      <header className="mb-8 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="font-heading text-2xl font-semibold tracking-tight">
+              Inbox schedule
+            </h1>
+            <span className="ml-1 rounded-full bg-surface-3 px-2 py-0.5 text-xs font-medium tabular-nums text-muted-foreground">
+              {open.length}
+            </span>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Captures arranged by when they need your attention.
+          </p>
+        </div>
+        <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          {format(new Date(), "EEEE, MMMM d")}
+        </p>
+      </header>
+
+      {open.length === 0 ? (
+        <InboxZero />
+      ) : (
+        <div className="space-y-8">
+          <TaskSection
+            icon={Clock3}
+            title="Past due"
+            tasks={overdue}
+            onProcess={onProcess}
+            tone="attention"
+          />
+          <TaskSection
+            icon={CircleDot}
+            title="Today"
+            tasks={dueToday}
+            onProcess={onProcess}
+          />
+          <TaskSection
+            icon={CalendarClock}
+            title="Coming up"
+            tasks={upcoming}
+            onProcess={onProcess}
+          />
+          <TaskSection
+            icon={Inbox}
+            title="No date"
+            tasks={unscheduled}
+            onProcess={onProcess}
+          />
+          <DoneTasks tasks={done} />
         </div>
       )}
+    </div>
+  );
+}
 
-      {doneTasks.length > 0 && (
-        <Collapsible className={openTasks.length > 0 ? "pt-3" : undefined}>
-          <CollapsibleTrigger className="group flex w-full items-center gap-2 rounded-lg px-1 py-2 text-left text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
-            <ChevronRight className="h-4 w-4 transition-transform group-data-[state=open]:rotate-90" />
-            <span>Done</span>
-            <span className="ml-auto text-xs tabular-nums">
-              {doneTasks.length}
-            </span>
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <div className={flatListClassName}>
-              {doneTasks.map((task) => (
-                <InboxTaskRow key={task._id} task={task} />
-              ))}
-            </div>
-          </CollapsibleContent>
-        </Collapsible>
-      )}
+function TaskSection({
+  icon,
+  title,
+  tasks,
+  onProcess,
+  tone,
+}: {
+  icon: LucideIcon;
+  title: string;
+  tasks: Doc<"tasks">[];
+  onProcess?: (task: Doc<"tasks">) => void;
+  tone?: "attention";
+}) {
+  if (tasks.length === 0) return null;
+
+  return (
+    <section>
+      <SectionHeading
+        icon={icon}
+        title={title}
+        count={tasks.length}
+        tone={tone}
+      />
+      <div className={cn("mt-3", flatListClassName)}>
+        {tasks.map((task) => (
+          <InboxTaskRow key={task._id} task={task} onProcess={onProcess} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function DoneTasks({ tasks }: { tasks: Doc<"tasks">[] }) {
+  if (tasks.length === 0) return null;
+
+  return (
+    <Collapsible className="mt-8">
+      <CollapsibleTrigger className="group flex w-full items-center gap-2 rounded-md py-2 text-left text-sm font-medium text-muted-foreground transition-colors hover:text-foreground">
+        <ChevronRight className="size-4 transition-transform group-data-[state=open]:rotate-90" />
+        <CheckCircle2 className="size-3.5" />
+        <span>Completed</span>
+        <span className="ml-auto text-xs tabular-nums">{tasks.length}</span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className={flatListClassName}>
+          {tasks.map((task) => (
+            <InboxTaskRow key={task._id} task={task} />
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function SectionHeading({
+  icon: Icon,
+  title,
+  count,
+  tone,
+}: {
+  icon: LucideIcon;
+  title: string;
+  count: number;
+  tone?: "attention";
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <Icon
+        className={cn(
+          "size-3.5 text-muted-foreground",
+          tone === "attention" && "text-condition-attention",
+        )}
+      />
+      <h2 className="text-sm font-semibold">{title}</h2>
+      <span className="text-xs tabular-nums text-muted-foreground">
+        {count}
+      </span>
+    </div>
+  );
+}
+
+function InboxZero() {
+  return (
+    <div className="flex min-h-64 flex-col items-center justify-center rounded-xl border border-dashed px-6 text-center">
+      <CheckCircle2 className="mb-3 size-7 text-muted-foreground" />
+      <h2 className="text-sm font-semibold">Inbox zero</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Nothing is waiting for a decision.
+      </p>
     </div>
   );
 }

--- a/apps/web/src/features/inbox/screens/inbox-screen.tsx
+++ b/apps/web/src/features/inbox/screens/inbox-screen.tsx
@@ -5,7 +5,6 @@ import { Skeleton } from "@vita-os/ui/components/skeleton";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useState } from "react";
 
-import { PageHeader } from "@/components/layout/page-header";
 import { InboxTaskList } from "@/features/inbox/components/inbox-task-list";
 import { ProcessTaskDialogContainer } from "@/features/tasks/process-task/process-task-dialog-container";
 
@@ -20,8 +19,7 @@ export function InboxScreen() {
   }
 
   return (
-    <div className="mx-auto max-w-3xl">
-      <PageHeader title="Inbox" />
+    <>
       <InboxTaskList tasks={tasks} onProcess={setProcessingTask} />
 
       {processingTask && (
@@ -33,7 +31,7 @@ export function InboxScreen() {
           task={processingTask}
         />
       )}
-    </div>
+    </>
   );
 }
 

--- a/apps/web/src/features/tasks/task-row/task-row.tsx
+++ b/apps/web/src/features/tasks/task-row/task-row.tsx
@@ -18,7 +18,6 @@ import {
   Item,
   ItemActions,
   ItemContent,
-  ItemDescription,
   ItemMedia,
 } from "@vita-os/ui/components/item";
 import {
@@ -98,7 +97,7 @@ export function TaskRow({
         />
       </ItemMedia>
       <ItemContent className="min-w-0 gap-1">
-        <div className="flex min-w-0 flex-1 items-start gap-1">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
           <EditableField
             value={task.text}
             onSave={(text) => {
@@ -115,59 +114,12 @@ export function TaskRow({
                 "text-muted-foreground/60 line-through decoration-muted-foreground/30",
             )}
           />
-          <ItemActions className="shrink-0 opacity-0 transition-opacity group-hover/item:opacity-100 group-focus-within/item:opacity-100 gap-1">
-            {onProcess && !isDone && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-6"
-                onClick={onProcess}
-                aria-label="Process task"
-              >
-                <ArrowRight className="size-4 text-muted-foreground" />
-              </Button>
-            )}
-            <AlertDialog>
-              <AlertDialogTrigger
-                render={
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="size-6"
-                    aria-label="Discard task"
-                  >
-                    <Trash2 className="size-4 text-muted-foreground" />
-                  </Button>
-                }
-              />
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Discard task?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This task will be permanently removed from your Inbox. This
-                    action cannot be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={() => {
-                      if (!isDiscardPending) {
-                        void onRemove();
-                      }
-                    }}
-                    disabled={isDiscardPending}
-                    aria-busy={isDiscardPending}
-                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                  >
-                    Discard
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          </ItemActions>
+          <span className="shrink-0 pt-1 text-xs tabular-nums text-muted-foreground/50">
+            {timestamp}
+          </span>
         </div>
-        <ItemDescription className="flex w-full items-center justify-between gap-2 text-xs text-muted-foreground">
+
+        <div className="flex min-h-6 w-full items-center gap-2 text-xs text-muted-foreground">
           <Popover open={isWhenOpen} onOpenChange={setIsWhenOpen}>
             <PopoverTrigger
               render={
@@ -224,10 +176,59 @@ export function TaskRow({
               )}
             </PopoverContent>
           </Popover>
-          <span className="ml-auto shrink-0 tabular-nums text-muted-foreground/50">
-            {timestamp}
-          </span>
-        </ItemDescription>
+
+          <ItemActions className="ml-auto shrink-0 gap-1 opacity-0 transition-opacity group-hover/item:opacity-100 group-focus-within/item:opacity-100">
+            {onProcess && !isDone && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-6"
+                onClick={onProcess}
+                aria-label="Process task"
+              >
+                <ArrowRight className="size-4 text-muted-foreground" />
+              </Button>
+            )}
+            <AlertDialog>
+              <AlertDialogTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-6"
+                    aria-label="Discard task"
+                  >
+                    <Trash2 className="size-4 text-muted-foreground" />
+                  </Button>
+                }
+              />
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Discard task?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This task will be permanently removed from your Inbox. This
+                    action cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => {
+                      if (!isDiscardPending) {
+                        void onRemove();
+                      }
+                    }}
+                    disabled={isDiscardPending}
+                    aria-busy={isDiscardPending}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    Discard
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </ItemActions>
+        </div>
       </ItemContent>
     </Item>
   );


### PR DESCRIPTION
## Summary

- Organize inbox tasks into past due, today, coming up, and no-date sections.
- Add an inbox-zero empty state and collapsible completed tasks.
- Refresh task-row layout with clearer timestamps and repositioned actions.

## Testing

- Not run (not requested)