### PR TITLE
feat(auth): add Google OAuth sign-in

### DIFF
--- a/apps/web/convex/auth.ts
+++ b/apps/web/convex/auth.ts
@@ -10,6 +10,16 @@ import authConfig from "./auth.config";
 
 const siteUrl = process.env.SITE_URL ?? "";
 
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Missing environment variable ${name}. Set it with: npx convex env set ${name} <value>`,
+    );
+  }
+  return value;
+}
+
 export const authComponent = createClient<DataModel>(components.betterAuth);
 
 export const createAuth = (ctx: GenericCtx<DataModel>) => {
@@ -23,8 +33,13 @@ export const createAuth = (ctx: GenericCtx<DataModel>) => {
     },
     socialProviders: {
       github: {
-        clientId: process.env.GITHUB_CLIENT_ID ?? "",
-        clientSecret: process.env.GITHUB_CLIENT_SECRET ?? "",
+        clientId: requireEnv("GITHUB_CLIENT_ID"),
+        clientSecret: requireEnv("GITHUB_CLIENT_SECRET"),
+      },
+      google: {
+        clientId: requireEnv("GOOGLE_CLIENT_ID"),
+        clientSecret: requireEnv("GOOGLE_CLIENT_SECRET"),
+        prompt: "select_account",
       },
     },
     plugins: [crossDomain({ siteUrl }), convex({ authConfig })],

--- a/apps/web/src/features/auth/auth-card-shell.tsx
+++ b/apps/web/src/features/auth/auth-card-shell.tsx
@@ -10,24 +10,53 @@ import {
   CardTitle,
 } from "@vita-os/ui/components/card";
 
+import type { SocialProviderId } from "@/features/auth/use-social-sign-in";
+
+export interface SocialProviderOption {
+  id: SocialProviderId;
+  name: string;
+  error?: string;
+  loading?: boolean;
+  onClick: () => void;
+}
+
 interface AuthCardShellProps {
   title: string;
   description: string;
   children: ReactNode;
   footer: ReactNode;
-  githubError?: string;
-  githubLoading?: boolean;
-  onGitHub: () => void;
+  providers: SocialProviderOption[];
 }
+
+const providerIcons: Record<SocialProviderId, ReactNode> = {
+  github: (
+    <svg
+      className="mr-2 h-4 w-4"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z" />
+    </svg>
+  ),
+  google: (
+    <svg
+      className="mr-2 h-4 w-4"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12.24 10.285v3.821h5.445c-.22 1.412-1.645 4.139-5.445 4.139-3.276 0-5.95-2.713-5.95-6.06s2.674-6.06 5.95-6.06c1.865 0 3.113.795 3.827 1.481l2.606-2.51C17 3.53 14.834 2.5 12.24 2.5 7.028 2.5 2.812 6.716 2.812 11.928c0 5.211 4.216 9.428 9.428 9.428 5.441 0 9.053-3.826 9.053-9.213 0-.619-.067-1.09-.148-1.559l-8.905-.299Z" />
+    </svg>
+  ),
+};
 
 export function AuthCardShell({
   title,
   description,
   children,
   footer,
-  githubError = "",
-  githubLoading = false,
-  onGitHub,
+  providers,
 }: AuthCardShellProps) {
   return (
     <div className="w-full max-w-md">
@@ -56,28 +85,31 @@ export function AuthCardShell({
               </span>
             </div>
           </div>
-          {githubError && (
-            <p role="alert" className="mb-4 text-sm text-destructive">
-              {githubError}
-            </p>
-          )}
-          <Button
-            variant="outline"
-            className="w-full"
-            onClick={onGitHub}
-            disabled={githubLoading}
-            aria-busy={githubLoading}
-          >
-            <svg
-              className="mr-2 h-4 w-4"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z" />
-            </svg>
-            {githubLoading ? "Connecting to GitHub..." : "Continue with GitHub"}
-          </Button>
+          <div className="space-y-3">
+            {providers.map(
+              ({ id, name, error = "", loading = false, onClick }) => (
+                <div key={id}>
+                  {error && (
+                    <p role="alert" className="mb-4 text-sm text-destructive">
+                      {error}
+                    </p>
+                  )}
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={onClick}
+                    disabled={loading}
+                    aria-busy={loading}
+                  >
+                    {providerIcons[id]}
+                    {loading
+                      ? `Connecting to ${name}...`
+                      : `Continue with ${name}`}
+                  </Button>
+                </div>
+              ),
+            )}
+          </div>
         </CardContent>
         <CardFooter className="justify-center">{footer}</CardFooter>
       </Card>

--- a/apps/web/src/features/auth/screens/sign-in-screen.tsx
+++ b/apps/web/src/features/auth/screens/sign-in-screen.tsx
@@ -1,30 +1,23 @@
 import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 
 import { SignInForm } from "@/features/auth/sign-in/sign-in-form";
-import { useGitHubSignIn } from "@/features/auth/use-github-sign-in";
 import { useSignIn } from "@/features/auth/use-sign-in";
+import { useSocialProviders } from "@/features/auth/use-social-providers";
 
 export function SignInScreen() {
   const signIn = useSignIn();
-  const signInWithGitHub = useGitHubSignIn();
+  const providers = useSocialProviders();
   const {
     run: runSignIn,
     isPending: isSigningIn,
     error: signInError,
   } = useGuardedAsyncAction(signIn, { errorToast: false });
-  const {
-    run: runGitHubSignIn,
-    isPending: isGitHubPending,
-    error: githubError,
-  } = useGuardedAsyncAction(signInWithGitHub, { errorToast: false });
 
   return (
     <SignInForm
       error={signInError ?? ""}
-      githubError={githubError ?? ""}
-      githubLoading={isGitHubPending}
       loading={isSigningIn}
-      onGitHub={() => void runGitHubSignIn()}
+      providers={providers}
       onSubmit={async ({ email, password }) => {
         await runSignIn({ email, password });
       }}

--- a/apps/web/src/features/auth/screens/sign-up-screen.tsx
+++ b/apps/web/src/features/auth/screens/sign-up-screen.tsx
@@ -1,30 +1,23 @@
 import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 
 import { SignUpForm } from "@/features/auth/sign-up/sign-up-form";
-import { useGitHubSignIn } from "@/features/auth/use-github-sign-in";
 import { useSignUp } from "@/features/auth/use-sign-up";
+import { useSocialProviders } from "@/features/auth/use-social-providers";
 
 export function SignUpScreen() {
   const signUp = useSignUp();
-  const signInWithGitHub = useGitHubSignIn();
+  const providers = useSocialProviders();
   const {
     run: runSignUp,
     isPending: isSigningUp,
     error: signUpError,
   } = useGuardedAsyncAction(signUp, { errorToast: false });
-  const {
-    run: runGitHubSignIn,
-    isPending: isGitHubPending,
-    error: githubError,
-  } = useGuardedAsyncAction(signInWithGitHub, { errorToast: false });
 
   return (
     <SignUpForm
       error={signUpError ?? ""}
-      githubError={githubError ?? ""}
-      githubLoading={isGitHubPending}
       loading={isSigningUp}
-      onGitHub={() => void runGitHubSignIn()}
+      providers={providers}
       onSubmit={async ({ name, email, password }) => {
         await runSignUp({ name, email, password });
       }}

--- a/apps/web/src/features/auth/sign-in/sign-in-form.test.tsx
+++ b/apps/web/src/features/auth/sign-in/sign-in-form.test.tsx
@@ -1,25 +1,45 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
+import type { SocialProviderOption } from "@/features/auth/auth-card-shell";
+
 import { render, screen } from "@/test/render-with-providers";
 
 import { SignInForm } from "./sign-in-form";
+
+function buildProviders(
+  overrides: {
+    github?: Partial<SocialProviderOption>;
+    google?: Partial<SocialProviderOption>;
+  } = {},
+): SocialProviderOption[] {
+  return [
+    { id: "github", name: "GitHub", onClick: vi.fn(), ...overrides.github },
+    { id: "google", name: "Google", onClick: vi.fn(), ...overrides.google },
+  ];
+}
 
 describe("SignInForm", () => {
   it("submits the entered email and password", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
+    const providers = buildProviders();
 
     render(
       <SignInForm
         error=""
-        githubError=""
-        githubLoading={false}
         loading={false}
-        onGitHub={vi.fn()}
+        providers={providers}
         onSubmit={onSubmit}
       />,
     );
+
+    expect(
+      screen.getByRole("button", { name: "Continue with GitHub" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    ).toBeInTheDocument();
 
     await user.type(screen.getByLabelText("Email"), "rigo@example.com");
     await user.type(screen.getByLabelText("Password"), "password-123");
@@ -29,16 +49,27 @@ describe("SignInForm", () => {
       email: "rigo@example.com",
       password: "password-123",
     });
+
+    await user.click(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    );
+    expect(providers[1]?.onClick).toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole("button", { name: "Continue with GitHub" }),
+    );
+    expect(providers[0]?.onClick).toHaveBeenCalled();
   });
 
-  it("shows email and GitHub pending states", () => {
+  it("shows email and social provider pending states", () => {
     render(
       <SignInForm
         error=""
-        githubError=""
-        githubLoading
         loading
-        onGitHub={vi.fn()}
+        providers={buildProviders({
+          github: { loading: true },
+          google: { loading: true },
+        })}
         onSubmit={vi.fn()}
       />,
     );
@@ -52,16 +83,23 @@ describe("SignInForm", () => {
     });
     expect(githubButton).toBeDisabled();
     expect(githubButton).toHaveAttribute("aria-busy", "true");
+
+    const googleButton = screen.getByRole("button", {
+      name: "Connecting to Google...",
+    });
+    expect(googleButton).toBeDisabled();
+    expect(googleButton).toHaveAttribute("aria-busy", "true");
   });
 
-  it("shows inline email and GitHub failures", () => {
+  it("shows inline email and social provider failures", () => {
     render(
       <SignInForm
         error="Invalid credentials"
-        githubError="GitHub is unavailable"
-        githubLoading={false}
         loading={false}
-        onGitHub={vi.fn()}
+        providers={buildProviders({
+          github: { error: "GitHub is unavailable" },
+          google: { error: "Google is unavailable" },
+        })}
         onSubmit={vi.fn()}
       />,
     );
@@ -71,6 +109,10 @@ describe("SignInForm", () => {
       "alert",
     );
     expect(screen.getByText("GitHub is unavailable")).toHaveAttribute(
+      "role",
+      "alert",
+    );
+    expect(screen.getByText("Google is unavailable")).toHaveAttribute(
       "role",
       "alert",
     );

--- a/apps/web/src/features/auth/sign-in/sign-in-form.tsx
+++ b/apps/web/src/features/auth/sign-in/sign-in-form.tsx
@@ -4,24 +4,23 @@ import { Input } from "@vita-os/ui/components/input";
 import { Label } from "@vita-os/ui/components/label";
 import { type SubmitEvent, useState } from "react";
 
-import { AuthCardShell } from "@/features/auth/auth-card-shell";
+import {
+  AuthCardShell,
+  type SocialProviderOption,
+} from "@/features/auth/auth-card-shell";
 
 interface SignInFormProps {
   error: string;
-  githubError: string;
-  githubLoading: boolean;
   loading: boolean;
+  providers: SocialProviderOption[];
   onSubmit: (value: { email: string; password: string }) => void;
-  onGitHub: () => void;
 }
 
 export function SignInForm({
   error,
-  githubError,
-  githubLoading,
   loading,
+  providers,
   onSubmit,
-  onGitHub,
 }: SignInFormProps) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -35,9 +34,7 @@ export function SignInForm({
     <AuthCardShell
       title="Sign In"
       description="Sign in to your account to continue"
-      githubError={githubError}
-      githubLoading={githubLoading}
-      onGitHub={onGitHub}
+      providers={providers}
       footer={
         <p className="text-sm text-muted-foreground">
           Don&apos;t have an account?{" "}

--- a/apps/web/src/features/auth/sign-up/sign-up-form.test.tsx
+++ b/apps/web/src/features/auth/sign-up/sign-up-form.test.tsx
@@ -1,25 +1,45 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
+import type { SocialProviderOption } from "@/features/auth/auth-card-shell";
+
 import { render, screen } from "@/test/render-with-providers";
 
 import { SignUpForm } from "./sign-up-form";
+
+function buildProviders(
+  overrides: {
+    github?: Partial<SocialProviderOption>;
+    google?: Partial<SocialProviderOption>;
+  } = {},
+): SocialProviderOption[] {
+  return [
+    { id: "github", name: "GitHub", onClick: vi.fn(), ...overrides.github },
+    { id: "google", name: "Google", onClick: vi.fn(), ...overrides.google },
+  ];
+}
 
 describe("SignUpForm", () => {
   it("submits the entered name, email, and password", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
+    const providers = buildProviders();
 
     render(
       <SignUpForm
         error=""
-        githubError=""
-        githubLoading={false}
         loading={false}
-        onGitHub={vi.fn()}
+        providers={providers}
         onSubmit={onSubmit}
       />,
     );
+
+    expect(
+      screen.getByRole("button", { name: "Continue with GitHub" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    ).toBeInTheDocument();
 
     await user.type(screen.getByLabelText("Name"), "Rigo");
     await user.type(screen.getByLabelText("Email"), "rigo@example.com");
@@ -31,16 +51,27 @@ describe("SignUpForm", () => {
       email: "rigo@example.com",
       password: "password-123",
     });
+
+    await user.click(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    );
+    expect(providers[1]?.onClick).toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole("button", { name: "Continue with GitHub" }),
+    );
+    expect(providers[0]?.onClick).toHaveBeenCalled();
   });
 
-  it("shows email and GitHub pending states", () => {
+  it("shows email and social provider pending states", () => {
     render(
       <SignUpForm
         error=""
-        githubError=""
-        githubLoading
         loading
-        onGitHub={vi.fn()}
+        providers={buildProviders({
+          github: { loading: true },
+          google: { loading: true },
+        })}
         onSubmit={vi.fn()}
       />,
     );
@@ -56,16 +87,23 @@ describe("SignUpForm", () => {
     });
     expect(githubButton).toBeDisabled();
     expect(githubButton).toHaveAttribute("aria-busy", "true");
+
+    const googleButton = screen.getByRole("button", {
+      name: "Connecting to Google...",
+    });
+    expect(googleButton).toBeDisabled();
+    expect(googleButton).toHaveAttribute("aria-busy", "true");
   });
 
-  it("shows inline email and GitHub failures", () => {
+  it("shows inline email and social provider failures", () => {
     render(
       <SignUpForm
         error="Email is already in use"
-        githubError="GitHub is unavailable"
-        githubLoading={false}
         loading={false}
-        onGitHub={vi.fn()}
+        providers={buildProviders({
+          github: { error: "GitHub is unavailable" },
+          google: { error: "Google is unavailable" },
+        })}
         onSubmit={vi.fn()}
       />,
     );
@@ -75,6 +113,10 @@ describe("SignUpForm", () => {
       "alert",
     );
     expect(screen.getByText("GitHub is unavailable")).toHaveAttribute(
+      "role",
+      "alert",
+    );
+    expect(screen.getByText("Google is unavailable")).toHaveAttribute(
       "role",
       "alert",
     );

--- a/apps/web/src/features/auth/sign-up/sign-up-form.tsx
+++ b/apps/web/src/features/auth/sign-up/sign-up-form.tsx
@@ -4,24 +4,23 @@ import { Input } from "@vita-os/ui/components/input";
 import { Label } from "@vita-os/ui/components/label";
 import { type SubmitEvent, useState } from "react";
 
-import { AuthCardShell } from "@/features/auth/auth-card-shell";
+import {
+  AuthCardShell,
+  type SocialProviderOption,
+} from "@/features/auth/auth-card-shell";
 
 interface SignUpFormProps {
   error: string;
-  githubError: string;
-  githubLoading: boolean;
   loading: boolean;
+  providers: SocialProviderOption[];
   onSubmit: (value: { name: string; email: string; password: string }) => void;
-  onGitHub: () => void;
 }
 
 export function SignUpForm({
   error,
-  githubError,
-  githubLoading,
   loading,
+  providers,
   onSubmit,
-  onGitHub,
 }: SignUpFormProps) {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -36,9 +35,7 @@ export function SignUpForm({
     <AuthCardShell
       title="Sign Up"
       description="Create a new account to get started"
-      githubError={githubError}
-      githubLoading={githubLoading}
-      onGitHub={onGitHub}
+      providers={providers}
       footer={
         <p className="text-sm text-muted-foreground">
           Already have an account?{" "}

--- a/apps/web/src/features/auth/use-social-providers.ts
+++ b/apps/web/src/features/auth/use-social-providers.ts
@@ -1,0 +1,37 @@
+import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
+
+import type { SocialProviderOption } from "@/features/auth/auth-card-shell";
+
+import { useSocialSignIn } from "@/features/auth/use-social-sign-in";
+
+export function useSocialProviders(): SocialProviderOption[] {
+  const signInWithGitHub = useSocialSignIn("github");
+  const signInWithGoogle = useSocialSignIn("google");
+  const {
+    run: runGitHubSignIn,
+    isPending: isGitHubPending,
+    error: githubError,
+  } = useGuardedAsyncAction(signInWithGitHub, { errorToast: false });
+  const {
+    run: runGoogleSignIn,
+    isPending: isGooglePending,
+    error: googleError,
+  } = useGuardedAsyncAction(signInWithGoogle, { errorToast: false });
+
+  return [
+    {
+      id: "github",
+      name: "GitHub",
+      error: githubError ?? "",
+      loading: isGitHubPending,
+      onClick: () => void runGitHubSignIn(),
+    },
+    {
+      id: "google",
+      name: "Google",
+      error: googleError ?? "",
+      loading: isGooglePending,
+      onClick: () => void runGoogleSignIn(),
+    },
+  ];
+}

--- a/apps/web/src/features/auth/use-social-sign-in.ts
+++ b/apps/web/src/features/auth/use-social-sign-in.ts
@@ -1,15 +1,19 @@
+import { useCallback } from "react";
+
 import { getAuthErrorMessage } from "@/features/auth/auth-result";
 import { authClient } from "@/lib/auth-client";
 
-export function useGitHubSignIn() {
-  return async () => {
+export type SocialProviderId = "github" | "google";
+
+export function useSocialSignIn(provider: SocialProviderId) {
+  return useCallback(async () => {
     const result = await authClient.signIn.social({
-      provider: "github",
+      provider,
     });
 
     const errorMessage = getAuthErrorMessage(result);
     if (errorMessage) {
       throw new Error(errorMessage);
     }
-  };
+  }, [provider]);
 }


### PR DESCRIPTION
## Summary
- Register the `google` social provider in the Better Auth config (`convex/auth.ts`) with `prompt: "select_account"`; provider credentials now go through a `requireEnv` helper that throws with an actionable message instead of silently passing empty strings.
- Generalize the auth UI from a hardcoded GitHub button to a `providers` list: parameterized `useSocialSignIn(provider)` hook (replaces `use-github-sign-in.ts`), new `useSocialProviders()` building GitHub + Google entries with independent loading/error state, and `AuthCardShell` rendering one button per provider.
- Update sign-in/sign-up form tests to cover both providers (render, click, pending state, per-provider `role="alert"` errors).

Deployment requirements: `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` set on the Convex deployment (`npx convex env set`), and the Google OAuth client's authorized redirect URI set to `<convex-site-url>/api/auth/callback/google`. Already configured on dev; prod needs the same before deploy.

## Test plan
- [x] `bun run lint` clean
- [x] `bun run build` (type-check + build) clean
- [x] `bun run test:run` — 233 tests passing, including new per-provider form tests
- [x] Manual end-to-end: Google sign-in verified working locally (consent screen → Convex callback → redirect back to app)
- [x] GitHub sign-in path unchanged and still wired through the same generalized code