### PR TITLE
feat(design): add design system showcase app

### DIFF
--- a/apps/design/index.html
+++ b/apps/design/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>Vita OS Design</title>
+    <meta
+      name="description"
+      content="Design system reference for Vita OS: tokens, typography, and components."
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/design/oxlint.config.ts
+++ b/apps/design/oxlint.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "oxlint";
+
+import { sharedOxlintConfig } from "../../oxlint.config.ts";
+
+export default defineConfig({
+  extends: [sharedOxlintConfig],
+});

--- a/apps/design/package.json
+++ b/apps/design/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@vita-os/design",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "oxlint --fix --deny-warnings . && oxfmt --write .",
+    "lint:check": "oxlint --deny-warnings . && oxfmt --check .",
+    "format": "oxfmt --write .",
+    "format:check": "oxfmt --check .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@vita-os/ui": "workspace:*",
+    "lucide-react": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "4.3.0",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "6.0.2",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:",
+    "vite": "8.0.13"
+  }
+}

--- a/apps/design/src/app.tsx
+++ b/apps/design/src/app.tsx
@@ -1,0 +1,68 @@
+import { Button } from "@vita-os/ui/components/button";
+import { Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { ColorsSection } from "./sections/colors";
+import { ComponentsSection } from "./sections/components";
+import { RadiiSection } from "./sections/radii";
+import { TypographySection } from "./sections/typography";
+
+const NAV_ITEMS = [
+  { id: "colors", label: "Colors" },
+  { id: "typography", label: "Typography" },
+  { id: "radii", label: "Radii" },
+  { id: "components", label: "Components" },
+];
+
+function useDarkMode() {
+  const [dark, setDark] = useState(
+    () => window.matchMedia("(prefers-color-scheme: dark)").matches,
+  );
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", dark);
+  }, [dark]);
+
+  return { dark, toggle: () => setDark((value) => !value) };
+}
+
+export function App() {
+  const { dark, toggle } = useDarkMode();
+
+  return (
+    <div className="min-h-svh">
+      <header className="sticky top-0 z-10 border-b bg-surface-1/90 backdrop-blur">
+        <div className="mx-auto flex h-14 w-full max-w-5xl items-center gap-6 px-6">
+          <span className="font-heading text-sm font-bold tracking-tight">
+            Vita OS Design
+          </span>
+          <nav className="flex flex-1 items-center gap-4">
+            {NAV_ITEMS.map((item) => (
+              <a
+                key={item.id}
+                href={`#${item.id}`}
+                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {item.label}
+              </a>
+            ))}
+          </nav>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={toggle}
+            aria-label={dark ? "Switch to light theme" : "Switch to dark theme"}
+          >
+            {dark ? <Sun /> : <Moon />}
+          </Button>
+        </div>
+      </header>
+      <main className="mx-auto w-full max-w-5xl space-y-16 px-6 py-12">
+        <ColorsSection />
+        <TypographySection />
+        <RadiiSection />
+        <ComponentsSection />
+      </main>
+    </div>
+  );
+}

