### PR TITLE
fix(threads): scroll only the activity log in the thread detail pane

### DIFF
--- a/apps/web/src/features/threads/components/thread-log.tsx
+++ b/apps/web/src/features/threads/components/thread-log.tsx
@@ -85,8 +85,8 @@ export function ActivityLog({ logs, onAddNote }: ActivityLogProps) {
   };
 
   return (
-    <section className="flex flex-col gap-3.5">
-      <div className="flex items-center gap-1">
+    <section className="flex min-h-0 flex-1 flex-col gap-3.5">
+      <div className="flex shrink-0 items-center gap-1">
         <h2 className="text-[11px] font-medium text-muted-foreground">
           Activity log
         </h2>
@@ -100,70 +100,76 @@ export function ActivityLog({ logs, onAddNote }: ActivityLogProps) {
         )}
       </div>
 
-      <div className="relative">
-        {/* The continuous rail: fades in at the top (the "now" origin) and
+      {/* Only this region scrolls; the pane's header and attention sections
+          stay fixed above it. The rail's `relative` box must live inside the
+          scroll container so the absolute rail spans the full entry list
+          instead of being clipped to the visible height. */}
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        <div className="relative pb-6">
+          {/* The continuous rail: fades in at the top (the "now" origin) and
             fades out at the bottom past the oldest entry. */}
-        <div
-          aria-hidden
-          className={cn(
-            "absolute top-1 bottom-0 w-px",
-            RAIL_LEFT,
-            "bg-gradient-to-b from-transparent via-border to-transparent",
-          )}
-        />
-
-        {/* Composer — the "now" node at the rail's origin. */}
-        <div className={cn("relative pb-5", ENTRY_PAD)}>
-          <span
+          <div
             aria-hidden
             className={cn(
-              "absolute top-[15px] size-2.5 -translate-x-1/2 rounded-full",
-              NODE_LEFT,
-              "border border-(--brand-gold) bg-background",
+              "absolute top-1 bottom-0 w-px",
+              RAIL_LEFT,
+              "bg-gradient-to-b from-transparent via-border to-transparent",
             )}
-          >
-            <span className="absolute inset-[3px] rounded-full bg-(--brand-gold)" />
-          </span>
-          <form onSubmit={handleAddNote}>
-            <FieldGroup className="gap-0">
-              <Field data-disabled={isPending || undefined}>
-                <FieldLabel htmlFor="activity-log-note" className="sr-only">
-                  Activity log note
-                </FieldLabel>
-                <InputGroup>
-                  <InputGroupTextarea
-                    id="activity-log-note"
-                    value={noteText}
-                    onChange={(event) => setNoteText(event.target.value)}
-                    disabled={isPending}
-                    aria-label="Activity log note"
-                    placeholder="Add a note about what happened…"
-                    className="min-h-10 pr-10 py-2 text-[13px]"
-                    rows={1}
-                    onKeyDown={handleNoteKeyDown}
-                  />
-                  <InputGroupAddon
-                    align="block-end"
-                    className="absolute right-2 bottom-2 w-auto p-0"
-                  >
-                    <InputGroupButton
-                      type="submit"
-                      size="icon-xs"
-                      variant="secondary"
-                      disabled={!noteText.trim() || isPending}
-                      aria-label="Add note"
-                      aria-busy={isPending}
-                    >
-                      <ArrowUp data-icon="inline-start" />
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              </Field>
-            </FieldGroup>
-          </form>
-        </div>
+          />
 
-        <ActivityLogTimeline logs={logs} />
+          {/* Composer — the "now" node at the rail's origin. */}
+          <div className={cn("relative pb-5", ENTRY_PAD)}>
+            <span
+              aria-hidden
+              className={cn(
+                "absolute top-[15px] size-2.5 -translate-x-1/2 rounded-full",
+                NODE_LEFT,
+                "border border-(--brand-gold) bg-background",
+              )}
+            >
+              <span className="absolute inset-[3px] rounded-full bg-(--brand-gold)" />
+            </span>
+            <form onSubmit={handleAddNote}>
+              <FieldGroup className="gap-0">
+                <Field data-disabled={isPending || undefined}>
+                  <FieldLabel htmlFor="activity-log-note" className="sr-only">
+                    Activity log note
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupTextarea
+                      id="activity-log-note"
+                      value={noteText}
+                      onChange={(event) => setNoteText(event.target.value)}
+                      disabled={isPending}
+                      aria-label="Activity log note"
+                      placeholder="Add a note about what happened…"
+                      className="min-h-10 pr-10 py-2 text-[13px]"
+                      rows={1}
+                      onKeyDown={handleNoteKeyDown}
+                    />
+                    <InputGroupAddon
+                      align="block-end"
+                      className="absolute right-2 bottom-2 w-auto p-0"
+                    >
+                      <InputGroupButton
+                        type="submit"
+                        size="icon-xs"
+                        variant="secondary"
+                        disabled={!noteText.trim() || isPending}
+                        aria-label="Add note"
+                        aria-busy={isPending}
+                      >
+                        <ArrowUp data-icon="inline-start" />
+                      </InputGroupButton>
+                    </InputGroupAddon>
+                  </InputGroup>
+                </Field>
+              </FieldGroup>
+            </form>
+          </div>
+
+          <ActivityLogTimeline logs={logs} />
+        </div>
       </div>
     </section>
   );

