### PR TITLE
docs(context): move date-rail visual description into ADR 0005 reference

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -97,7 +97,7 @@ _Avoid_: Task list, project board, backlog.
 
 ## Thread Attention
 
-- **Open Threads** across the **Dashboard Overview** and **Area** inventory share one flat attention-ordered list with no visible group headings. Attention groups survive as ordering only; a per-row state signal on each row's date rail replaces the headings. The rail's visual states are recorded in ADR 0005.
+- **Open Threads** across the **Dashboard Overview** and **Area** inventory share one flat attention-ordered list with no visible group headings. Attention groups survive as ordering only; a state signal on each row's date rail replaces the headings. The rail's visual states are recorded in ADR 0005.
 - The flat order is **Overdue Follow-ups**, **Upcoming Follow-ups**, **Threads with Next Moves**, then plain **Open Threads**. On the **Dashboard**, dated upcoming **Follow-ups** come before undated **Threads with Next Moves**.
 - **Overdue Follow-ups** have a **Follow-up** before today. **Upcoming Follow-ups** have a **Follow-up** today or later.
 - A **Follow-up** takes precedence when a **Thread** also has a **Next Move**.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -97,7 +97,7 @@ _Avoid_: Task list, project board, backlog.
 
 ## Thread Attention
 
-- **Open Threads** across the **Dashboard Overview** and **Area** inventory share one flat attention-ordered list with no visible group headings. A stateful date rail on each row carries the attention signal: tinted for overdue, filled for due today, plain for scheduled later, dashed ring for unscheduled.
+- **Open Threads** across the **Dashboard Overview** and **Area** inventory share one flat attention-ordered list with no visible group headings. Attention groups survive as ordering only; a per-row state signal on each row's date rail replaces the headings. The rail's visual states are recorded in ADR 0005.
 - The flat order is **Overdue Follow-ups**, **Upcoming Follow-ups**, **Threads with Next Moves**, then plain **Open Threads**. On the **Dashboard**, dated upcoming **Follow-ups** come before undated **Threads with Next Moves**.
 - **Overdue Follow-ups** have a **Follow-up** before today. **Upcoming Follow-ups** have a **Follow-up** today or later.
 - A **Follow-up** takes precedence when a **Thread** also has a **Next Move**.


### PR DESCRIPTION
Closes #238

CONTEXT.md's Thread Attention bullet described the date rail's visual treatments (tinted, filled, plain, dashed ring) — presentation detail in a ubiquitous-language document. This rewrites the bullet to state only the domain rule: attention groups survive as ordering, with a per-row state signal on the date rail replacing visible headings, pointing to ADR 0005 for the visual states.

ADR 0005 already fully lists the rail's four states, so no ADR change was needed.

## Acceptance criteria
- [x] CONTEXT.md contains no visual-treatment vocabulary (verified: no tint/filled/dashed matches) while still conveying ordering + per-row signal
- [x] ADR 0005 fully describes the rail states (already did, in the Stateful date rail option)