### PR TITLE
feat(dashboard): cap plain Open Threads behind a Show all control

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -103,6 +103,7 @@ _Avoid_: Task list, project board, backlog.
 - A **Follow-up** takes precedence when a **Thread** also has a **Next Move**.
 - **Threads with Next Moves** have a **Next Move** and no **Follow-up**.
 - Plain **Open Threads** have neither field and appear inline at the end of the flat run.
+- The **Dashboard Overview** shows at most five plain **Open Threads** inline; the rest sit behind a **Show all** control that extends the same flat run in place. Attention-bearing **Threads** are never capped, and the **Area** inventory always lists every **Thread**.
 - **Follow-ups** are ordered oldest-first when overdue and soonest-first when upcoming. The user's **Thread** order breaks ties and orders undated attention groups.
 - An **Open Thread** with no **Next Move** and no **Follow-up** is valid; it is not automatically overdue, stale, or broken.
 - Opening or reviewing a **Thread** does not clear its **Follow-up**; the user must clear, reschedule, or resolve it explicitly.

--- a/apps/web/src/features/dashboard/components/dashboard-overview.test.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-overview.test.tsx
@@ -182,6 +182,71 @@ describe("DashboardOverview", () => {
     );
   });
 
+  it("caps plain Open Threads behind a Show all control", async () => {
+    const user = userEvent.setup();
+    render(
+      <DashboardOverview
+        overview={dashboard({
+          threads: [
+            thread("Overdue thread", {
+              followUp: new Date(2026, 6, 16).getTime(),
+            }),
+            thread("Next Move thread", { nextMove: "Make the call" }),
+            ...Array.from({ length: 7 }, (_, index) =>
+              thread(`Open ${index + 1}`),
+            ),
+          ],
+        })}
+        currentDate={currentDate}
+        onCreateArea={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Overdue thread")).toBeVisible();
+    expect(screen.getByText("Next Move thread")).toBeVisible();
+    expect(screen.getByText("Open 5")).toBeVisible();
+    expect(screen.queryByText("Open 6")).toBeNull();
+
+    const showAll = screen.getByRole("button", { name: /show all/i });
+    expect(showAll).toHaveTextContent("2 more");
+
+    await user.click(showAll);
+
+    expect(screen.getByText("Open 6")).toBeVisible();
+    expect(screen.getByText("Open 7")).toBeVisible();
+    expect(screen.queryByRole("button", { name: /show all/i })).toBeNull();
+    expect(
+      screen
+        .getByText("Open 5")
+        .compareDocumentPosition(screen.getByText("Open 6")),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("never caps attention-bearing Threads and skips the control at the cap", () => {
+    render(
+      <DashboardOverview
+        overview={dashboard({
+          threads: [
+            ...Array.from({ length: 7 }, (_, index) =>
+              thread(`Overdue ${index + 1}`, {
+                followUp: new Date(2026, 6, 16).getTime(),
+              }),
+            ),
+            ...Array.from({ length: 5 }, (_, index) =>
+              thread(`Open ${index + 1}`),
+            ),
+          ],
+        })}
+        currentDate={currentDate}
+        onCreateArea={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Overdue 7")).toBeVisible();
+    expect(screen.getByText("Open 5")).toBeVisible();
+    expect(screen.queryByRole("button", { name: /show all/i })).toBeNull();
+  });
+
   it("handles Inbox clear, remaining Tasks, and optional Recent activity", () => {
     const { rerender } = render(
       <DashboardOverview

--- a/apps/web/src/features/dashboard/components/dashboard-overview.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-overview.tsx
@@ -191,14 +191,15 @@ function DashboardThreadList({
   }
 
   const groups = groupDashboardThreads(threads, currentDate);
-  const hiddenOpenCount = showAllOpen
-    ? 0
-    : Math.max(0, groups.open.length - OPEN_THREAD_CAP);
+  const visibleOpen = showAllOpen
+    ? groups.open
+    : groups.open.slice(0, OPEN_THREAD_CAP);
+  const hiddenOpenCount = groups.open.length - visibleOpen.length;
   const flatThreads = [
     ...groups.overdue,
     ...groups.upcoming,
     ...groups.withNextMoves,
-    ...groups.open.slice(0, groups.open.length - hiddenOpenCount),
+    ...visibleOpen,
   ];
 
   return (
@@ -222,7 +223,7 @@ function DashboardThreadList({
         <button
           type="button"
           onClick={() => setShowAllOpen(true)}
-          className="group flex w-full items-center gap-2 py-2 text-left text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+          className="flex w-full items-center gap-2 py-2 text-left text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
         >
           <ChevronRight className="size-3.5" />
           Show all

--- a/apps/web/src/features/dashboard/components/dashboard-overview.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-overview.tsx
@@ -22,6 +22,7 @@ import {
   Inbox,
   MessagesSquare,
 } from "lucide-react";
+import { useState } from "react";
 
 import { AreaIcon } from "@/features/areas/components/area-icon";
 import {
@@ -172,6 +173,8 @@ function OverviewTab({
   );
 }
 
+const OPEN_THREAD_CAP = 5;
+
 function DashboardThreadList({
   areaById,
   currentDate,
@@ -181,16 +184,21 @@ function DashboardThreadList({
   currentDate: number;
   threads: DashboardThread[];
 }) {
+  const [showAllOpen, setShowAllOpen] = useState(false);
+
   if (threads.length === 0) {
     return <AttentionEmpty>Your Life Areas are clear for now.</AttentionEmpty>;
   }
 
   const groups = groupDashboardThreads(threads, currentDate);
+  const hiddenOpenCount = showAllOpen
+    ? 0
+    : Math.max(0, groups.open.length - OPEN_THREAD_CAP);
   const flatThreads = [
     ...groups.overdue,
     ...groups.upcoming,
     ...groups.withNextMoves,
-    ...groups.open,
+    ...groups.open.slice(0, groups.open.length - hiddenOpenCount),
   ];
 
   return (
@@ -210,6 +218,20 @@ function DashboardThreadList({
 
         return <AttentionRow key={thread.id} now={currentDate} row={row} />;
       })}
+      {hiddenOpenCount > 0 && (
+        <button
+          type="button"
+          onClick={() => setShowAllOpen(true)}
+          className="group flex w-full items-center gap-2 py-2 text-left text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronRight className="size-3.5" />
+          Show all
+          <span className="tabular-nums opacity-60">
+            {hiddenOpenCount} more
+          </span>
+          <div className="ml-1 h-px flex-1 bg-border/40" />
+        </button>
+      )}
     </AttentionList>
   );
 }


### PR DESCRIPTION
Closes #235

## Summary

- Dashboard Overview now shows at most 5 plain Open Threads inline; the rest sit behind a flat "Show all · N more" button that reveals them in place, in the existing order.
- Attention-bearing threads (Overdue Follow-ups, Upcoming Follow-ups, Threads with Next Moves) are never capped. With 5 or fewer plain Open Threads the control doesn't render and behavior is unchanged.
- The cap is Dashboard-only; the Area inventory stays complete.
- CONTEXT.md's Thread Attention rules document the capped behavior.

## Verification

- `bun run lint`, `bun run build`, `bun run test:run` all pass (235 tests).
- Two new tests: cap + reveal + order preservation, and never-capping attention groups / no control at exactly the cap.
- Two-axis review (standards + spec) ran clean; minor style findings addressed in the follow-up commit.