### PR TITLE
feat(threads): open thread rail in place via thread search param

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -114,6 +114,7 @@ _Avoid_: Task list, project board, backlog.
 - **Overview** is the default view. It shows Thread attention groups alongside a compact **Inbox** preview and recent **Activity Log Entries** from distinct Open Threads.
 - **Plan** is a read-only time distribution of **Open Threads** based on **Follow-up**. Threads without a Follow-up appear in a collapsed No Date group.
 - **Plan** does not introduce a separate schedule or priority model. Rescheduling continues to mean changing the Thread's existing **Follow-up**.
+- Opening a **Thread** from any surface — **Dashboard**, **Inbox**, the palette, or an **Area** inventory — shows its detail pane in place over the current page rather than navigating to the **Area** page; closing the pane returns the user to where they were. The in-place behavior is recorded in ADR 0007.
 
 ## Task Handling
 

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -99,31 +99,34 @@ export function AppShell({ children }: { children: ReactNode }) {
   };
 
   return (
-    <div className="flex min-h-svh flex-col">
-      <AppTopBar
-        taskCount={taskCount}
-        inboxActive={pathname === "/inbox"}
-        onNewTask={dialogs.openNewTask}
-        onOpenPalette={() => setPaletteOpen(true)}
-      />
-      <div className="flex min-w-0 flex-1">
+    <div className="flex min-h-svh">
+      {/* The whole chrome column — topbar included — sits beside the thread
+          rail's width spacer, so an open rail pushes the topbar too instead
+          of sliding over it. */}
+      <div className="flex min-h-svh min-w-0 flex-1 flex-col">
+        <AppTopBar
+          taskCount={taskCount}
+          inboxActive={pathname === "/inbox"}
+          onNewTask={dialogs.openNewTask}
+          onOpenPalette={() => setPaletteOpen(true)}
+        />
         <main className="w-full min-w-0 flex-1 px-4 pt-3 pb-24 md:pb-8">
           {children}
         </main>
-        {openThreadSlug !== undefined && (
-          <ThreadDetailView
-            threadSlug={openThreadSlug}
-            areaSlug={isSearchSource ? undefined : routeAreaSlug}
-            onClose={closeThreadPane}
-            onThreadLocationChange={handleThreadLocationChange}
-          />
-        )}
+        <MobileTabBar
+          taskCount={taskCount}
+          onNewTask={dialogs.openNewTask}
+          onOpenPalette={() => setPaletteOpen(true)}
+        />
       </div>
-      <MobileTabBar
-        taskCount={taskCount}
-        onNewTask={dialogs.openNewTask}
-        onOpenPalette={() => setPaletteOpen(true)}
-      />
+      {openThreadSlug !== undefined && (
+        <ThreadDetailView
+          threadSlug={openThreadSlug}
+          areaSlug={isSearchSource ? undefined : routeAreaSlug}
+          onClose={closeThreadPane}
+          onThreadLocationChange={handleThreadLocationChange}
+        />
+      )}
 
       <CommandPalette
         open={paletteOpen}

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -1,7 +1,12 @@
 import type { ReactNode } from "react";
 
 import { api } from "@convex/_generated/api";
-import { useLocation, useNavigate } from "@tanstack/react-router";
+import {
+  useLocation,
+  useMatch,
+  useNavigate,
+  useSearch,
+} from "@tanstack/react-router";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useState } from "react";
 
@@ -11,6 +16,7 @@ import { useCreateDialogs } from "@/features/navigation/use-create-dialogs";
 import { useGlobalNewTaskShortcut } from "@/features/navigation/use-global-new-task-shortcut";
 import { NewTaskDialog } from "@/features/tasks/new-task/new-task-dialog";
 import { useCreateTask } from "@/features/tasks/use-create-task";
+import { ThreadDetailView } from "@/features/threads/thread-detail/thread-detail-view";
 import { CreateThreadDialog } from "@/features/threads/thread-form/create-thread-dialog";
 
 import { AppTopBar } from "./app-top-bar";
