### PR TITLE
chore(worktrees): set up isolated worktree environment

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "worktree": {
+    "symlinkDirectories": [
+      "node_modules",
+      "apps/web/node_modules",
+      "packages/ui/node_modules"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ dist-ssr
 # Turborepo
 .turbo
 .codex
+
+# Claude Code
+.claude/worktrees/
+.claude/settings.local.json

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+# Gitignored files copied into every worktree Claude Code creates.
+# Uses .gitignore syntax; only files that match AND are gitignored are copied.
+apps/web/.env.local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,18 @@ Use conventional commits for all commits with the type and scope.
 git commit -m "<type>(<scope>): <description>"
 ```
 
+## Parallel work in worktrees
+
+Sessions and subagents can run in isolated git worktrees under `.claude/worktrees/`. Setup is already committed:
+
+- `.worktreeinclude` copies `apps/web/.env.local` into every new worktree.
+- `.claude/settings.json` symlinks the `node_modules` directories back to the main checkout, so no `bun install` is needed per worktree.
+
+Two rules when splitting work across worktrees:
+
+- **Serialize Convex changes.** There is a single Convex deployment. Never run two agents that both touch `apps/web/convex/schema.ts` or push functions — they overwrite each other's deployment. Parallelize UI and client-side logic only.
+- **One dependency change at a time.** `node_modules` is symlinked and therefore shared across worktrees, so a `bun add` in one worktree mutates all of them. Keep dependency changes to a single agent per batch.
+
 ## Agent skills
 
 ### Issue tracker


### PR DESCRIPTION
## Summary

- Add `.worktreeinclude` so `apps/web/.env.local` is copied into every worktree Claude Code creates — worktrees are fresh checkouts and don't get gitignored files.
- Add `.claude/settings.json` with `worktree.symlinkDirectories` linking the three `node_modules` directories back to the main checkout, instead of duplicating 1.6G and running `bun install` per worktree.
- Gitignore `.claude/worktrees/` (recommended by the Claude Code docs, otherwise worktrees show as untracked in the main checkout) and `.claude/settings.local.json` (personal permission allowlist).
- Document in `AGENTS.md` the two constraints no setting can enforce: Convex changes must be serialized (single deployment), and dependency changes can't be parallelized (shared `node_modules`).

## Test plan

- [x] `claude -p --worktree wt-smoketest` creates a worktree where `apps/web/.env.local` is present as a real file
- [x] All three `node_modules` paths resolve as symlinks to the main checkout inside that worktree
- [x] New worktree lands on branch `worktree-<name>` and produces no untracked noise in the main checkout's `git status`
- [x] `bun run lint:check` passes (255 files, formatting clean)
- [x] Reviewer: confirm `.claude/settings.local.json` stays untracked after pulling this branch