### PR TITLE
Remove dependency overrides

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -80,10 +80,6 @@
       },
     },
   },
-  "overrides": {
-    "date-fns": "4.2.1",
-    "vite": "8.0.13",
-  },
   "catalog": {
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,6 @@
     "oxlint": "1.66.0",
     "turbo": "^2.9.12"
   },
-  "overrides": {
-    "date-fns": "4.2.1",
-    "vite": "8.0.13"
-  },
   "packageManager": "bun@1.3.14",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

- Remove the `date-fns` and `vite` dependency overrides from the root package configuration.
- Update `bun.lock` to match the simplified dependency configuration.

## Testing

- Not run (not requested).

Closes #232