--- a/apps/web/src/features/threads/thread-detail/thread-detail-view.test.tsx
+++ b/apps/web/src/features/threads/thread-detail/thread-detail-view.test.tsx
@@ -280,6 +280,35 @@ describe("ThreadDetailView", () => {
     ).toBeTruthy();
   });
 
+  it("scrolls only the activity log, keeping header and attention fixed", async () => {
+    mocks.showDesktopPane = true;
+    renderThreadDetail();
+
+    const pane = await screen.findByRole("complementary", {
+      name: "Sister's front teeth",
+    });
+
+    const composer = screen.getByRole("textbox", {
+      name: "Activity log note",
+    });
+    const scrollRegion = composer.closest(".overflow-y-auto");
+    expect(scrollRegion).not.toBeNull();
+    expect(pane.contains(scrollRegion)).toBe(true);
+
+    const header = screen.getByRole("banner", { name: "Thread header" });
+    const attention = screen.getByRole("region", { name: "Thread attention" });
+    expect(scrollRegion!.contains(header)).toBe(false);
+    expect(scrollRegion!.contains(attention)).toBe(false);
+    // The activity log heading stays visible while entries scroll beneath it.
+    expect(
+      scrollRegion!.contains(
+        screen.getByRole("heading", { name: "Activity log" }),
+      ),
+    ).toBe(false);
+    // No scroll container wraps the whole pane content anymore.
+    expect(header.closest(".overflow-y-auto")).toBeNull();
+  });
+
   it("keeps a Resolved Thread oriented without active attention controls", async () => {
     mocks.showDesktopPane = true;
     mocks.threadState = "resolved";

--- a/apps/web/src/features/threads/thread-detail/thread-detail-view.tsx
+++ b/apps/web/src/features/threads/thread-detail/thread-detail-view.tsx
@@ -167,7 +167,7 @@ function ThreadDetailDrawer({
           showActions={showActions}
           onRequestClose={requestClose}
         />
-        <div className="min-h-0 flex-1 overflow-y-auto px-5 pt-8 pb-[calc(2rem+env(safe-area-inset-bottom))]">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-5 pt-8 pb-[calc(2rem+env(safe-area-inset-bottom))]">
           {children}
         </div>
       </DrawerContent>
@@ -212,7 +212,7 @@ function ThreadDetailPane({
           showActions={showActions}
           onRequestClose={requestClose}
         />
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-8">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-6 py-8">
           {children}
         </div>
       </aside>
@@ -269,11 +269,11 @@ function ThreadDetailContent({
   const isResolved = thread.state === "resolved";
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex min-h-0 flex-1 flex-col gap-5">
       <header
         role="banner"
         aria-label="Thread header"
-        className="sticky top-0 z-10 flex flex-col gap-3 bg-popover pb-1"
+        className="flex shrink-0 flex-col gap-3 pb-1"
       >
         <div className="flex items-center gap-2 pr-24">
           <ThreadAreaSectionSection
@@ -292,7 +292,7 @@ function ThreadDetailContent({
         <section
           role="region"
           aria-label="Thread attention"
-          className="flex flex-col gap-5"
+          className="flex shrink-0 flex-col gap-5"
         >
           <div className="grid grid-cols-[repeat(auto-fit,minmax(14rem,1fr))] gap-5">
             <NextMoveSection threadSlug={threadSlug} />
@@ -302,7 +302,7 @@ function ThreadDetailContent({
         </section>
       )}
 
-      <div>
+      <div className="flex min-h-0 flex-1 flex-col">
         <ActivityLogSection threadSlug={threadSlug} />
       </div>
     </div>


### PR DESCRIPTION
## Summary

The thread detail sidebar previously scrolled all of its content in a single `overflow-y-auto` region, with the title/summary header pinned via `position: sticky`. Since the activity log is the part that grows, the scroll boundary now lives inside it:

- The desktop pane and mobile drawer content wrappers are non-scrolling `overflow-hidden` flex columns; the header (breadcrumb, title, summary) and the Next Move / Follow-up attention section stay fixed (`shrink-0`), and the header's now-dead `sticky` styling is removed.
- The activity log section fills the remaining height with an internal `overflow-y-auto` container around the timeline rail region. The rail's `relative` box sits inside the scroll content so the absolutely-positioned rail spans every entry instead of clipping at the viewport, and the note composer scrolls with the rail to keep the "now" node attached. `pb-6` keeps the last entry off the clip edge.

## Test plan

- New regression test in `thread-detail-view.test.tsx` pins the contract: composer/timeline inside the scroll container; header, attention section, and "Activity log" heading outside it; no scroll container wrapping the whole pane.
- `bun run lint`, `bun run build`, `bun run test:run` all green (48 files / 238 tests).

Known trade-off: on extremely short viewports (< ~450px tall) the fixed header + attention section could exceed the pane height and clip, since only the log scrolls now.