@@ -30,6 +36,68 @@ export function AppShell({ children }: { children: ReactNode }) {
   useGlobalNewTaskShortcut(dialogs.openNewTask);
   useCommandPaletteShortcut(() => setPaletteOpen(true));
 
+  // The thread pane opens from two sources: the global `?thread=<slug>`
+  // search param (any page, in place) or the /$areaSlug/$threadSlug deep
+  // link. When both are present, the search param wins.
+  const { thread: searchThreadSlug } = useSearch({ from: "/_authenticated" });
+  const threadRouteMatch = useMatch({
+    from: "/_authenticated/$areaSlug/$threadSlug",
+    shouldThrow: false,
+  });
+  const routeAreaSlug = threadRouteMatch?.params.areaSlug;
+  const isSearchSource = searchThreadSlug !== undefined;
+  const openThreadSlug =
+    searchThreadSlug ?? threadRouteMatch?.params.threadSlug;
+
+  const openThreadInPlace = (slug: string) => {
+    navigate({
+      to: ".",
+      search: (prev) => ({ ...prev, thread: slug }),
+    });
+  };
+
+  // Close must leave the thread route when one is matched underneath, even if
+  // the pane was showing a search-param thread on top of it — stripping only
+  // the param would let the route match reopen the pane with the stale thread.
+  const closeThreadPane = () => {
+    if (routeAreaSlug !== undefined) {
+      navigate({
+        to: "/$areaSlug",
+        params: { areaSlug: routeAreaSlug },
+        search: (prev) => ({ ...prev, thread: undefined }),
+        replace: true,
+      });
+    } else {
+      navigate({
+        to: ".",
+        search: (prev) => ({ ...prev, thread: undefined }),
+        replace: true,
+      });
+    }
+  };
+
+  const handleThreadLocationChange = ({
+    areaSlug,
+    threadSlug,
+  }: {
+    areaSlug: string;
+    threadSlug: string;
+  }) => {
+    if (isSearchSource) {
+      navigate({
+        to: ".",
+        search: (prev) => ({ ...prev, thread: threadSlug }),
+        replace: true,
+      });
+    } else {
+      navigate({
+        to: "/$areaSlug/$threadSlug",
+        params: { areaSlug, threadSlug },
+        replace: true,
+      });
+    }
+  };
+
   return (
     <div className="flex min-h-svh flex-col">
       <AppTopBar
@@ -38,7 +106,19 @@ export function AppShell({ children }: { children: ReactNode }) {
         onNewTask={dialogs.openNewTask}
         onOpenPalette={() => setPaletteOpen(true)}
       />
-      <main className="w-full flex-1 px-4 pt-3 pb-24 md:pb-8">{children}</main>
+      <div className="flex min-w-0 flex-1">
+        <main className="w-full min-w-0 flex-1 px-4 pt-3 pb-24 md:pb-8">
+          {children}
+        </main>
+        {openThreadSlug !== undefined && (
+          <ThreadDetailView
+            threadSlug={openThreadSlug}
+            areaSlug={isSearchSource ? undefined : routeAreaSlug}
+            onClose={closeThreadPane}
+            onThreadLocationChange={handleThreadLocationChange}
+          />
+        )}
+      </div>
       <MobileTabBar
         taskCount={taskCount}
         onNewTask={dialogs.openNewTask}
@@ -60,14 +140,8 @@ export function AppShell({ children }: { children: ReactNode }) {
         onOpenChange={dialogs.setShowCreateThread}
         areas={areas ?? []}
         defaultAreaId={dialogs.createForAreaId}
-        onCreated={({ slug, areaId }) => {
-          const area = (areas ?? []).find((a) => a._id === areaId);
-          if (area) {
-            navigate({
-              to: "/$areaSlug/$threadSlug",
-              params: { areaSlug: area.slug ?? area._id, threadSlug: slug },
-            });
-          }
+        onCreated={({ slug }) => {
+          openThreadInPlace(slug);
         }}
       />
       <NewTaskDialog

--- a/apps/web/src/components/layout/app-top-bar.tsx
+++ b/apps/web/src/components/layout/app-top-bar.tsx
@@ -27,7 +27,8 @@ export function AppTopBar({
   const { theme, setTheme } = useTheme();
 
   return (
-    // Below the thread detail rail (z-30) so slide-over panels cover the chrome.
+    // Below the thread detail rail (z-30): the desktop rail pushes the chrome
+    // aside, but the mobile drawer (and the rail mid-animation) overlay it.
     <header className="sticky top-0 z-20 border-b bg-background/95 backdrop-blur">
       <div className="flex h-12 items-center gap-3 px-4">
         <Link

--- a/apps/web/src/components/layout/command-palette.tsx
+++ b/apps/web/src/components/layout/command-palette.tsx
@@ -112,34 +112,36 @@ export function CommandPalette({
         <CommandGroup heading="Threads">
           {(threads ?? []).map((thread) => {
             const area = areaById.get(thread.areaId);
-            if (!area) return null;
+            const meta = [
+              area?.name,
+              thread.state === "resolved" ? "resolved" : undefined,
+            ]
+              .filter(Boolean)
+              .join(" · ");
             return (
               <CommandItem
                 key={thread._id}
                 value={`thread-${thread._id}`}
-                keywords={[thread.title, area.name]}
+                keywords={area ? [thread.title, area.name] : [thread.title]}
                 onSelect={() =>
                   run(() =>
                     navigate({
-                      to: "/$areaSlug/$threadSlug",
-                      params: {
-                        areaSlug: area.slug ?? area._id,
-                        threadSlug: thread.slug ?? thread._id,
-                      },
+                      to: ".",
+                      search: (prev) => ({
+                        ...prev,
+                        thread: thread.slug ?? thread._id,
+                      }),
                     }),
                   )
                 }
               >
                 <MessageSquare />
                 <span className="min-w-0 flex-1 truncate">{thread.title}</span>
-                <span className="shrink-0 text-xs text-muted-foreground">
-                  {[
-                    area.name,
-                    thread.state === "resolved" ? "resolved" : undefined,
-                  ]
-                    .filter(Boolean)
-                    .join(" · ")}
-                </span>
+                {meta && (
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {meta}
+                  </span>
+                )}
               </CommandItem>
             );
           })}

--- a/apps/web/src/features/areas/area-detail/area-detail-screen.tsx
+++ b/apps/web/src/features/areas/area-detail/area-detail-screen.tsx
@@ -56,8 +56,8 @@ export function AreaDetailScreen({ areaSlug }: AreaDetailScreenProps) {
         defaultAreaId={area._id}
         onCreated={({ slug }) => {
           navigate({
-            to: "/$areaSlug/$threadSlug",
-            params: { areaSlug, threadSlug: slug },
+            to: ".",
+            search: (prev) => ({ ...prev, thread: slug }),
           });
         }}
       />

--- a/apps/web/src/features/areas/components/area-threads-section.tsx
+++ b/apps/web/src/features/areas/components/area-threads-section.tsx
@@ -30,7 +30,6 @@ export function AreaThreadsSection({
 
   return (
     <AreaThreads
-      areaSlug={areaSlug}
       threads={threads ?? []}
       currentDate={Date.now()}
       isLoading={threads === undefined}

--- a/apps/web/src/features/areas/components/area-threads.test.tsx
+++ b/apps/web/src/features/areas/components/area-threads.test.tsx
@@ -40,7 +40,6 @@ describe("AreaThreads", () => {
   it("renders a flat thread list with header actions", () => {
     render(
       <AreaThreads
-        areaSlug="admin"
         threads={[
           thread("call-clinic", "Call clinic", { followUp: tomorrow }),
           thread("renew-passport", "Renew passport"),
@@ -64,7 +63,6 @@ describe("AreaThreads", () => {
   it("shows a loading skeleton while Threads are still loading", () => {
     render(
       <AreaThreads
-        areaSlug="admin"
         threads={[]}
         currentDate={today}
         isLoading
@@ -82,7 +80,6 @@ describe("AreaThreads", () => {
   it("shows an empty state when there are no Threads", () => {
     render(
       <AreaThreads
-        areaSlug="admin"
         threads={[]}
         currentDate={today}
         onCreateThread={vi.fn()}
@@ -98,7 +95,6 @@ describe("AreaThreads", () => {
   it("shows each scheduled date once and hides empty Next Move lines", () => {
     render(
       <AreaThreads
-        areaSlug="admin"
         threads={[
           thread("call-clinic", "Call clinic", { followUp: yesterday }),
           thread("renew-passport", "Renew passport", { followUp: tomorrow }),
@@ -122,7 +118,6 @@ describe("AreaThreads", () => {
   it("orders due Follow-ups before Next Move Threads and plain Open Threads", () => {
     render(
       <AreaThreads
-        areaSlug="admin"
         threads={[
           thread("future", "Future Follow-up", { followUp: tomorrow }),
           thread("today", "Today Follow-up", { followUp: today }),

--- a/apps/web/src/features/areas/components/area-threads.tsx
+++ b/apps/web/src/features/areas/components/area-threads.tsx
@@ -15,7 +15,6 @@ import {
 import { AreaThreadsSkeleton } from "./area-threads-skeleton";
 
 interface AreaThreadsProps {
-  areaSlug: string;
   threads: Doc<"threads">[];
   currentDate: number;
   isLoading?: boolean;
@@ -24,7 +23,6 @@ interface AreaThreadsProps {
 }
 
 export function AreaThreads({
-  areaSlug,
   threads,
   currentDate,
   isLoading = false,
@@ -66,7 +64,6 @@ export function AreaThreads({
           {flatThreads.map((thread) => (
             <AreaThreadRow
               key={thread._id}
-              areaSlug={areaSlug}
               thread={thread}
               now={currentDate}
               onRemoveThread={onRemoveThread}
@@ -79,12 +76,10 @@ export function AreaThreads({
 }
 
 function AreaThreadRow({
-  areaSlug,
   thread,
   now,
   onRemoveThread,
 }: {
-  areaSlug: string;
   thread: Doc<"threads">;
   now: number;
   onRemoveThread: (threadId: Id<"threads">) => void;
@@ -94,7 +89,7 @@ function AreaThreadRow({
     detail: thread.nextMove?.trim() || undefined,
     detailKind: "next-move",
     when: thread.followUp,
-    linkTo: { areaSlug, threadSlug: thread.slug ?? thread._id },
+    linkTo: { threadSlug: thread.slug ?? thread._id },
     actions: (
       <RowDeleteAction
         label="Delete thread"

--- a/apps/web/src/features/attention-list/attention-row-model.ts
+++ b/apps/web/src/features/attention-list/attention-row-model.ts
@@ -7,7 +7,7 @@ export interface AttentionRowModel {
   detailKind?: "next-move" | "summary";
   done?: boolean;
   isSavingText?: boolean;
-  linkTo?: { areaSlug: string; threadSlug: string };
+  linkTo?: { threadSlug: string };
   onSetWhen?: (when: number | undefined) => void;
   onToggleDone?: () => void;
   onUpdateText?: (text: string) => void;

--- a/apps/web/src/features/attention-list/row-parts.tsx
+++ b/apps/web/src/features/attention-list/row-parts.tsx
@@ -38,14 +38,15 @@ export function RowShell({
   className?: string;
   row: AttentionRowModel;
 }) {
-  if (!row.linkTo) {
+  const linkTo = row.linkTo;
+  if (!linkTo) {
     return <div className={className}>{children}</div>;
   }
 
   return (
     <Link
-      to="/$areaSlug/$threadSlug"
-      params={row.linkTo}
+      to="."
+      search={(prev) => ({ ...prev, thread: linkTo.threadSlug })}
       className={cn("outline-none", className)}
     >
       {children}

--- a/apps/web/src/features/dashboard/components/dashboard-overview.test.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-overview.test.tsx
@@ -11,9 +11,10 @@ import { DashboardOverview } from "./dashboard-overview";
 vi.mock("@tanstack/react-router", () => ({
   Link: ({
     to,
+    search: _search,
     children,
     ...props
-  }: ComponentPropsWithoutRef<"a"> & { to: string }) => (
+  }: ComponentPropsWithoutRef<"a"> & { to: string; search?: unknown }) => (
     <a href={to} {...props}>
       {children}
     </a>

--- a/apps/web/src/features/dashboard/components/dashboard-overview.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-overview.tsx
@@ -214,7 +214,7 @@ function DashboardThreadList({
           detailKind: thread.nextMove ? "next-move" : "summary",
           area: { icon: area.icon, name: area.name },
           when: thread.followUp,
-          linkTo: { areaSlug: area.slug, threadSlug: thread.slug },
+          linkTo: { threadSlug: thread.slug },
         };
 
         return <AttentionRow key={thread.id} now={currentDate} row={row} />;
@@ -316,8 +316,8 @@ function RecentActivity({
           return (
             <Link
               key={entry.id}
-              to="/$areaSlug/$threadSlug"
-              params={{ areaSlug: area.slug, threadSlug: thread.slug }}
+              to="."
+              search={(prev) => ({ ...prev, thread: thread.slug })}
               className="block rounded-md px-1 py-2 transition-colors hover:bg-muted/50"
             >
               <div className="flex items-center gap-1.5">
@@ -431,8 +431,8 @@ function PlanThreadLink({
 
   return (
     <Link
-      to="/$areaSlug/$threadSlug"
-      params={{ areaSlug: area.slug, threadSlug: thread.slug }}
+      to="."
+      search={(prev) => ({ ...prev, thread: thread.slug })}
       className="inline-flex h-7 max-w-full items-center justify-center gap-1.5 rounded-md border bg-background px-2.5 text-xs font-medium shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground"
     >
       <MessagesSquare className="size-3.5 shrink-0" />

--- a/apps/web/src/features/threads/components/thread-area-section-section.tsx
+++ b/apps/web/src/features/threads/components/thread-area-section-section.tsx
@@ -1,11 +1,11 @@
 import type { Id } from "@convex/_generated/dataModel";
 
 import { api } from "@convex/_generated/api";
-import { useNavigate } from "@tanstack/react-router";
 import { useGuardedAsyncAction } from "@vita-os/ui/hooks/use-guarded-async-action";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 
 import { ThreadAreaSection } from "@/features/threads/components/thread-area-section";
+import { useThreadPaneNav } from "@/features/threads/thread-detail/thread-pane-nav";
 import { useUpdateThread } from "@/features/threads/use-update-thread";
 import { useStableQuery } from "@/hooks/use-stable-query";
 
@@ -22,7 +22,7 @@ export function ThreadAreaSectionSection({
   const thread = useStableQuery(api.threads.getBySlug, {
     slug: threadSlug,
   });
-  const navigate = useNavigate();
+  const { onThreadLocationChange } = useThreadPaneNav();
   const updateThread = useUpdateThread(threadSlug);
 
   const { run: moveThread, isPending: isMoving } = useGuardedAsyncAction(
@@ -45,11 +45,7 @@ export function ThreadAreaSectionSection({
 
       const nextAreaSlug = result.value.slug ?? result.value._id;
       if (nextAreaSlug !== areaSlug) {
-        navigate({
-          to: "/$areaSlug/$threadSlug",
-          params: { areaSlug: nextAreaSlug, threadSlug },
-          replace: true,
-        });
+        onThreadLocationChange({ areaSlug: nextAreaSlug, threadSlug });
       }
     });
   };

--- a/apps/web/src/features/threads/components/thread-header-section.tsx
+++ b/apps/web/src/features/threads/components/thread-header-section.tsx
@@ -1,6 +1,6 @@
 import { api } from "@convex/_generated/api";
-import { useNavigate } from "@tanstack/react-router";
 
+import { useThreadPaneNav } from "@/features/threads/thread-detail/thread-pane-nav";
 import { useUpdateThread } from "@/features/threads/use-update-thread";
 import { useStableQuery } from "@/hooks/use-stable-query";
 
@@ -18,18 +18,14 @@ export function ThreadHeaderSection({
   const thread = useStableQuery(api.threads.getBySlug, {
     slug: threadSlug,
   });
-  const navigate = useNavigate();
+  const { onThreadLocationChange } = useThreadPaneNav();
   const updateThread = useUpdateThread(threadSlug);
 
   const handleTitleSave = async (title: string) => {
     if (!title || !thread) return;
     const result = await updateThread({ id: thread._id, title });
-    if (result?.slug) {
-      navigate({
-        to: "/$areaSlug/$threadSlug",
-        params: { areaSlug, threadSlug: result.slug },
-        replace: true,
-      });
+    if (result?.slug && result.slug !== threadSlug) {
+      onThreadLocationChange({ areaSlug, threadSlug: result.slug });
     }
   };
 

--- a/apps/web/src/features/threads/thread-detail/thread-detail-view.test.tsx
+++ b/apps/web/src/features/threads/thread-detail/thread-detail-view.test.tsx
@@ -16,17 +16,14 @@ import { ThreadDetailView } from "./thread-detail-view";
 
 const mocks = vi.hoisted(() => ({
   showDesktopPane: false,
-  navigate: vi.fn(),
+  onClose: vi.fn(),
+  onThreadLocationChange: vi.fn(),
   threadState: "open" as "open" | "resolved",
+  threadExists: true,
 }));
 
 vi.mock("@/hooks/use-thread-pane-viewport", () => ({
   useThreadPaneViewport: () => mocks.showDesktopPane,
-}));
-
-vi.mock("@tanstack/react-router", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@tanstack/react-router")>()),
-  useNavigate: () => mocks.navigate,
 }));
 
 const area = {
@@ -54,11 +51,14 @@ const thread = {
 } satisfies Doc<"threads">;
 
 vi.mock("convex-helpers/react/cache/hooks", () => ({
-  useQuery: (query: unknown) => {
+  useQuery: (query: unknown, args: unknown) => {
+    if (args === "skip") return undefined;
     const name = getFunctionName(query as never);
     if (name === "areas:getBySlug") return area;
+    if (name === "areas:get") return area;
     if (name === "areas:list") return [area];
     if (name === "threads:getBySlug") {
+      if (!mocks.threadExists) return null;
       return { ...thread, state: mocks.threadState };
     }
     if (name === "activityLogs:listByThread") return [];
@@ -75,17 +75,30 @@ vi.mock("convex/react", () => ({
   },
 }));
 
-function renderThreadDetail(threadSlug = "sister-s-front-teeth") {
+function renderThreadDetail(
+  props: { threadSlug?: string; areaSlug?: string } = {},
+) {
+  const threadSlug = props.threadSlug ?? "sister-s-front-teeth";
+  // Only default areaSlug when the key is absent, so tests can pass an
+  // explicit `areaSlug: undefined` to exercise the search-param source.
+  const areaSlug = "areaSlug" in props ? props.areaSlug : "family-health";
   return render(
-    <ThreadDetailView areaSlug="family-health" threadSlug={threadSlug} />,
+    <ThreadDetailView
+      areaSlug={areaSlug}
+      threadSlug={threadSlug}
+      onClose={mocks.onClose}
+      onThreadLocationChange={mocks.onThreadLocationChange}
+    />,
   );
 }
 
 describe("ThreadDetailView", () => {
   beforeEach(() => {
     mocks.showDesktopPane = false;
-    mocks.navigate.mockReset();
+    mocks.onClose.mockReset();
+    mocks.onThreadLocationChange.mockReset();
     mocks.threadState = "open";
+    mocks.threadExists = true;
   });
 
   it("opens Thread detail as a near-full bottom drawer below the pane breakpoint", async () => {
@@ -100,31 +113,32 @@ describe("ThreadDetailView", () => {
     expect(screen.getByRole("button", { name: "Close thread" })).toBeVisible();
   });
 
-  it("leaves the narrow Thread route after its close animation", async () => {
+  it("closes the narrow Thread pane after its close animation", async () => {
     renderThreadDetail();
 
     await screen.findByRole("dialog", { name: "Sister's front teeth" });
     fireEvent.click(screen.getByRole("button", { name: "Close thread" }));
 
-    expect(mocks.navigate).not.toHaveBeenCalled();
+    expect(mocks.onClose).not.toHaveBeenCalled();
 
     await waitFor(() => {
-      expect(mocks.navigate).toHaveBeenCalledWith({
-        to: "/$areaSlug",
-        params: { areaSlug: "family-health" },
-        replace: true,
-      });
+      expect(mocks.onClose).toHaveBeenCalledTimes(1);
     });
   });
 
-  it("opens a fresh Drawer shell when the Thread route changes", async () => {
+  it("opens a fresh Drawer shell when the open Thread changes", async () => {
     const { rerender } = renderThreadDetail();
 
     await screen.findByRole("dialog", { name: "Sister's front teeth" });
     fireEvent.click(screen.getByRole("button", { name: "Close thread" }));
 
     rerender(
-      <ThreadDetailView areaSlug="family-health" threadSlug="moms-legs" />,
+      <ThreadDetailView
+        areaSlug="family-health"
+        threadSlug="moms-legs"
+        onClose={mocks.onClose}
+        onThreadLocationChange={mocks.onThreadLocationChange}
+      />,
     );
 
     await waitFor(() => {
@@ -159,7 +173,7 @@ describe("ThreadDetailView", () => {
     ).toBeVisible();
   });
 
-  it("leaves the desktop Thread route after the pane width transition", async () => {
+  it("closes the desktop Thread pane after the pane width transition", async () => {
     mocks.showDesktopPane = true;
     renderThreadDetail();
 
@@ -168,7 +182,7 @@ describe("ThreadDetailView", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Close thread" }));
 
-    expect(mocks.navigate).not.toHaveBeenCalled();
+    expect(mocks.onClose).not.toHaveBeenCalled();
 
     const paneSpace = document.querySelector(
       '[data-slot="thread-detail-pane-space"]',
@@ -176,14 +190,10 @@ describe("ThreadDetailView", () => {
     expect(paneSpace).toHaveAttribute("data-state", "closed");
     fireEvent.transitionEnd(paneSpace as Element, { propertyName: "width" });
 
-    expect(mocks.navigate).toHaveBeenCalledWith({
-      to: "/$areaSlug",
-      params: { areaSlug: "family-health" },
-      replace: true,
-    });
+    expect(mocks.onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the desktop pane open when the Thread route changes", async () => {
+  it("keeps the desktop pane open when the open Thread changes", async () => {
     mocks.showDesktopPane = true;
     const { rerender } = renderThreadDetail();
     const pane = await screen.findByRole("complementary", {
@@ -192,13 +202,43 @@ describe("ThreadDetailView", () => {
     await waitFor(() => expect(pane).toHaveAttribute("data-state", "open"));
 
     rerender(
-      <ThreadDetailView areaSlug="family-health" threadSlug="moms-legs" />,
+      <ThreadDetailView
+        areaSlug="family-health"
+        threadSlug="moms-legs"
+        onClose={mocks.onClose}
+        onThreadLocationChange={mocks.onThreadLocationChange}
+      />,
     );
 
     expect(
       screen.getByRole("complementary", { name: "Sister's front teeth" }),
     ).toBe(pane);
     expect(pane).toHaveAttribute("data-state", "open");
+  });
+
+  it("renders the Thread without an areaSlug by deriving the area from the thread", async () => {
+    mocks.showDesktopPane = true;
+    renderThreadDetail({ areaSlug: undefined });
+
+    await screen.findByRole("complementary", {
+      name: "Sister's front teeth",
+    });
+
+    const header = screen.getByRole("banner", { name: "Thread header" });
+    expect(
+      within(header).getByRole("button", { name: "Family Health" }),
+    ).toBeVisible();
+  });
+
+  it("shows a closable not-found state for an unknown thread slug without an area", async () => {
+    mocks.showDesktopPane = true;
+    mocks.threadExists = false;
+    renderThreadDetail({ areaSlug: undefined, threadSlug: "nope" });
+
+    expect(await screen.findByText("Thread not found.")).toBeVisible();
+
+    await userEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(mocks.onClose).toHaveBeenCalledTimes(1);
   });
 
   it("restores orientation before presenting attention and continuity", async () => {

--- a/apps/web/src/features/threads/thread-detail/thread-detail-view.tsx
+++ b/apps/web/src/features/threads/thread-detail/thread-detail-view.tsx
@@ -1,7 +1,6 @@
 import type { Doc } from "@convex/_generated/dataModel";
 
 import { api } from "@convex/_generated/api";
-import { useNavigate } from "@tanstack/react-router";
 import { Badge } from "@vita-os/ui/components/badge";
 import { Button } from "@vita-os/ui/components/button";
 import {
@@ -16,6 +15,7 @@ import {
 } from "@vita-os/ui/components/drawer";
 import { Separator } from "@vita-os/ui/components/separator";
 import { X } from "lucide-react";
+import { useMemo } from "react";
 
 import { FollowUpSection } from "@/features/threads/components/follow-up-section";
 import { NextMoveSection } from "@/features/threads/components/next-move-section";
@@ -29,61 +29,81 @@ import { useDocumentTitle } from "@/hooks/use-document-title";
 import { useStableQuery } from "@/hooks/use-stable-query";
 import { useThreadPaneViewport } from "@/hooks/use-thread-pane-viewport";
 
+import type { ThreadLocation } from "./thread-pane-nav";
+
 import { ThreadNotFound } from "./thread-not-found";
+import { ThreadPaneNavContext } from "./thread-pane-nav";
 import { useDeferredRouteClose } from "./use-deferred-route-close";
 
 interface ThreadDetailViewProps {
-  areaSlug: string;
   threadSlug: string;
+  /**
+   * Present when the pane was opened via the /$areaSlug/$threadSlug deep
+   * link; the thread is then validated to belong to this area. Absent when
+   * opened via the `?thread` search param — the area is derived from the
+   * thread itself.
+   */
+  areaSlug?: string;
+  onClose: () => void;
+  onThreadLocationChange: (location: ThreadLocation) => void;
 }
 
 export function ThreadDetailView({
-  areaSlug,
   threadSlug,
+  areaSlug,
+  onClose,
+  onThreadLocationChange,
 }: ThreadDetailViewProps) {
   const showDesktopPane = useThreadPaneViewport();
-  const navigate = useNavigate();
-  const area = useStableQuery(api.areas.getBySlug, { slug: areaSlug });
   const thread = useStableQuery(api.threads.getBySlug, { slug: threadSlug });
+  const areaBySlug = useStableQuery(
+    api.areas.getBySlug,
+    areaSlug !== undefined ? { slug: areaSlug } : "skip",
+  );
+  const areaById = useStableQuery(
+    api.areas.get,
+    areaSlug === undefined && thread ? { id: thread.areaId } : "skip",
+  );
+  const area = areaSlug !== undefined ? areaBySlug : areaById;
 
   useDocumentTitle(thread?.title ?? "Thread");
 
-  const leaveThreadRoute = () => {
-    navigate({
-      to: "/$areaSlug",
-      params: { areaSlug },
-      replace: true,
-    });
-  };
+  const paneNav = useMemo(
+    () => ({ onThreadLocationChange }),
+    [onThreadLocationChange],
+  );
 
   const title = thread?.title ?? "Thread detail";
+  const isLoading =
+    thread === undefined || (thread !== null && area === undefined);
   const hasMatchingThread =
-    area !== undefined &&
-    area !== null &&
-    thread !== undefined &&
+    !isLoading &&
     thread !== null &&
-    thread.areaId === area._id;
-  const content =
-    area === undefined || thread === undefined ? (
-      <ThreadDetailSkeleton />
-    ) : area === null || thread === null || thread.areaId !== area._id ? (
-      <ThreadNotFound areaSlug={areaSlug} />
-    ) : (
+    area !== null &&
+    area !== undefined &&
+    (areaSlug === undefined || thread.areaId === area._id);
+  const content = isLoading ? (
+    <ThreadDetailSkeleton />
+  ) : !hasMatchingThread ? (
+    <ThreadNotFound areaSlug={areaSlug} onClose={onClose} />
+  ) : (
+    <ThreadPaneNavContext.Provider value={paneNav}>
       <ThreadDetailContent
-        areaSlug={areaSlug}
+        areaSlug={area.slug ?? area._id}
         threadSlug={threadSlug}
         thread={thread}
       />
-    );
+    </ThreadPaneNavContext.Provider>
+  );
 
   if (!showDesktopPane) {
     return (
       <ThreadDetailDrawer
-        key={`${areaSlug}/${threadSlug}`}
+        key={threadSlug}
         title={title}
         threadSlug={threadSlug}
         showActions={hasMatchingThread}
-        onClosed={leaveThreadRoute}
+        onClosed={onClose}
       >
         {content}
       </ThreadDetailDrawer>
@@ -95,7 +115,7 @@ export function ThreadDetailView({
       title={title}
       threadSlug={threadSlug}
       showActions={hasMatchingThread}
-      onClosed={leaveThreadRoute}
+      onClosed={onClose}
     >
       {content}
     </ThreadDetailPane>

--- a/apps/web/src/features/threads/thread-detail/thread-not-found.tsx
+++ b/apps/web/src/features/threads/thread-detail/thread-not-found.tsx
@@ -1,20 +1,31 @@
 import { Link } from "@tanstack/react-router";
 
 interface ThreadNotFoundProps {
-  areaSlug: string;
+  areaSlug?: string;
+  onClose?: () => void;
 }
 
-export function ThreadNotFound({ areaSlug }: ThreadNotFoundProps) {
+export function ThreadNotFound({ areaSlug, onClose }: ThreadNotFoundProps) {
   return (
     <div className="py-16 text-center">
       <p className="text-sm text-muted-foreground">Thread not found.</p>
-      <Link
-        to="/$areaSlug"
-        params={{ areaSlug }}
-        className="mt-2 inline-block text-sm underline"
-      >
-        Back to area
-      </Link>
+      {areaSlug !== undefined ? (
+        <Link
+          to="/$areaSlug"
+          params={{ areaSlug }}
+          className="mt-2 inline-block text-sm underline"
+        >
+          Back to area
+        </Link>
+      ) : (
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-2 inline-block text-sm underline"
+        >
+          Close
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/threads/thread-detail/thread-pane-nav.ts
+++ b/apps/web/src/features/threads/thread-detail/thread-pane-nav.ts
@@ -1,0 +1,26 @@
+import { createContext, useContext } from "react";
+
+export interface ThreadLocation {
+  areaSlug: string;
+  threadSlug: string;
+}
+
+export interface ThreadPaneNav {
+  /**
+   * Called when the open thread's location changes from within the pane
+   * (title rename changes the thread slug, moving the thread changes the
+   * area). The pane host decides how to reflect it: update the `?thread`
+   * search param in place, or replace the /$areaSlug/$threadSlug URL.
+   */
+  onThreadLocationChange: (location: ThreadLocation) => void;
+}
+
+export const ThreadPaneNavContext = createContext<ThreadPaneNav | null>(null);
+
+export function useThreadPaneNav(): ThreadPaneNav {
+  const nav = useContext(ThreadPaneNavContext);
+  if (!nav) {
+    throw new Error("useThreadPaneNav must be used within ThreadDetailView");
+  }
+  return nav;
+}

--- a/apps/web/src/routes/_authenticated/$areaSlug/$threadSlug.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/$threadSlug.tsx
@@ -1,14 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { RouteErrorFallback } from "@/components/error-boundary";
-import { ThreadDetailView } from "@/features/threads/thread-detail/thread-detail-view";
 
+// The thread detail pane is rendered globally by AppShell (it reads this
+// route's params via useMatch). The route exists purely so the deep-link URL
+// /$areaSlug/$threadSlug keeps matching.
 export const Route = createFileRoute("/_authenticated/$areaSlug/$threadSlug")({
   errorComponent: RouteErrorFallback,
-  component: ThreadRoute,
+  component: () => null,
 });
-
-function ThreadRoute() {
-  const { areaSlug, threadSlug } = Route.useParams();
-  return <ThreadDetailView areaSlug={areaSlug} threadSlug={threadSlug} />;
-}

--- a/apps/web/src/routes/_authenticated/$areaSlug/route.tsx
+++ b/apps/web/src/routes/_authenticated/$areaSlug/route.tsx
@@ -12,14 +12,10 @@ function AreaLayoutRoute() {
   const { areaSlug } = Route.useParams();
 
   return (
-    <div
-      data-slot="area-thread-workspace"
-      className="flex min-h-[calc(100dvh-5.25rem)] min-w-0 items-start gap-4"
-    >
-      <div data-slot="area-content" className="min-w-0 flex-1">
-        <AreaDetailScreen areaSlug={areaSlug} />
-      </div>
+    <>
+      <AreaDetailScreen areaSlug={areaSlug} />
+      {/* Child thread route renders null; the pane itself lives in AppShell. */}
       <Outlet />
-    </div>
+    </>
   );
 }

--- a/apps/web/src/routes/_authenticated/route.tsx
+++ b/apps/web/src/routes/_authenticated/route.tsx
@@ -6,6 +6,12 @@ import { RouteErrorFallback } from "@/components/error-boundary";
 import { AppShell } from "@/components/layout/app-shell";
 
 export const Route = createFileRoute("/_authenticated")({
+  validateSearch: (search: Record<string, unknown>): { thread?: string } => ({
+    thread:
+      typeof search.thread === "string" && search.thread.length > 0
+        ? search.thread
+        : undefined,
+  }),
   errorComponent: RouteErrorFallback,
   component: AuthenticatedLayout,
 });

--- a/docs/adr/0004-area-thread-detail-layout.md
+++ b/docs/adr/0004-area-thread-detail-layout.md
@@ -1,5 +1,7 @@
 # Area and Thread detail layout
 
+Status: Amended by ADR 0007 — the pane is now hosted globally by `AppShell` and opens in place over any page, not only the Area.
+
 On wide desktop viewports, opening a **Thread** from an **Area** should preserve the Area as context without covering it with a modal surface. Thread detail will use a full-height right rail that pushes the Area content into the remaining workspace. Below 1280px, Thread detail will continue to use the near-full-height bottom Drawer.
 
 ## Considered Options

--- a/docs/adr/0007-global-in-place-thread-rail.md
+++ b/docs/adr/0007-global-in-place-thread-rail.md
@@ -1,0 +1,26 @@
+# Global in-place thread rail
+
+ADR 0006 made the palette the sole jumping surface and the **Dashboard** the sole browsing surface, but jumping or browsing to a **Thread** still navigated to `/$areaSlug/$threadSlug`, yanking the user onto the **Area** page and losing their place. The Thread detail pane (desktop right rail / bottom Drawer per ADR 0004) was already self-contained — it fetches by slug and is positioned fixed — so it becomes a global in-place overlay hosted by `AppShell`: a `thread` search param on the authenticated layout opens the pane over whatever page the user is on, and every opener (command palette, Dashboard attention rows, recent activity, Plan chips, Area inventory rows, create-thread flows) sets the param instead of navigating.
+
+## Considered Options
+
+- **Keep route navigation to `/$areaSlug/$threadSlug`**: the status quo. Every opener already worked, but each jump replaced the page under the user — losing the place the Dashboard and palette had just put them in.
+- **Search param only, retiring the path route**: a single URL model, but existing bookmarks and shared links break, and a Thread loses its canonical address.
+- **Search param overlay with the path retained as a deep link**: chosen. In-app opens keep the user's place; the path stays canonical and lands identically to before.
+
+## URL model
+
+- `?thread=<threadSlug>` on any authenticated route opens the pane over the current page. Thread slugs are unique per user, so the param needs no Area segment.
+- Closing the pane strips the param; the page underneath was never left.
+- `/$areaSlug/$threadSlug` remains the supported, canonical deep link. Its route renders nothing; `AppShell` detects the match and shows the pane over the **Area** page, exactly as before. Close from a deep link still navigates to `/$areaSlug`.
+- When both a matched thread route and a `thread` search param are present, the search param wins.
+- Renaming a **Thread** (slug change) or moving it to another **Area** updates the search param in place when opened via param, and replaces the path route when opened via deep link.
+
+## Consequences
+
+- The desktop rail still pushes rather than covers: the width spacer moved from the Area layout into `AppShell`, so ADR 0004's push behavior now holds on every page.
+- The **Dashboard** and **Inbox** show the rail with no **Area** behind it, partially superseding ADR 0004's premise that the rail exists to keep the Area visible as context.
+- The palette no longer needs to resolve an **Area** before offering a **Thread**; selecting one sets the param and keeps the current page.
+- Opening a **Thread** preserves scroll position and in-progress context on the underlying page; close returns exactly there.
+- Below 1280px the bottom Drawer behavior is unchanged; only its host moved from the Area page into `AppShell`.
+- `/$areaSlug/$threadSlug` stays valid for bookmarks and sharing, but its route component renders nothing itself.


### PR DESCRIPTION
## Summary

Opening a thread from the palette or the dashboard no longer yanks you to the area page. The thread rail is now a **global in-place overlay** hosted by `AppShell`, driven by a `?thread=<threadSlug>` search param on the `_authenticated` layout (thread slugs are unique per user). You keep your place; closing the pane strips the param.

- **All openers set the search param**: command palette, dashboard attention rows, recent activity, plan chips, area inventory rows, and both create-thread flows. Side effect: the palette no longer skips threads whose area isn't resolved (it only needed the area to build the old URL).
- **`/$areaSlug/$threadSlug` stays a supported deep link**: the route renders nothing; AppShell detects the match and shows the pane over the area page as before. Search param wins if both are present. Close from a deep link still navigates to `/$areaSlug` (and always strips the param, so a stale route match can't reopen the pane).
- **`ThreadDetailView` decoupled from the area**: `areaSlug` is optional (derived from the thread's `areaId` in search mode); close and rename/move go through callbacks supplied by AppShell (`onClose` / `onThreadLocationChange` via a small `ThreadPaneNav` context).
- **Push behavior preserved everywhere**: the width-animating spacer moved from the area layout into AppShell's main flex row, so the desktop rail pushes content on every page (ADR 0004's push-not-cover).
- **Docs**: new ADR 0007 (global in-place thread rail); ADR 0004 marked amended; CONTEXT.md updated.

No Convex schema or function changes.

## Verification

- `bun run lint` clean
- `bun run build` green
- `bun run test:run` — 48 files, 237 tests passing (thread pane tests extended for the search-source and closable not-found cases)
- Independent code review pass; the one confirmed issue (close reopening a stale deep-linked thread underneath a search-opened pane) is fixed in this branch.