### PR TITLE
chore(worktrees): fetch origin before EnterWorktree creates a worktree

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,15 @@
-{}
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "git fetch origin --quiet || true"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add a `PreToolUse` hook on `EnterWorktree` that runs `git fetch origin --quiet || true`, so worktrees created in-session (including background jobs) always branch from the latest remote main instead of a possibly-stale `origin/HEAD`.

## Context
With the default `worktree.baseRef: "fresh"`, Claude Code only auto-fetches when the repo hasn't been fetched in the last 24 hours, so a worktree can start up to a day behind remote main. This hook forces a fetch right before every `EnterWorktree` call. The `|| true` keeps worktree creation working offline (a non-zero hook exit would block the tool).

Worktrees created at launch via `claude --worktree` don't trigger tool hooks and still rely on the built-in 24-hour auto-fetch.

Follows up on #264, which removed the `symlinkDirectories` config from this file.