### PR TITLE
Symlink CLAUDE.md to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Adds `CLAUDE.md` as a symlink to `AGENTS.md` so Claude Code picks up the project instructions in every checkout — fresh clones, git worktrees, and cloud review environments — without duplicating content. This is the approach recommended by the Claude Code docs (Claude Code reads `CLAUDE.md`, not `AGENTS.md`, and follows symlinks).

## Notes

- Git stores the symlink as a blob containing the target path; no content is duplicated.
- If a Windows environment without symlink support ever enters the picture, the fallback is a real `CLAUDE.md` containing `@AGENTS.md` (the docs' import syntax).