--- a/apps/design/src/components/section.tsx
+++ b/apps/design/src/components/section.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+interface SectionProps {
+  children: ReactNode;
+  description?: string;
+  id: string;
+  title: string;
+}
+
+export function Section({ children, description, id, title }: SectionProps) {
+  return (
+    <section id={id} className="scroll-mt-20 space-y-6">
+      <div className="space-y-1">
+        <h2 className="font-heading text-2xl font-semibold tracking-tight">
+          {title}
+        </h2>
+        {description ? (
+          <p className="max-w-2xl text-sm text-muted-foreground">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/apps/design/src/lib/tokens.ts
+++ b/apps/design/src/lib/tokens.ts
@@ -1,0 +1,130 @@
+import type { CSSProperties } from "react";
+
+export interface TokenEntry {
+  name: string;
+  light?: string;
+  dark?: string;
+}
+
+export type TokenGroup =
+  | "Brand"
+  | "Surfaces"
+  | "Semantic"
+  | "Condition"
+  | "Charts"
+  | "Sidebar"
+  | "Other";
+
+export const TOKEN_GROUP_ORDER: TokenGroup[] = [
+  "Brand",
+  "Surfaces",
+  "Semantic",
+  "Condition",
+  "Charts",
+  "Sidebar",
+  "Other",
+];
+
+export type VarStyle = CSSProperties & Record<`--${string}`, string>;
+
+const SEMANTIC_KEYS = new Set([
+  "foreground",
+  "card",
+  "card-foreground",
+  "popover",
+  "popover-foreground",
+  "primary",
+  "primary-foreground",
+  "secondary",
+  "secondary-foreground",
+  "muted",
+  "muted-foreground",
+  "accent",
+  "accent-foreground",
+  "destructive",
+  "destructive-foreground",
+  "border",
+  "input",
+  "ring",
+]);
+
+function collectFromRules(
+  rules: CSSRuleList,
+  target: Map<string, { light?: string; dark?: string }>,
+) {
+  for (const rule of Array.from(rules)) {
+    if (rule instanceof CSSStyleRule) {
+      const selector = rule.selectorText.trim();
+      if (selector !== ":root" && selector !== ".dark") continue;
+      const { style } = rule;
+      for (let i = 0; i < style.length; i++) {
+        const prop = style.item(i);
+        if (!prop.startsWith("--") || prop.startsWith("--tw-")) continue;
+        const value = style.getPropertyValue(prop).trim();
+        const entry = target.get(prop) ?? {};
+        if (selector === ":root") entry.light = value;
+        else entry.dark = value;
+        target.set(prop, entry);
+      }
+    } else if (rule instanceof CSSGroupingRule) {
+      collectFromRules(rule.cssRules, target);
+    }
+  }
+}
+
+/**
+ * Walks every loaded stylesheet and collects custom properties declared on
+ * `:root` (light) and `.dark` (dark), recursing into layer/media blocks.
+ */
+export function collectTokens(): TokenEntry[] {
+  const collected = new Map<string, { light?: string; dark?: string }>();
+  for (const sheet of Array.from(document.styleSheets)) {
+    let rules: CSSRuleList;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      continue;
+    }
+    collectFromRules(rules, collected);
+  }
+  return Array.from(collected.entries())
+    .map(([name, value]) => ({ name, ...value }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Buckets a token by name; returns null for radius/font tokens, which have their own sections. */
+export function groupToken(name: string): TokenGroup | null {
+  const key = name.replace(/^--/, "");
+  if (
+    key === "radius" ||
+    key.startsWith("radius-") ||
+    key.startsWith("font-")
+  ) {
+    return null;
+  }
+  if (key.startsWith("brand-")) return "Brand";
+  if (key.startsWith("surface-")) return "Surfaces";
+  if (key.startsWith("condition-")) return "Condition";
+  if (key.startsWith("chart-")) return "Charts";
+  if (key.startsWith("sidebar")) return "Sidebar";
+  if (SEMANTIC_KEYS.has(key)) return "Semantic";
+  return "Other";
+}
+
+/**
+ * Inlines every token's declared value as a CSS custom property so a wrapper
+ * renders correctly for a given mode regardless of the ambient `.dark` class
+ * on `<html>` (the global theme toggle). Chained `var(--x)` references
+ * resolve locally since every referenced token is set on the same element.
+ */
+export function tokenStyleVars(
+  tokens: TokenEntry[],
+  mode: "light" | "dark",
+): VarStyle {
+  const style: Record<string, string> = {};
+  for (const token of tokens) {
+    const value = mode === "dark" ? (token.dark ?? token.light) : token.light;
+    if (value) style[token.name] = value;
+  }
+  return style as VarStyle;
+}

--- a/apps/design/src/main.tsx
+++ b/apps/design/src/main.tsx
@@ -1,0 +1,14 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./app";
+import "@vita-os/ui/globals.css";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/design/src/sections/colors.tsx
+++ b/apps/design/src/sections/colors.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+
+import { Section } from "@/components/section";
+import {
+  collectTokens,
+  groupToken,
+  TOKEN_GROUP_ORDER,
+  tokenStyleVars,
+  type TokenEntry,
+  type TokenGroup,
+} from "@/lib/tokens";
+
+function TokenCard({ token }: { token: TokenEntry }) {
+  return (
+    <div className="space-y-2 rounded-lg border bg-card p-3">
+      <div
+        className="h-12 w-full rounded-md border"
+        style={{ background: `var(${token.name})` }}
+      />
+      <div className="space-y-0.5">
+        <p className="truncate font-mono text-xs font-medium">{token.name}</p>
+        {token.light ? (
+          <p
+            className="truncate font-mono text-[11px] text-muted-foreground"
+            title={token.light}
+          >
+            {token.light}
+          </p>
+        ) : null}
+        {token.dark && token.dark !== token.light ? (
+          <p
+            className="truncate font-mono text-[11px] text-muted-foreground"
+            title={token.dark}
+          >
+            dark: {token.dark}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function TokenGroupGrid({
+  group,
+  tokens,
+}: {
+  group: TokenGroup;
+  tokens: TokenEntry[];
+}) {
+  return (
+    <div className="space-y-3">
+      <h4 className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+        {group}
+      </h4>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        {tokens.map((token) => (
+          <TokenCard key={token.name} token={token} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ColorsSection() {
+  const [tokens, setTokens] = useState<TokenEntry[]>([]);
+
+  useEffect(() => {
+    setTokens(collectTokens());
+  }, []);
+
+  const colorTokens = tokens.filter((token) => groupToken(token.name) !== null);
+  const groups = TOKEN_GROUP_ORDER.map((group) => ({
+    group,
+    tokens: colorTokens.filter((token) => groupToken(token.name) === group),
+  })).filter((entry) => entry.tokens.length > 0);
+
+  const lightStyle = tokenStyleVars(colorTokens, "light");
+  const darkStyle = tokenStyleVars(colorTokens, "dark");
+
+  return (
+    <Section
+      id="colors"
+      title="Colors"
+      description="Every custom property declared on :root and .dark in globals.css, enumerated at runtime and grouped by prefix."
+    >
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div
+          className="space-y-8 rounded-xl border bg-surface-1 p-6 text-foreground"
+          style={lightStyle}
+        >
+          <p className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+            Light
+          </p>
+          {groups.map(({ group, tokens: groupTokens }) => (
+            <TokenGroupGrid key={group} group={group} tokens={groupTokens} />
+          ))}
+        </div>
+        <div
+          className="dark space-y-8 rounded-xl border bg-surface-1 p-6 text-foreground"
+          style={darkStyle}
+        >
+          <p className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+            Dark
+          </p>
+          {groups.map(({ group, tokens: groupTokens }) => (
+            <TokenGroupGrid key={group} group={group} tokens={groupTokens} />
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/apps/design/src/sections/components.tsx
+++ b/apps/design/src/sections/components.tsx
@@ -1,0 +1,25 @@
+import { Section } from "@/components/section";
+
+import { ButtonsGroup } from "./components/buttons";
+import { FeedbackGroup } from "./components/feedback";
+import { FormControlsGroup } from "./components/form-controls";
+import { OverlaysGroup } from "./components/overlays";
+import { StructureGroup } from "./components/structure";
+
+export function ComponentsSection() {
+  return (
+    <Section
+      id="components"
+      title="Components"
+      description="A tour of the Vita OS component library, grouped by role — the building blocks used across tasks, threads, areas, and goals."
+    >
+      <div className="grid gap-6">
+        <ButtonsGroup />
+        <FormControlsGroup />
+        <FeedbackGroup />
+        <OverlaysGroup />
+        <StructureGroup />
+      </div>
+    </Section>
+  );
+}

--- a/apps/design/src/sections/components/buttons.tsx
+++ b/apps/design/src/sections/components/buttons.tsx
@@ -1,0 +1,90 @@
+import { Button } from "@vita-os/ui/components/button";
+import {
+  ButtonGroup,
+  ButtonGroupSeparator,
+  ButtonGroupText,
+} from "@vita-os/ui/components/button-group";
+import { CalendarPlus, ChevronDown, Plus, Trash2 } from "lucide-react";
+
+import { Example, Group } from "./group";
+
+const VARIANTS = [
+  "default",
+  "secondary",
+  "outline",
+  "ghost",
+  "destructive",
+  "link",
+] as const;
+
+const SIZES = ["sm", "default", "lg"] as const;
+
+export function ButtonsGroup() {
+  return (
+    <Group title="Buttons">
+      <Example label="Variants">
+        {VARIANTS.map((variant) => (
+          <Button key={variant} variant={variant}>
+            {variant}
+          </Button>
+        ))}
+      </Example>
+
+      <Example label="Sizes">
+        {SIZES.map((size) => (
+          <Button key={size} size={size}>
+            New task
+          </Button>
+        ))}
+        <Button size="icon" aria-label="Add task">
+          <Plus />
+        </Button>
+      </Example>
+
+      <Example label="With icon">
+        <Button>
+          <Plus />
+          New goal
+        </Button>
+        <Button variant="secondary">
+          <CalendarPlus />
+          Schedule
+        </Button>
+        <Button variant="destructive">
+          <Trash2 />
+          Delete
+        </Button>
+      </Example>
+
+      <Example label="Disabled">
+        <Button disabled>Saving…</Button>
+        <Button variant="outline" disabled>
+          Archive
+        </Button>
+      </Example>
+
+      <Example label="Button group">
+        <ButtonGroup>
+          <Button variant="outline">Day</Button>
+          <Button variant="outline">Week</Button>
+          <Button variant="outline">Month</Button>
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button variant="outline">
+            <Plus />
+            Add area
+          </Button>
+          <ButtonGroupSeparator />
+          <Button variant="outline" size="icon" aria-label="More options">
+            <ChevronDown />
+          </Button>
+        </ButtonGroup>
+        <ButtonGroup>
+          <ButtonGroupText>Filter</ButtonGroupText>
+          <Button variant="outline">Active</Button>
+          <Button variant="outline">Done</Button>
+        </ButtonGroup>
+      </Example>
+    </Group>
+  );
+}

--- a/apps/design/src/sections/components/feedback.tsx
+++ b/apps/design/src/sections/components/feedback.tsx
@@ -1,0 +1,95 @@
+import { Badge } from "@vita-os/ui/components/badge";
+import { Button } from "@vita-os/ui/components/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@vita-os/ui/components/empty";
+import { Kbd, KbdGroup } from "@vita-os/ui/components/kbd";
+import { Skeleton } from "@vita-os/ui/components/skeleton";
+import { Toaster } from "@vita-os/ui/components/sonner";
+import { toast } from "@vita-os/ui/lib/toast";
+import { Inbox } from "lucide-react";
+
+import { Example, Group } from "./group";
+
+const BADGE_VARIANTS = [
+  "default",
+  "secondary",
+  "outline",
+  "destructive",
+  "ghost",
+] as const;
+
+export function FeedbackGroup() {
+  return (
+    <Group title="Feedback & status">
+      <Example label="Badge">
+        {BADGE_VARIANTS.map((variant) => (
+          <Badge key={variant} variant={variant}>
+            {variant}
+          </Badge>
+        ))}
+      </Example>
+
+      <Example label="Skeleton">
+        <div className="flex w-64 flex-col gap-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-1/2" />
+        </div>
+      </Example>
+
+      <Example label="Kbd">
+        <KbdGroup>
+          <Kbd>⌘</Kbd>
+          <Kbd>K</Kbd>
+        </KbdGroup>
+        <KbdGroup>
+          <Kbd>Ctrl</Kbd>
+          <Kbd>Enter</Kbd>
+        </KbdGroup>
+      </Example>
+
+      <Example label="Toast">
+        <Button
+          variant="outline"
+          onClick={() =>
+            toast.success("Goal marked complete", {
+              description: "Ship the Vita OS design showcase",
+            })
+          }
+        >
+          Complete goal
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => toast.error("Could not sync thread")}
+        >
+          Trigger error
+        </Button>
+        <Toaster />
+      </Example>
+
+      <Example label="Empty">
+        <Empty className="w-full border">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <Inbox />
+            </EmptyMedia>
+            <EmptyTitle>No open threads</EmptyTitle>
+            <EmptyDescription>
+              Threads you start will show up here.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button size="sm">Start a thread</Button>
+          </EmptyContent>
+        </Empty>
+      </Example>
+    </Group>
+  );
+}

--- a/apps/design/src/sections/components/form-controls.tsx
+++ b/apps/design/src/sections/components/form-controls.tsx
@@ -1,0 +1,149 @@
+import { Checkbox } from "@vita-os/ui/components/checkbox";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "@vita-os/ui/components/combobox";
+import { DatePicker } from "@vita-os/ui/components/date-picker";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+} from "@vita-os/ui/components/field";
+import { Input } from "@vita-os/ui/components/input";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@vita-os/ui/components/input-group";
+import { Label } from "@vita-os/ui/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vita-os/ui/components/select";
+import { Textarea } from "@vita-os/ui/components/textarea";
+import { Search } from "lucide-react";
+import { useState } from "react";
+
+import { Example, Group } from "./group";
+
+const PROJECTS = ["Personal OS", "Health Reset", "Deep Work Q3", "Home Move"];
+
+const HABITS = [
+  { id: "morning-review", label: "Morning review" },
+  { id: "deep-work-block", label: "Deep work block" },
+  { id: "evening-shutdown", label: "Evening shutdown" },
+];
+
+export function FormControlsGroup() {
+  const [priority, setPriority] = useState<string | null>("medium");
+  const [project, setProject] = useState<string | null>(PROJECTS[0] ?? null);
+  const [projectQuery, setProjectQuery] = useState(PROJECTS[0] ?? "");
+  const [dueDate, setDueDate] = useState<Date | undefined>(undefined);
+
+  return (
+    <Group title="Form controls">
+      <Example label="Input">
+        <Field className="max-w-xs">
+          <FieldLabel htmlFor="task-title">Task title</FieldLabel>
+          <Input id="task-title" placeholder="Write the Q3 retro" />
+        </Field>
+      </Example>
+
+      <Example label="Input group">
+        <InputGroup className="max-w-xs">
+          <InputGroupAddon>
+            <Search className="size-4" />
+          </InputGroupAddon>
+          <InputGroupInput placeholder="Search projects" />
+        </InputGroup>
+      </Example>
+
+      <Example label="Textarea">
+        <Field className="max-w-sm">
+          <FieldLabel htmlFor="task-notes">Notes</FieldLabel>
+          <Textarea id="task-notes" placeholder="Add context for future you…" />
+          <FieldDescription>Visible only to you.</FieldDescription>
+        </Field>
+      </Example>
+
+      <Example label="Checkbox">
+        <div className="flex flex-col gap-2.5">
+          {HABITS.map((habit) => (
+            <Label key={habit.id} htmlFor={habit.id} className="gap-2.5">
+              <Checkbox
+                id={habit.id}
+                defaultChecked={habit.id === "morning-review"}
+              />
+              {habit.label}
+            </Label>
+          ))}
+        </div>
+      </Example>
+
+      <Example label="Select">
+        <Field className="w-40">
+          <FieldLabel htmlFor="priority-select">Priority</FieldLabel>
+          <Select value={priority} onValueChange={setPriority}>
+            <SelectTrigger id="priority-select" className="w-full">
+              <SelectValue placeholder="Priority" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="low">Low</SelectItem>
+              <SelectItem value="medium">Medium</SelectItem>
+              <SelectItem value="high">High</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+      </Example>
+
+      <Example label="Combobox">
+        <Field className="w-52">
+          <FieldLabel htmlFor="project-combobox">Project</FieldLabel>
+          <Combobox<string>
+            items={PROJECTS}
+            value={project}
+            onValueChange={setProject}
+            inputValue={projectQuery}
+            onInputValueChange={setProjectQuery}
+          >
+            <ComboboxInput
+              id="project-combobox"
+              placeholder="Choose a project"
+            />
+            <ComboboxContent>
+              <ComboboxEmpty>No projects found</ComboboxEmpty>
+              <ComboboxList>
+                {(name: string) => (
+                  <ComboboxItem key={name} value={name}>
+                    {name}
+                  </ComboboxItem>
+                )}
+              </ComboboxList>
+            </ComboboxContent>
+          </Combobox>
+        </Field>
+      </Example>
+
+      <Example label="Date picker">
+        <Field className="w-fit">
+          <FieldContent>
+            <FieldLabel>Due date</FieldLabel>
+            <DatePicker
+              value={dueDate}
+              onChange={setDueDate}
+              placeholder="Set a due date"
+            />
+          </FieldContent>
+        </Field>
+      </Example>
+    </Group>
+  );
+}

--- a/apps/design/src/sections/components/group.tsx
+++ b/apps/design/src/sections/components/group.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+interface GroupProps {
+  children: ReactNode;
+  title: string;
+}
+
+export function Group({ children, title }: GroupProps) {
+  return (
+    <div className="space-y-4 rounded-xl border bg-card p-6">
+      <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+interface ExampleProps {
+  children: ReactNode;
+  label: string;
+}
+
+export function Example({ children, label }: ExampleProps) {
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <div className="flex flex-wrap items-center gap-3">{children}</div>
+    </div>
+  );
+}

--- a/apps/design/src/sections/components/overlays.tsx
+++ b/apps/design/src/sections/components/overlays.tsx
@@ -1,0 +1,236 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@vita-os/ui/components/alert-dialog";
+import { Button } from "@vita-os/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@vita-os/ui/components/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@vita-os/ui/components/dropdown-menu";
+import { Field, FieldLabel } from "@vita-os/ui/components/field";
+import { Input } from "@vita-os/ui/components/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@vita-os/ui/components/popover";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@vita-os/ui/components/responsive-dialog";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@vita-os/ui/components/sheet";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vita-os/ui/components/tooltip";
+import {
+  Archive,
+  MoreHorizontal,
+  Pencil,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
+import { useState } from "react";
+
+import { Example, Group } from "./group";
+
+export function OverlaysGroup() {
+  const [responsiveOpen, setResponsiveOpen] = useState(false);
+
+  return (
+    <Group title="Overlays">
+      <Example label="Dialog">
+        <Dialog>
+          <DialogTrigger render={<Button variant="outline" />}>
+            New task
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>New task</DialogTitle>
+              <DialogDescription>
+                Add a task to your Vita OS inbox.
+              </DialogDescription>
+            </DialogHeader>
+            <Field>
+              <FieldLabel htmlFor="overlay-task-title">Title</FieldLabel>
+              <Input
+                id="overlay-task-title"
+                placeholder="Draft the weekly review"
+              />
+            </Field>
+            <DialogFooter showCloseButton>
+              <Button>Create task</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </Example>
+
+      <Example label="Responsive dialog">
+        <Button variant="outline" onClick={() => setResponsiveOpen(true)}>
+          View goal
+        </Button>
+        <ResponsiveDialog
+          open={responsiveOpen}
+          onOpenChange={setResponsiveOpen}
+        >
+          <ResponsiveDialogContent>
+            <ResponsiveDialogHeader>
+              <ResponsiveDialogTitle>
+                Ship the design showcase
+              </ResponsiveDialogTitle>
+              <ResponsiveDialogDescription>
+                Renders as a dialog on desktop and a drawer on mobile.
+              </ResponsiveDialogDescription>
+            </ResponsiveDialogHeader>
+            <ResponsiveDialogFooter>
+              <Button>Mark as done</Button>
+            </ResponsiveDialogFooter>
+          </ResponsiveDialogContent>
+        </ResponsiveDialog>
+      </Example>
+
+      <Example label="Sheet">
+        <Sheet>
+          <SheetTrigger render={<Button variant="outline" />}>
+            Area settings
+          </SheetTrigger>
+          <SheetContent>
+            <SheetHeader>
+              <SheetTitle>Health Reset</SheetTitle>
+              <SheetDescription>
+                Configure how this area shows up across Vita OS.
+              </SheetDescription>
+            </SheetHeader>
+            <SheetFooter>
+              <Button>Save changes</Button>
+            </SheetFooter>
+          </SheetContent>
+        </Sheet>
+      </Example>
+
+      <Example label="Alert dialog">
+        <AlertDialog>
+          <AlertDialogTrigger render={<Button variant="destructive" />}>
+            <Trash2 />
+            Delete area
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete this area?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Tasks and threads inside "Home Move" will be archived, not
+                deleted.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction>Delete</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </Example>
+
+      <Example label="Popover">
+        <Popover>
+          <PopoverTrigger render={<Button variant="outline" />}>
+            <Sparkles />
+            Quick add
+          </PopoverTrigger>
+          <PopoverContent>
+            <PopoverHeader>
+              <PopoverTitle>Capture a thought</PopoverTitle>
+              <PopoverDescription>
+                It lands in your inbox for triage later.
+              </PopoverDescription>
+            </PopoverHeader>
+            <Input placeholder="Renew passport" />
+          </PopoverContent>
+        </Popover>
+      </Example>
+
+      <Example label="Tooltip">
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button variant="ghost" size="icon" aria-label="Archive" />
+              }
+            >
+              <Archive />
+            </TooltipTrigger>
+            <TooltipContent>Archive thread</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </Example>
+
+      <Example label="Dropdown menu">
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                variant="outline"
+                size="icon"
+                aria-label="Thread actions"
+              />
+            }
+          >
+            <MoreHorizontal />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuLabel>Thread actions</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>
+              <Pencil />
+              Rename
+            </DropdownMenuItem>
+            <DropdownMenuItem>
+              <Archive />
+              Archive
+            </DropdownMenuItem>
+            <DropdownMenuItem variant="destructive">
+              <Trash2 />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </Example>
+    </Group>
+  );
+}

--- a/apps/design/src/sections/components/structure.tsx
+++ b/apps/design/src/sections/components/structure.tsx
@@ -1,0 +1,147 @@
+import { Badge } from "@vita-os/ui/components/badge";
+import { Button } from "@vita-os/ui/components/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@vita-os/ui/components/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@vita-os/ui/components/collapsible";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle,
+} from "@vita-os/ui/components/item";
+import { Separator } from "@vita-os/ui/components/separator";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@vita-os/ui/components/tabs";
+import { CheckCircle2, ChevronsUpDown, Circle, Target } from "lucide-react";
+
+import { Example, Group } from "./group";
+
+export function StructureGroup() {
+  return (
+    <Group title="Structure">
+      <Example label="Card">
+        <Card className="w-80">
+          <CardHeader>
+            <CardTitle>Deep Work Q3</CardTitle>
+            <CardDescription>4 tasks · 2 threads open</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Target className="size-4" />
+              Goal: ship the design showcase
+            </div>
+          </CardContent>
+          <CardFooter className="gap-2">
+            <Button size="sm">Open project</Button>
+            <Badge variant="secondary">On track</Badge>
+          </CardFooter>
+        </Card>
+      </Example>
+
+      <Example label="Tabs">
+        <Tabs defaultValue="today" className="w-80">
+          <TabsList>
+            <TabsTrigger value="today">Today</TabsTrigger>
+            <TabsTrigger value="upcoming">Upcoming</TabsTrigger>
+            <TabsTrigger value="someday">Someday</TabsTrigger>
+          </TabsList>
+          <TabsContent
+            value="today"
+            className="pt-3 text-sm text-muted-foreground"
+          >
+            3 tasks scheduled for today.
+          </TabsContent>
+          <TabsContent
+            value="upcoming"
+            className="pt-3 text-sm text-muted-foreground"
+          >
+            5 tasks in the next 7 days.
+          </TabsContent>
+          <TabsContent
+            value="someday"
+            className="pt-3 text-sm text-muted-foreground"
+          >
+            12 tasks parked without a date.
+          </TabsContent>
+        </Tabs>
+      </Example>
+
+      <Example label="Separator">
+        <div className="w-64 space-y-3">
+          <p className="text-sm">Personal OS</p>
+          <Separator />
+          <p className="text-sm text-muted-foreground">Health Reset</p>
+        </div>
+        <div className="flex h-8 items-center gap-3 text-sm text-muted-foreground">
+          <span>Areas</span>
+          <Separator orientation="vertical" />
+          <span>Threads</span>
+          <Separator orientation="vertical" />
+          <span>Goals</span>
+        </div>
+      </Example>
+
+      <Example label="Item">
+        <ItemGroup className="w-96">
+          <Item variant="outline">
+            <ItemMedia variant="icon">
+              <CheckCircle2 className="text-primary" />
+            </ItemMedia>
+            <ItemContent>
+              <ItemTitle>Write the weekly review</ItemTitle>
+              <ItemDescription>
+                Personal OS · Completed yesterday
+              </ItemDescription>
+            </ItemContent>
+          </Item>
+          <Item variant="outline">
+            <ItemMedia variant="icon">
+              <Circle />
+            </ItemMedia>
+            <ItemContent>
+              <ItemTitle>Book physio follow-up</ItemTitle>
+              <ItemDescription>Health Reset · Due tomorrow</ItemDescription>
+            </ItemContent>
+            <ItemActions>
+              <Badge variant="outline">High</Badge>
+            </ItemActions>
+          </Item>
+        </ItemGroup>
+      </Example>
+
+      <Example label="Collapsible">
+        <Collapsible className="w-72 space-y-2">
+          <CollapsibleTrigger
+            render={
+              <Button variant="ghost" className="w-full justify-between" />
+            }
+          >
+            Show completed tasks
+            <ChevronsUpDown className="size-4" />
+          </CollapsibleTrigger>
+          <CollapsibleContent className="space-y-1.5 rounded-2xl border p-3 text-sm text-muted-foreground">
+            <p>Renew passport</p>
+            <p>Pack for offsite</p>
+          </CollapsibleContent>
+        </Collapsible>
+      </Example>
+    </Group>
+  );
+}

--- a/apps/design/src/sections/radii.tsx
+++ b/apps/design/src/sections/radii.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+
+import { Section } from "@/components/section";
+import { collectTokens, type TokenEntry } from "@/lib/tokens";
+
+const RADIUS_SCALE = [
+  "rounded-sm",
+  "rounded-md",
+  "rounded-lg",
+  "rounded-xl",
+  "rounded-2xl",
+  "rounded-3xl",
+  "rounded-4xl",
+];
+
+export function RadiiSection() {
+  const [tokens, setTokens] = useState<TokenEntry[]>([]);
+
+  useEffect(() => {
+    setTokens(collectTokens());
+  }, []);
+
+  const radius = tokens.find((token) => token.name === "--radius");
+
+  return (
+    <Section
+      id="radii"
+      title="Radii"
+      description={
+        radius?.light
+          ? `Radius scale, derived in @theme inline from the base --radius token (${radius.light}).`
+          : "Radius scale, derived in @theme inline from the base --radius token."
+      }
+    >
+      <div className="flex flex-wrap gap-6">
+        {RADIUS_SCALE.map((className) => (
+          <div key={className} className="flex flex-col items-center gap-2">
+            <div className={`h-20 w-20 border bg-surface-3 ${className}`} />
+            <p className="font-mono text-xs text-muted-foreground">
+              {className}
+            </p>
+          </div>
+        ))}
+      </div>
+    </Section>
+  );
+}

--- a/apps/design/src/sections/typography.tsx
+++ b/apps/design/src/sections/typography.tsx
@@ -1,0 +1,104 @@
+import { Section } from "@/components/section";
+
+const TYPE_SCALE = [
+  "text-4xl",
+  "text-3xl",
+  "text-2xl",
+  "text-xl",
+  "text-lg",
+  "text-base",
+  "text-sm",
+  "text-xs",
+];
+
+const WEIGHTS = [
+  { className: "font-light", label: "300 Light" },
+  { className: "font-normal", label: "400 Regular" },
+  { className: "font-medium", label: "500 Medium" },
+  { className: "font-semibold", label: "600 Semibold" },
+  { className: "font-bold", label: "700 Bold" },
+  { className: "font-extrabold", label: "800 Extrabold" },
+];
+
+function FamilySpecimen({
+  title,
+  fontClassName,
+  sample,
+}: {
+  title: string;
+  fontClassName: string;
+  sample: string;
+}) {
+  return (
+    <div className="space-y-8">
+      <h3 className="font-heading text-lg font-semibold">{title}</h3>
+      <div className="space-y-2">
+        <p className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+          Scale
+        </p>
+        <div className="divide-y">
+          {TYPE_SCALE.map((className) => (
+            <div key={className} className="flex items-baseline gap-4 py-2">
+              <span className="w-16 shrink-0 font-mono text-[11px] text-muted-foreground">
+                {className}
+              </span>
+              <span className={`${fontClassName} ${className} truncate`}>
+                {sample}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <p className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+          Weight
+        </p>
+        <div className="divide-y">
+          {WEIGHTS.map(({ className, label }) => (
+            <div key={className} className="flex items-baseline gap-4 py-2">
+              <span className="w-28 shrink-0 font-mono text-[11px] text-muted-foreground">
+                {label}
+              </span>
+              <span className={`${fontClassName} ${className} text-xl`}>
+                {sample}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function TypographySection() {
+  return (
+    <Section
+      id="typography"
+      title="Typography"
+      description="Raleway Variable drives headings (font-heading); Manrope Variable drives body text (font-sans). Both are variable fonts spanning weights 300 through 800."
+    >
+      <div className="grid gap-10 lg:grid-cols-2">
+        <FamilySpecimen
+          title="Raleway Variable — font-heading"
+          fontClassName="font-heading"
+          sample="Design system reference"
+        />
+        <FamilySpecimen
+          title="Manrope Variable — font-sans"
+          fontClassName="font-sans"
+          sample="Design system reference"
+        />
+      </div>
+      <div className="max-w-2xl space-y-2">
+        <p className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+          Paragraph sample
+        </p>
+        <p className="font-sans text-base leading-relaxed text-foreground">
+          Vita OS pairs Raleway Variable for headings with Manrope Variable for
+          body copy, keeping interface text legible at small sizes while giving
+          section titles a distinct, editorial character.
+        </p>
+      </div>
+    </Section>
+  );
+}

--- a/apps/design/tsconfig.app.json
+++ b/apps/design/tsconfig.app.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+
+    /* Path aliases */
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/apps/design/tsconfig.json
+++ b/apps/design/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ],
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"],
+      "@vita-os/ui/*": ["../../packages/ui/src/*"]
+    }
+  }
+}

--- a/apps/design/tsconfig.node.json
+++ b/apps/design/tsconfig.node.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": [],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/design/vite.config.ts
+++ b/apps/design/vite.config.ts
@@ -1,0 +1,18 @@
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": "/src",
+    },
+  },
+  server: {
+    port: 5174,
+  },
+  preview: {
+    port: 5174,
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,25 @@
         "turbo": "^2.9.12",
       },
     },
+    "apps/design": {
+      "name": "@vita-os/design",
+      "version": "0.0.0",
+      "dependencies": {
+        "@vita-os/ui": "workspace:*",
+        "lucide-react": "catalog:",
+        "react": "catalog:",
+        "react-dom": "catalog:",
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "4.3.0",
+        "@types/react": "catalog:",
+        "@types/react-dom": "catalog:",
+        "@vitejs/plugin-react": "6.0.2",
+        "tailwindcss": "catalog:",
+        "typescript": "catalog:",
+        "vite": "8.0.13",
+      },
+    },
     "apps/web": {
       "name": "@vita-os/web",
       "version": "0.0.0",
@@ -762,6 +781,8 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
+    "@vita-os/design": ["@vita-os/design@workspace:apps/design"],
+
     "@vita-os/ui": ["@vita-os/ui@workspace:packages/ui"],
 
     "@vita-os/web": ["@vita-os/web@workspace:apps/web"],
@@ -1210,7 +1231,7 @@
 
     "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "nanostores": ["nanostores@1.4.1", "", {}, "sha512-PGd3uPojJB9Z07d5NX3Db/SOSBbyy3wLMUGq0GpnEEJfVzY9mq7daPMAZ3jObV5D3Jn+YKND636eI5ULg7F80Q=="],
 
@@ -1268,7 +1289,7 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
-    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 
@@ -1630,11 +1651,11 @@
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
+    "shadcn/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
     "tsx/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
-
-    "vite/postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "vitest/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
@@ -1673,6 +1694,8 @@
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "data-urls/whatwg-url/@exodus/bytes": ["@exodus/bytes@1.14.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ=="],
+
+    "shadcn/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -1725,8 +1748,6 @@
     "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
 
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
-
-    "vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "vitest/tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 


### PR DESCRIPTION
## Summary

Adds `apps/design` — a minimal Vite + React app that renders a single-page reference for the design system in `packages/ui`:

- **Colors** — every custom property declared on `:root` / `.dark` in `globals.css`, enumerated **at runtime** from the loaded stylesheet (so new tokens show up automatically), grouped by prefix (Brand / Surfaces / Semantic / Condition / Charts / Sidebar), rendered as light and dark panels side by side. Each panel inlines its theme's token values locally, so both render correctly regardless of the active global theme.
- **Typography** — Raleway Variable (`font-heading`) and Manrope Variable (`font-sans`) specimens: type scale, weight ramp (300–800), paragraph sample.
- **Radii** — the `rounded-sm`…`rounded-4xl` scale with the base `--radius` value read at runtime.
- **Components** — curated showcase of the `@vita-os/ui` library in five groups (buttons, form controls, feedback & status, overlays, structure) with working interactive examples and Vita OS-flavored sample content. Only `sidebar` is excluded (needs its own layout/provider).

The app shell has a sticky anchor nav and a light/dark toggle. Dev server runs on port 5174 (`bunx turbo run dev --filter=@vita-os/design`).

## Notes

- New workspace registered in `bun.lock`; no dependency versions changed — everything reuses the catalog and versions already used by `apps/web`.
- No changes to `packages/ui` or `apps/web`.

## Verification

- `bun run lint` clean
- `bun run build` — all 3 packages build (`tsc -b` + `vite build` for the new app)
- Runtime smoke test via headless browser: all four sections render, token enumeration works, theme toggle works, light/dark panels legible under both global themes.