### PR TITLE
chore(worktrees): replace node_modules symlinks with per-worktree installs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,1 @@
-{
-  "worktree": {
-    "symlinkDirectories": [
-      "node_modules",
-      "apps/web/node_modules",
-      "packages/ui/node_modules"
-    ]
-  }
-}
+{}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,15 +55,15 @@ git commit -m "<type>(<scope>): <description>"
 
 ## Parallel work in worktrees
 
-Sessions and subagents can run in isolated git worktrees under `.claude/worktrees/`. Setup is already committed:
+Sessions and subagents can run in isolated git worktrees under `.claude/worktrees/`.
 
 - `.worktreeinclude` copies `apps/web/.env.local` into every new worktree.
-- `.claude/settings.json` symlinks the `node_modules` directories back to the main checkout, so no `bun install` is needed per worktree.
+- **Run `bun install` from the worktree root before dev/build/test.** Each worktree gets its own real `node_modules`; bun's global cache keeps repeat installs fast.
+- Do **not** symlink `node_modules` between worktrees or back to the main checkout. The root `node_modules` contains bun's workspace links (e.g. `@vita-os/ui -> packages/ui`), so a symlinked install silently resolves `@vita-os/*` imports to the main checkout's package source instead of the worktree's.
 
-Two rules when splitting work across worktrees:
+One rule when splitting work across worktrees:
 
 - **Serialize Convex changes.** There is a single Convex deployment. Never run two agents that both touch `apps/web/convex/schema.ts` or push functions — they overwrite each other's deployment. Parallelize UI and client-side logic only.
-- **One dependency change at a time.** `node_modules` is symlinked and therefore shared across worktrees, so a `bun add` in one worktree mutates all of them. Keep dependency changes to a single agent per batch.
 
 ## Agent skills
 


### PR DESCRIPTION
Closes #263

## What

- Removes `worktree.symlinkDirectories` (all three entries) from `.claude/settings.json` — new worktrees no longer get `node_modules` symlinked back to the main checkout.
- Rewrites the worktree section of `AGENTS.md` (`CLAUDE.md` symlinks to it): documents `bun install` from the worktree root as the setup step, adds an explicit do-not-symlink note explaining the bun workspace-link failure mode, and drops the now-obsolete "one dependency change at a time" rule.

## Verification

Exercised end-to-end in the worktree this PR was built in:

- Removed the three symlinks and ran a real `bun install` (~1s thanks to bun's global cache; 1247 packages).
- `node_modules/@vita-os/ui` now resolves via a **relative** link to the worktree's own `packages/ui` (`../../../../packages/ui`), not the main checkout.
- End-to-end probe: appended a marker rule to the worktree's `packages/ui/src/styles/globals.css`, built, and confirmed the marker landed in the worktree's `dist` CSS while the main checkout's copy stayed untouched — the exact incident from the issue no longer reproduces.
- `bun run lint`, `bun run build`, and `bun run test:run` (48 files, 237 tests) all pass.

## Notes from review

- The `@vita-os/ui` Vite alias workaround named in the issue never landed on `main` — it lives only on the unmerged branch `worktree-condition-palette-coherence` (bbdc44b), together with a `server.fs.allow` symlink workaround. That branch should drop both when it rebases onto this change, or it reintroduces the workaround with a now-false rationale.
- Pre-existing worktrees keep their old symlinks; to migrate one, delete the three `node_modules` symlinks and run `bun install`.
- Parallel `bun add` in two worktrees no longer mutates shared state, but divergent branches touching `package.json`/`bun.lock` will still produce ordinary lockfile merge conflicts — a normal git concern, no longer a coordination rule.
- Turbo's cache is shared across worktrees (content-addressed), which remains safe and keeps worktree builds fast.