### PR TITLE
feat(dashboard): mobile Plan canvas — PlanSchedule agenda (#268)

### DIFF
--- a/apps/web/src/features/dashboard/components/dashboard-model.test.ts
+++ b/apps/web/src/features/dashboard/components/dashboard-model.test.ts
@@ -1,68 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  followUpDateLabel,
-  groupDashboardThreads,
-  type DashboardThread,
-} from "./dashboard-model";
-
-function thread(
-  id: string,
-  fields: Partial<DashboardThread> = {},
-): DashboardThread {
-  return {
-    id,
-    title: id,
-    slug: id,
-    areaId: "area",
-    order: 0,
-    ...fields,
-  };
-}
-
-describe("groupDashboardThreads", () => {
-  const today = new Date(2026, 6, 17, 12).getTime();
-  const yesterday = new Date(2026, 6, 16, 18).getTime();
-  const older = new Date(2026, 6, 10, 8).getTime();
-  const tomorrow = new Date(2026, 6, 18, 8).getTime();
-
-  it("gives Follow-up precedence and uses local-day boundaries", () => {
-    const groups = groupDashboardThreads(
-      [
-        thread("overdue", { followUp: yesterday, nextMove: "Call" }),
-        thread("today", { followUp: today }),
-        thread("tomorrow", { followUp: tomorrow }),
-      ],
-      today,
-    );
-
-    expect(groups.overdue.map((item) => item.id)).toEqual(["overdue"]);
-    expect(groups.upcoming.map((item) => item.id)).toEqual([
-      "today",
-      "tomorrow",
-    ]);
-    expect(groups.withNextMoves).toEqual([]);
-  });
-
-  it("orders Follow-ups chronologically and classifies undated Threads", () => {
-    const groups = groupDashboardThreads(
-      [
-        thread("newer-overdue", { followUp: yesterday }),
-        thread("older-overdue", { followUp: older }),
-        thread("next-move", { nextMove: "Send the form" }),
-        thread("open"),
-      ],
-      today,
-    );
-
-    expect(groups.overdue.map((item) => item.id)).toEqual([
-      "older-overdue",
-      "newer-overdue",
-    ]);
-    expect(groups.withNextMoves.map((item) => item.id)).toEqual(["next-move"]);
-    expect(groups.open.map((item) => item.id)).toEqual(["open"]);
-  });
-});
+import { followUpDateLabel } from "./dashboard-model";
 
 describe("followUpDateLabel", () => {
   const today = new Date(2026, 6, 17, 12).getTime();

--- a/apps/web/src/features/dashboard/components/dashboard-model.ts
+++ b/apps/web/src/features/dashboard/components/dashboard-model.ts
@@ -1,7 +1,6 @@
 import type { AreaIcon } from "@convex/lib/areaIcons";
 import type { Condition } from "@convex/lib/condition";
 
-import { groupThreadsByAttention } from "@convex/lib/attentionOrdering";
 import { format } from "date-fns";
 
 export const DAY = 24 * 60 * 60 * 1000;
@@ -50,34 +49,10 @@ export interface DashboardOverviewData {
   threads: DashboardThread[];
 }
 
-export interface DashboardThreadGroups {
-  open: DashboardThread[];
-  overdue: DashboardThread[];
-  upcoming: DashboardThread[];
-  withNextMoves: DashboardThread[];
-}
-
-export function groupDashboardThreads(
-  threads: DashboardThread[],
-  currentDate: number,
-): DashboardThreadGroups {
-  return groupThreadsByAttention(threads, currentDate);
-}
-
 export function followUpDateLabel(timestamp: number, currentDate: number) {
   const difference = dayDifference(timestamp, currentDate);
   if (difference === 0) return "Today";
   if (difference === 1) return "Tomorrow";
-  return format(new Date(timestamp), "MMM d");
-}
-
-export function taskDateLabel(timestamp: number, currentDate: number) {
-  const difference = dayDifference(timestamp, currentDate);
-  if (difference === 0) return "Today";
-  if (difference === 1) return "Tomorrow";
-  if (difference === -1) return "Yesterday";
-  if (difference < 0) return `${Math.abs(difference)} days ago`;
-  if (difference <= 7) return `In ${difference} days`;
   return format(new Date(timestamp), "MMM d");
 }
 

--- a/apps/web/src/features/dashboard/components/dashboard-overview.test.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-overview.test.tsx
@@ -2,7 +2,7 @@ import type { ComponentPropsWithoutRef } from "react";
 
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { DashboardOverviewData, DashboardThread } from "./dashboard-model";
 
@@ -21,24 +21,33 @@ vi.mock("@tanstack/react-router", () => ({
   ),
 }));
 
-// The Plan canvas is a live surface of its own — Convex mutations, drag and
-// drop, the Thread rail. Here we only care that the dashboard hands it the
-// full open set.
-vi.mock("@/features/dashboard/plan", () => ({
-  PlanCanvas: ({
-    tasks,
-    threads,
-  }: {
-    tasks: unknown[];
-    threads: unknown[];
-  }) => (
-    <div data-testid="plan-canvas">
-      {threads.length} Threads · {tasks.length} Tasks
-    </div>
-  ),
-}));
+// Both Plan surfaces are live surfaces of their own — Convex mutations, drag
+// and drop, the Thread rail. Here we only care which one the dashboard mounts
+// and that it hands it the full open set.
+vi.mock("@/features/dashboard/plan", () => {
+  const stub =
+    (testId: string) =>
+    ({ tasks, threads }: { tasks: unknown[]; threads: unknown[] }) => (
+      <div data-testid={testId}>
+        {threads.length} Threads · {tasks.length} Tasks
+      </div>
+    );
+  return {
+    PlanCanvas: stub("plan-canvas"),
+    PlanSchedule: stub("plan-schedule"),
+  };
+});
 
 const currentDate = new Date(2026, 6, 17, 12).getTime();
+
+/** `useIsCompact` reads `innerWidth`; jsdom's default is a desktop width. */
+function compactViewport() {
+  vi.stubGlobal("innerWidth", 390);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 function thread(
   id: string,
@@ -165,6 +174,38 @@ describe("DashboardOverview", () => {
     expect(screen.getByTestId("plan-canvas")).toHaveTextContent(
       "2 Threads · 1 Tasks",
     );
+    expect(screen.queryByTestId("plan-schedule")).toBeNull();
+  });
+
+  it("swaps the canvas for the schedule on a phone-sized viewport", () => {
+    compactViewport();
+    render(
+      <DashboardOverview
+        overview={dashboard({
+          threads: [
+            thread("Check renewal", { followUp: currentDate }),
+            thread("Without date"),
+          ],
+          inbox: {
+            items: [
+              {
+                id: "task",
+                text: "Renew passport",
+                createdAt: currentDate,
+              },
+            ],
+            totalOpen: 1,
+          },
+        })}
+        currentDate={currentDate}
+        onCreateArea={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("plan-schedule")).toHaveTextContent(
+      "2 Threads · 1 Tasks",
+    );
+    expect(screen.queryByTestId("plan-canvas")).toBeNull();
   });
 
   it("renders Recent activity as a strip below the canvas", () => {
@@ -208,169 +249,7 @@ describe("DashboardOverview", () => {
     expect(screen.queryByText("Recent activity")).toBeNull();
   });
 
-  it("keeps the attention list and Inbox in the mobile-only block", () => {
-    render(
-      <DashboardOverview
-        overview={dashboard({
-          threads: [thread("Insurance appeal")],
-          inbox: {
-            items: [
-              {
-                id: "task",
-                text: "Renew passport",
-                when: currentDate,
-                createdAt: currentDate,
-              },
-            ],
-            totalOpen: 3,
-          },
-        })}
-        currentDate={currentDate}
-        onCreateArea={vi.fn()}
-      />,
-    );
-
-    const threadRow = screen.getByRole("link", { name: /insurance appeal/i });
-    expect(threadRow.closest(".sm\\:hidden")).not.toBeNull();
-
-    const inboxLink = screen.getByRole("link", { name: /inbox 3/i });
-    expect(inboxLink).toHaveAttribute("href", "/inbox");
-    expect(inboxLink.closest(".sm\\:hidden")).not.toBeNull();
-    expect(screen.getByText("2 more Tasks in Inbox")).toBeVisible();
-
-    expect(
-      screen.getByTestId("plan-canvas").closest(".sm\\:hidden"),
-    ).toBeNull();
-  });
-
-  it("shows date rails and keeps Open Threads inline", () => {
-    render(
-      <DashboardOverview
-        overview={dashboard({
-          threads: [
-            thread("Due today", { followUp: currentDate }),
-            thread("Due tomorrow", {
-              followUp: new Date(2026, 6, 18, 12).getTime(),
-            }),
-            thread("Due later", {
-              followUp: new Date(2026, 6, 20, 12).getTime(),
-            }),
-            thread("Without date"),
-          ],
-        })}
-        currentDate={currentDate}
-        onCreateArea={vi.fn()}
-      />,
-    );
-
-    expect(screen.getByText("Due today")).toBeVisible();
-    expect(screen.getByText("18")).toBeVisible();
-    expect(screen.getByText("20")).toBeVisible();
-    expect(screen.getByRole("link", { name: /without date/i })).toBeVisible();
-  });
-
-  it("places upcoming Follow-ups before Next Moves and Open Threads", () => {
-    render(
-      <DashboardOverview
-        overview={dashboard({
-          threads: [
-            thread("Overdue thread", {
-              followUp: new Date(2026, 6, 16).getTime(),
-            }),
-            thread("Next Move thread", { nextMove: "Make the call" }),
-            thread("Upcoming thread", {
-              followUp: new Date(2026, 6, 18).getTime(),
-            }),
-            thread("Open thread"),
-          ],
-        })}
-        currentDate={currentDate}
-        onCreateArea={vi.fn()}
-      />,
-    );
-
-    const overdue = screen.getByText("Overdue thread");
-    const upcoming = screen.getByText("Upcoming thread");
-    const nextMoves = screen.getByText("Next Move thread");
-    const open = screen.getByText("Open thread");
-
-    expect(overdue.compareDocumentPosition(upcoming)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
-    expect(upcoming.compareDocumentPosition(nextMoves)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
-    expect(nextMoves.compareDocumentPosition(open)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
-  });
-
-  it("caps plain Open Threads behind a Show all control", async () => {
-    const user = userEvent.setup();
-    render(
-      <DashboardOverview
-        overview={dashboard({
-          threads: [
-            thread("Overdue thread", {
-              followUp: new Date(2026, 6, 16).getTime(),
-            }),
-            thread("Next Move thread", { nextMove: "Make the call" }),
-            ...Array.from({ length: 7 }, (_, index) =>
-              thread(`Open ${index + 1}`),
-            ),
-          ],
-        })}
-        currentDate={currentDate}
-        onCreateArea={vi.fn()}
-      />,
-    );
-
-    expect(screen.getByText("Overdue thread")).toBeVisible();
-    expect(screen.getByText("Next Move thread")).toBeVisible();
-    expect(screen.getByText("Open 5")).toBeVisible();
-    expect(screen.queryByText("Open 6")).toBeNull();
-
-    const showAll = screen.getByRole("button", { name: /show all/i });
-    expect(showAll).toHaveTextContent("2 more");
-
-    await user.click(showAll);
-
-    expect(screen.getByText("Open 6")).toBeVisible();
-    expect(screen.getByText("Open 7")).toBeVisible();
-    expect(screen.queryByRole("button", { name: /show all/i })).toBeNull();
-    expect(
-      screen
-        .getByText("Open 5")
-        .compareDocumentPosition(screen.getByText("Open 6")),
-    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
-  });
-
-  it("never caps attention-bearing Threads and skips the control at the cap", () => {
-    render(
-      <DashboardOverview
-        overview={dashboard({
-          threads: [
-            ...Array.from({ length: 7 }, (_, index) =>
-              thread(`Overdue ${index + 1}`, {
-                followUp: new Date(2026, 6, 16).getTime(),
-              }),
-            ),
-            ...Array.from({ length: 5 }, (_, index) =>
-              thread(`Open ${index + 1}`),
-            ),
-          ],
-        })}
-        currentDate={currentDate}
-        onCreateArea={vi.fn()}
-      />,
-    );
-
-    expect(screen.getByText("Overdue 7")).toBeVisible();
-    expect(screen.getByText("Open 5")).toBeVisible();
-    expect(screen.queryByRole("button", { name: /show all/i })).toBeNull();
-  });
-
-  it("preserves Area onboarding and the no-Thread state", async () => {
+  it("preserves Area onboarding until the first Area exists", async () => {
     const user = userEvent.setup();
     const onCreateArea = vi.fn();
     const { rerender } = render(
@@ -383,6 +262,7 @@ describe("DashboardOverview", () => {
 
     await user.click(screen.getByRole("button", { name: "Create Life Area" }));
     expect(onCreateArea).toHaveBeenCalledOnce();
+    expect(screen.queryByTestId("plan-canvas")).toBeNull();
 
     rerender(
       <DashboardOverview
@@ -392,8 +272,10 @@ describe("DashboardOverview", () => {
       />,
     );
     expect(
-      screen.getByText("Your Life Areas are clear for now."),
-    ).toBeVisible();
-    expect(screen.getByText("Inbox is clear")).toBeVisible();
+      screen.queryByRole("button", { name: "Create Life Area" }),
+    ).toBeNull();
+    expect(screen.getByTestId("plan-canvas")).toHaveTextContent(
+      "0 Threads · 0 Tasks",
+    );
   });
 });

--- a/apps/web/src/features/dashboard/components/dashboard-overview.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-overview.tsx
@@ -1,27 +1,17 @@
 import { Link } from "@tanstack/react-router";
-import { Badge } from "@vita-os/ui/components/badge";
 import { Button } from "@vita-os/ui/components/button";
 import { format, formatDistance } from "date-fns";
-import { ChevronRight, History, Inbox } from "lucide-react";
-import { useState } from "react";
+import { History } from "lucide-react";
 
 import { AreaIcon } from "@/features/areas/components/area-icon";
-import {
-  AttentionEmpty,
-  AttentionList,
-  AttentionRow,
-  type AttentionRowModel,
-} from "@/features/attention-list";
-import { PlanCanvas } from "@/features/dashboard/plan";
-import { flatListClassName } from "@/lib/flat-surface";
+import { PlanCanvas, PlanSchedule } from "@/features/dashboard/plan";
+import { useIsCompact } from "@/hooks/use-mobile";
 
 import { AreaConditionStrip } from "./area-condition-strip";
 import {
   type DashboardArea,
   type DashboardOverviewData,
   type DashboardThread,
-  groupDashboardThreads,
-  taskDateLabel,
 } from "./dashboard-model";
 
 interface DashboardOverviewProps {
@@ -36,6 +26,7 @@ export function DashboardOverview({
   onCreateArea,
 }: DashboardOverviewProps) {
   const areaById = new Map(overview.areas.map((area) => [area.id, area]));
+  const compact = useIsCompact();
 
   if (overview.areas.length === 0) {
     return (
@@ -61,38 +52,36 @@ export function DashboardOverview({
       <DashboardHeader currentDate={currentDate} />
       <AreaConditionStrip areas={overview.areas} />
 
-      <div className="hidden sm:flex sm:flex-col sm:gap-6">
-        <PlanCanvas
+      {/* Two shapes of the same Plan. A phone gets the vertical schedule; the
+          branch is real, not a CSS switch, so only the mounted one runs its
+          scroll and observer effects. */}
+      {compact ? (
+        <PlanSchedule
           areas={overview.areas}
           currentDate={currentDate}
           tasks={overview.inbox.items}
           threads={overview.threads}
         />
-        {overview.recentActivity.length > 0 && (
-          <RecentActivity
-            entries={overview.recentActivity}
-            areaById={areaById}
-            threadById={
-              new Map(overview.threads.map((thread) => [thread.id, thread]))
-            }
+      ) : (
+        <>
+          <PlanCanvas
+            areas={overview.areas}
             currentDate={currentDate}
+            tasks={overview.inbox.items}
+            threads={overview.threads}
           />
-        )}
-      </div>
-
-      {/* Interim mobile dashboard until the canvas adapts to small screens (#268). */}
-      <div className="flex flex-col gap-6 sm:hidden">
-        <DashboardThreadList
-          threads={overview.threads}
-          areaById={areaById}
-          currentDate={currentDate}
-        />
-        <InboxSection
-          items={overview.inbox.items}
-          totalOpen={overview.inbox.totalOpen}
-          currentDate={currentDate}
-        />
-      </div>
+          {overview.recentActivity.length > 0 && (
+            <RecentActivity
+              entries={overview.recentActivity}
+              areaById={areaById}
+              threadById={
+                new Map(overview.threads.map((thread) => [thread.id, thread]))
+              }
+              currentDate={currentDate}
+            />
+          )}
+        </>
+      )}
     </div>
   );
 }
@@ -118,131 +107,6 @@ function DashboardHeader({ currentDate }: { currentDate: number }) {
         </span>
       </time>
     </header>
-  );
-}
-
-const OPEN_THREAD_CAP = 5;
-
-function DashboardThreadList({
-  areaById,
-  currentDate,
-  threads,
-}: {
-  areaById: Map<string, DashboardArea>;
-  currentDate: number;
-  threads: DashboardThread[];
-}) {
-  const [showAllOpen, setShowAllOpen] = useState(false);
-
-  if (threads.length === 0) {
-    return <AttentionEmpty>Your Life Areas are clear for now.</AttentionEmpty>;
-  }
-
-  const groups = groupDashboardThreads(threads, currentDate);
-  const visibleOpen = showAllOpen
-    ? groups.open
-    : groups.open.slice(0, OPEN_THREAD_CAP);
-  const hiddenOpenCount = groups.open.length - visibleOpen.length;
-  const flatThreads = [
-    ...groups.overdue,
-    ...groups.upcoming,
-    ...groups.withNextMoves,
-    ...visibleOpen,
-  ];
-
-  return (
-    <AttentionList>
-      {flatThreads.map((thread) => {
-        const area = areaById.get(thread.areaId);
-        if (!area) return null;
-
-        const row: AttentionRowModel = {
-          title: thread.title,
-          detail: thread.nextMove ?? thread.summary,
-          detailKind: thread.nextMove ? "next-move" : "summary",
-          area: { icon: area.icon, name: area.name },
-          when: thread.followUp,
-          linkTo: { threadSlug: thread.slug },
-        };
-
-        return <AttentionRow key={thread.id} now={currentDate} row={row} />;
-      })}
-      {hiddenOpenCount > 0 && (
-        <button
-          type="button"
-          onClick={() => setShowAllOpen(true)}
-          className="flex w-full items-center gap-2 py-2 text-left text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <ChevronRight className="size-3.5" />
-          Show all
-          <span className="tabular-nums opacity-60">
-            {hiddenOpenCount} more
-          </span>
-          <div className="ml-1 h-px flex-1 bg-border/40" />
-        </button>
-      )}
-    </AttentionList>
-  );
-}
-
-/**
- * The mobile dashboard keeps the Inbox to a glance; the Plan canvas is what
- * needs the full set of Tasks, so the query hands over every Open Task and
- * the cap lives here — the same arrangement plain Open Threads use above.
- */
-const INBOX_PREVIEW = 3;
-
-function InboxSection({
-  items,
-  totalOpen,
-  currentDate,
-}: {
-  items: DashboardOverviewData["inbox"]["items"];
-  totalOpen: number;
-  currentDate: number;
-}) {
-  const preview = items.slice(0, INBOX_PREVIEW);
-  const remaining = Math.max(0, totalOpen - preview.length);
-
-  return (
-    <section>
-      <Link
-        to="/inbox"
-        className="group mb-2 flex items-center gap-2 rounded-md outline-none hover:text-primary focus-visible:ring-2 focus-visible:ring-ring"
-      >
-        <Inbox className="size-3.5 text-muted-foreground" />
-        <h2 className="text-sm font-semibold">Inbox</h2>
-        <span className="text-xs tabular-nums text-muted-foreground">
-          {totalOpen}
-        </span>
-        <ChevronRight className="ml-auto size-3.5 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-      </Link>
-      {totalOpen === 0 ? (
-        <p className="py-2 text-sm text-muted-foreground">Inbox is clear</p>
-      ) : (
-        <>
-          <div className={flatListClassName}>
-            {preview.map((task) => (
-              <div key={task.id} className="flex items-center gap-2 px-1 py-2">
-                <span className="min-w-0 flex-1 truncate text-sm">
-                  {task.text}
-                </span>
-                {task.when != null && (
-                  <Badge variant="outline">
-                    {taskDateLabel(task.when, currentDate)}
-                  </Badge>
-                )}
-              </div>
-            ))}
-          </div>
-          {remaining > 0 && (
-            <p className="mt-2 text-xs text-muted-foreground">
-              {remaining} more {remaining === 1 ? "Task" : "Tasks"} in Inbox
-            </p>
-          )}
-        </>
-      )}
-    </section>
   );
 }
 

--- a/apps/web/src/features/dashboard/plan/index.ts
+++ b/apps/web/src/features/dashboard/plan/index.ts
@@ -1,1 +1,2 @@
 export { PlanCanvas } from "./plan-canvas";
+export { PlanSchedule } from "./plan-schedule";

--- a/apps/web/src/features/dashboard/plan/plan-model.ts
+++ b/apps/web/src/features/dashboard/plan/plan-model.ts
@@ -121,9 +121,10 @@ export type Density = "comfortable" | "compact";
 
 /** Days shown at full tick density before the axis coarsens into "Later". */
 export const NEAR_DAYS = 14;
-/** The axis always reaches this far so there is somewhere to plan into. */
-const MIN_HORIZON = 27;
-const MAX_HORIZON = 90;
+/** Every day surface reaches this far so there is somewhere to plan into. */
+export const MIN_HORIZON = 27;
+/** And no further, however distant the furthest planned day is. */
+export const MAX_HORIZON = 90;
 
 export const HEADER_WIDTH = 178;
 /** Below the md breakpoint the lane header stacks icon over name and narrows. */
@@ -394,7 +395,8 @@ export function buildLanes(
   return { areaLanes, inbox };
 }
 
-function byDateThenTitle(a: PlanItem, b: PlanItem): number {
+/** Reading order inside any one slot: earliest first, then alphabetical. */
+export function byDateThenTitle(a: PlanItem, b: PlanItem): number {
   const left = a.date ?? 0;
   const right = b.date ?? 0;
   if (left !== right) return left - right;
@@ -465,12 +467,65 @@ export interface DropPlan {
   valid: boolean;
 }
 
+/** The date half of a drop, with nothing said about lanes or Areas. */
+export interface DayDropPlan {
+  /** Names the exact day, "No date", or why the drop is refused. */
+  caption: string;
+  /** The drop takes the date off the item. */
+  clears: boolean;
+  /** The day the drop writes; undefined when it clears. */
+  date?: number;
+  /** The item is not already sitting in the slot it would land in. */
+  reschedule: boolean;
+  valid: boolean;
+}
+
+/**
+ * What a drop means *as a date* — the one rule every Plan surface shares.
+ *
+ * `from` and `to` are slot keys: a day key (`d3`), `"none"`, or `"overdue"`.
+ * `dayAtKey` resolves a day key to the timestamp that slot writes, which is
+ * all a surface has to supply — the canvas looks it up on its axis, the phone
+ * schedule counts days off `now`.
+ *
+ * The past is not a target: a waiting bay shows a debt, it does not accept new
+ * plans. A no-op drop still comes back as a plan (`reschedule: false`) rather
+ * than as nothing, so a caller that has its own reason to act on it — the
+ * canvas moving a Thread's Area without touching its day — can.
+ */
+export function planDayDrop(
+  from: string,
+  to: string,
+  dayAtKey: (key: string) => number | undefined,
+): DayDropPlan | null {
+  if (to === "overdue") {
+    return {
+      caption: "Can't plan into the past",
+      clears: false,
+      reschedule: false,
+      valid: false,
+    };
+  }
+
+  const clears = to === "none";
+  const date = clears ? undefined : dayAtKey(to);
+  // A day the surface does not carry is not a drop at all.
+  if (!clears && date == null) return null;
+
+  return {
+    caption: clears ? "No date" : dayCaption(date!),
+    clears,
+    date,
+    reschedule: to !== from,
+    valid: true,
+  };
+}
+
 /**
  * What would happen if the drag ended right now.
  *
- * The caption always names the exact calendar day — never a horizon, never
- * "somewhere next week". The past is not a target: a lane's waiting bay shows
- * a debt, it does not accept new plans.
+ * The date half is `planDayDrop`'s; what this adds is the lane half — the
+ * Area a Thread would land in, and the two crossings the canvas refuses.
  */
 export function planDrop(
   drag: DragState,
@@ -479,6 +534,13 @@ export function planDrop(
 ): DropPlan | null {
   const { overLaneId, overSlotKey } = drag;
   if (!overLaneId || !overSlotKey) return null;
+
+  const day = planDayDrop(
+    drag.slotKey,
+    overSlotKey,
+    (key) => axis.days.find((entry) => entry.key === key)?.at,
+  );
+  if (!day) return null;
 
   const blocked = (caption: string): DropPlan => ({
     caption,
@@ -490,7 +552,7 @@ export function planDrop(
     valid: false,
   });
 
-  if (overSlotKey === "overdue") return blocked("Can't plan into the past");
+  if (!day.valid) return blocked(day.caption);
 
   const wrongLane =
     drag.kind === "task"
@@ -504,29 +566,20 @@ export function planDrop(
     );
   }
 
-  const clears = overSlotKey === "none";
-  const day = clears
-    ? undefined
-    : axis.days.find((entry) => entry.key === overSlotKey);
-  if (!clears && !day) return null;
-
-  const reschedule = overSlotKey !== drag.slotKey;
   const movedLane = overLaneId !== drag.laneId;
-  const when = clears ? "No date" : dayCaption(day!.at);
-
-  if (!reschedule && !movedLane) return null;
+  if (!day.reschedule && !movedLane) return null;
 
   return {
     areaMove: movedLane ? overLaneId : undefined,
     caption: movedLane
-      ? reschedule
-        ? `${areaName(overLaneId)} · ${when}`
+      ? day.reschedule
+        ? `${areaName(overLaneId)} · ${day.caption}`
         : areaName(overLaneId)
-      : when,
-    clears,
-    date: day?.at,
+      : day.caption,
+    clears: day.clears,
+    date: day.date,
     laneId: overLaneId,
-    reschedule,
+    reschedule: day.reschedule,
     slotKey: overSlotKey,
     tone: movedLane ? "move" : "default",
     valid: true,

--- a/apps/web/src/features/dashboard/plan/plan-schedule-model.test.ts
+++ b/apps/web/src/features/dashboard/plan/plan-schedule-model.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import type { PlanItem } from "./plan-model";
+import type { ScheduleRow } from "./plan-schedule-model";
+
+import { dayAt, MAX_HORIZON, MIN_HORIZON, NEAR_DAYS } from "./plan-model";
+import { buildSchedule, planScheduleDrop } from "./plan-schedule-model";
+
+/** A Thursday in August, so the schedule crosses into September inside MIN. */
+const now = new Date(2026, 7, 6, 9).getTime();
+
+function item(fields: Partial<PlanItem> & { id: string }): PlanItem {
+  return { kind: "thread", title: fields.id, ...fields };
+}
+
+const dayRows = (rows: ScheduleRow[]) =>
+  rows.filter((row) => row.kind === "day").map((row) => row.offset);
+
+const gapRows = (rows: ScheduleRow[]) =>
+  rows
+    .filter((row) => row.kind === "gap")
+    .map((row) => [row.from, row.to] as const);
+
+const monthRows = (rows: ScheduleRow[]) =>
+  rows.filter((row) => row.kind === "month").map((row) => row.label);
+
+describe("buildSchedule", () => {
+  it("buckets by day and reads earliest first inside a day", () => {
+    const schedule = buildSchedule(
+      [
+        item({ date: dayAt(2, now) + 6 * 60 * 60 * 1000, id: "afternoon" }),
+        item({ date: dayAt(2, now), id: "morning" }),
+        item({ date: dayAt(2, now), id: "also morning" }),
+        item({ date: dayAt(-3, now), id: "late" }),
+        item({ id: "undated" }),
+      ],
+      now,
+    );
+
+    expect(schedule.byDay.get("d2")?.map((entry) => entry.id)).toEqual([
+      "also morning",
+      "morning",
+      "afternoon",
+    ]);
+    expect(schedule.overdue.map((entry) => entry.id)).toEqual(["late"]);
+    expect(schedule.none.map((entry) => entry.id)).toEqual(["undated"]);
+    expect(schedule.total).toBe(5);
+  });
+
+  it("prints every day of the near horizon, empty ones included", () => {
+    const rows = buildSchedule(
+      [item({ date: dayAt(3, now), id: "one" })],
+      now,
+    ).rows;
+
+    expect(dayRows(rows).slice(0, NEAR_DAYS)).toEqual(
+      Array.from({ length: NEAR_DAYS }, (_, offset) => offset),
+    );
+  });
+
+  it("folds the quiet stretches past the near horizon into one row", () => {
+    const rows = buildSchedule(
+      [item({ date: dayAt(NEAR_DAYS + 5, now), id: "far" })],
+      now,
+    ).rows;
+
+    expect(gapRows(rows)).toEqual([
+      [NEAR_DAYS, NEAR_DAYS + 4],
+      [NEAR_DAYS + 6, MIN_HORIZON],
+    ]);
+    expect(dayRows(rows)).toContain(NEAR_DAYS + 5);
+  });
+
+  it("keeps today on the list however empty the schedule is", () => {
+    const rows = buildSchedule([], now).rows;
+
+    expect(dayRows(rows)).toContain(0);
+    expect(gapRows(rows)).toEqual([[NEAR_DAYS, MIN_HORIZON]]);
+  });
+
+  it("reaches the minimum horizon and stops at the maximum", () => {
+    expect(dayRows(buildSchedule([], now).rows).at(-1)).toBe(NEAR_DAYS - 1);
+    expect(gapRows(buildSchedule([], now).rows).at(-1)?.[1]).toBe(MIN_HORIZON);
+
+    const far = buildSchedule(
+      [item({ date: dayAt(MAX_HORIZON + 40, now), id: "distant" })],
+      now,
+    );
+
+    expect(dayRows(far.rows).at(-1)).toBe(MAX_HORIZON);
+    // Past the horizon piles onto the last day it prints, rather than vanishing.
+    expect(far.byDay.get(`d${MAX_HORIZON}`)?.map((entry) => entry.id)).toEqual([
+      "distant",
+    ]);
+  });
+
+  it("bands each month it reaches, the first one included", () => {
+    // 26 days on from 6 August is 1 September, so the band lands on a printed
+    // day rather than inside a folded gap.
+    const rows = buildSchedule(
+      [item({ date: dayAt(26, now), id: "september" })],
+      now,
+    ).rows;
+
+    expect(monthRows(rows)).toEqual(["August 2026", "September 2026"]);
+    expect(rows[0]).toMatchObject({ kind: "month", label: "August 2026" });
+  });
+});
+
+describe("planScheduleDrop", () => {
+  it("names the exact day a drop lands on", () => {
+    const plan = planScheduleDrop("d2", "d4", now);
+
+    expect(plan).toMatchObject({
+      clears: false,
+      reschedule: true,
+      valid: true,
+    });
+    expect(plan!.date).toBe(dayAt(4, now));
+    expect(plan!.caption).toMatch(/^\w{3} \d{1,2} \w{3}$/);
+  });
+
+  it("clears the date on the No-date section", () => {
+    expect(planScheduleDrop("d2", "none", now)).toMatchObject({
+      caption: "No date",
+      clears: true,
+      date: undefined,
+      reschedule: true,
+      valid: true,
+    });
+  });
+
+  it("refuses the past", () => {
+    expect(planScheduleDrop("d2", "overdue", now)).toMatchObject({
+      caption: "Can't plan into the past",
+      reschedule: false,
+      valid: false,
+    });
+  });
+
+  it("still names the day of a drop that changes nothing", () => {
+    expect(planScheduleDrop("d2", "d2", now)).toMatchObject({
+      reschedule: false,
+      valid: true,
+    });
+    expect(planScheduleDrop("none", "none", now)).toMatchObject({
+      reschedule: false,
+    });
+  });
+
+  it("ignores a slot key no day answers to", () => {
+    expect(planScheduleDrop("d2", "elsewhere", now)).toBeNull();
+  });
+});

--- a/apps/web/src/features/dashboard/plan/plan-schedule-model.ts
+++ b/apps/web/src/features/dashboard/plan/plan-schedule-model.ts
@@ -1,0 +1,151 @@
+import { format } from "date-fns";
+
+import type { DayDropPlan, PlanItem } from "./plan-model";
+
+import {
+  byDateThenTitle,
+  dayAt,
+  dayDelta,
+  dayKey,
+  MAX_HORIZON,
+  MIN_HORIZON,
+  NEAR_DAYS,
+  planDayDrop,
+} from "./plan-model";
+
+/**
+ * Model for the Plan schedule — the phone's vertical agenda.
+ *
+ * The canvas compresses its day axis sideways; a phone has no sideways to
+ * spend, so this one runs down the screen and compresses by *folding*: the near
+ * horizon prints every day, empty ones included — a calendar that hides
+ * Thursday because nothing is on it stops being a calendar — and only the quiet
+ * stretches past it collapse into a single "N quiet days" row.
+ *
+ * Same dates, same day keys and the same drop rules as the canvas: everything
+ * here is pure, and the view rebuilds it from the dashboard query on every
+ * render.
+ */
+
+/* -------------------------------------------------------------- schedule -- */
+
+/** One line of the agenda. Days and gaps carry the offsets they stand for. */
+export type ScheduleRow =
+  | { from: number; key: string; kind: "gap"; to: number }
+  | { key: string; kind: "day"; offset: number }
+  | { key: string; kind: "month"; label: string };
+
+export interface Schedule {
+  /** Day key → the items planned on it, earliest first. */
+  byDay: Map<string, PlanItem[]>;
+  none: PlanItem[];
+  overdue: PlanItem[];
+  rows: ScheduleRow[];
+  /** Everything the schedule holds, undated and overdue included. */
+  total: number;
+}
+
+/**
+ * One pass from `PlanItem[]` to the rows the schedule renders.
+ *
+ * `items` is the **visible** set: filtering an Area out empties the days only
+ * it occupied, which lets them fold away like any other quiet day.
+ */
+export function buildSchedule(items: PlanItem[], now: number): Schedule {
+  const byDay = new Map<string, PlanItem[]>();
+  const none: PlanItem[] = [];
+  const overdue: PlanItem[] = [];
+  let furthest = 0;
+
+  for (const item of items) {
+    if (item.date == null) {
+      none.push(item);
+      continue;
+    }
+    const offset = dayDelta(item.date, now);
+    if (offset < 0) {
+      overdue.push(item);
+      continue;
+    }
+    if (offset > furthest) furthest = offset;
+  }
+
+  const horizon = Math.min(MAX_HORIZON, Math.max(MIN_HORIZON, furthest));
+
+  for (const item of items) {
+    if (item.date == null) continue;
+    const offset = dayDelta(item.date, now);
+    if (offset < 0) continue;
+    // Anything past the horizon piles into the last day it prints, so a very
+    // distant date is still reachable rather than dropped.
+    const key = dayKey(Math.min(offset, horizon));
+    const bucket = byDay.get(key);
+    if (bucket) bucket.push(item);
+    else byDay.set(key, [item]);
+  }
+
+  for (const bucket of byDay.values()) bucket.sort(byDateThenTitle);
+  overdue.sort(byDateThenTitle);
+  none.sort(byDateThenTitle);
+
+  const rows: ScheduleRow[] = [];
+  let month = "";
+
+  /** A band whenever the list crosses into a new month, the first included. */
+  function pushMonth(at: number) {
+    const label = monthLabel(at);
+    if (label === month) return;
+    month = label;
+    rows.push({ key: `m${label}`, kind: "month", label });
+  }
+
+  let gapFrom: number | null = null;
+  function flushGap(to: number) {
+    if (gapFrom == null) return;
+    pushMonth(dayAt(gapFrom, now));
+    rows.push({ from: gapFrom, key: `g${gapFrom}`, kind: "gap", to });
+    gapFrom = null;
+  }
+
+  for (let offset = 0; offset <= horizon; offset += 1) {
+    const occupied = (byDay.get(dayKey(offset))?.length ?? 0) > 0;
+    // Today is inside the near horizon, so the present never folds away.
+    if (!occupied && offset >= NEAR_DAYS) {
+      if (gapFrom == null) gapFrom = offset;
+      continue;
+    }
+    flushGap(offset - 1);
+    pushMonth(dayAt(offset, now));
+    rows.push({ key: dayKey(offset), kind: "day", offset });
+  }
+  flushGap(horizon);
+
+  return { byDay, none, overdue, rows, total: items.length };
+}
+
+/** "August 2026" — the band that pins under the app bar. */
+export function monthLabel(at: number): string {
+  return format(new Date(at), "MMMM yyyy");
+}
+
+/* ------------------------------------------------------------------ drop -- */
+
+/**
+ * What a drop on this surface means.
+ *
+ * The schedule has no lanes, so `planDayDrop` is the whole rule set: the past
+ * refuses, No date clears, and a day key names the exact date it writes. A drop
+ * back onto the row it came from comes back as `reschedule: false` — the
+ * caption still names the day, but nothing is written.
+ */
+export function planScheduleDrop(
+  from: string,
+  to: string,
+  now: number,
+): DayDropPlan | null {
+  return planDayDrop(from, to, (key) => {
+    const match = /^d(\d+)$/.exec(key);
+    if (!match) return undefined;
+    return dayAt(Math.min(Number(match[1]), MAX_HORIZON), now);
+  });
+}

--- a/apps/web/src/features/dashboard/plan/plan-schedule.test.tsx
+++ b/apps/web/src/features/dashboard/plan/plan-schedule.test.tsx
@@ -1,0 +1,237 @@
+import { api } from "@convex/_generated/api";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FeedbackProvider } from "@vita-os/ui/lib/feedback";
+import { getFunctionName } from "convex/server";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import type {
+  DashboardArea,
+  DashboardInboxTask,
+  DashboardThread,
+} from "@/features/dashboard/components/dashboard-model";
+
+import { PlanSchedule } from "./plan-schedule";
+
+const mocks = vi.hoisted(() => ({
+  mutations: new Map<string, ReturnType<typeof vi.fn>>(),
+  navigate: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: (reference: Parameters<typeof getFunctionName>[0]) => {
+    const name = getFunctionName(reference);
+    const existing = mocks.mutations.get(name);
+    const mutation =
+      existing ?? vi.fn(() => Promise.resolve(undefined as unknown));
+    mocks.mutations.set(name, mutation);
+    return Object.assign(mutation, { withOptimisticUpdate: () => mutation });
+  },
+}));
+
+/**
+ * The list opens on today, and jsdom ships `window.scrollTo` as a
+ * not-implemented stub that only complains to the virtual console. Replacing it
+ * here keeps the mount effect quiet; `IntersectionObserver` needs no stub — jsdom
+ * has none and the component already guards on that, which is what keeps the
+ * floating Today pill out of these trees.
+ */
+beforeAll(() => {
+  window.scrollTo = vi.fn();
+});
+
+/** A Thursday in August, so the near horizon crosses into September. */
+const now = new Date(2026, 7, 6, 9).getTime();
+const day = (offset: number) => new Date(2026, 7, 6 + offset).getTime();
+
+/** Weekday over day number is the schedule's only date marker. */
+const WEEKDAY = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun)$/;
+
+const NEAR_WEEKDAYS = [
+  "Thu",
+  "Fri",
+  "Sat",
+  "Sun",
+  "Mon",
+  "Tue",
+  "Wed",
+  "Thu",
+  "Fri",
+  "Sat",
+  "Sun",
+  "Mon",
+  "Tue",
+  "Wed",
+];
+
+const areas: DashboardArea[] = [
+  {
+    condition: "healthy",
+    id: "home",
+    name: "Home",
+    order: 1,
+    slug: "home",
+  },
+  {
+    condition: "critical",
+    id: "health",
+    name: "Family Health",
+    order: 0,
+    slug: "family-health",
+  },
+];
+
+const threads: DashboardThread[] = [
+  {
+    areaId: "health",
+    followUp: day(-3),
+    id: "t1",
+    order: 0,
+    slug: "dads-cardiologist",
+    title: "Dad's cardiologist",
+  },
+  {
+    areaId: "home",
+    followUp: day(2),
+    id: "t2",
+    order: 1,
+    slug: "kitchen-faucet",
+    title: "Kitchen faucet",
+  },
+  {
+    areaId: "home",
+    id: "t3",
+    order: 2,
+    slug: "garage-clear-out",
+    title: "Garage clear-out",
+  },
+];
+
+const tasks: DashboardInboxTask[] = [
+  { createdAt: day(-1), id: "k1", text: "Renew passport", when: day(1) },
+];
+
+function renderSchedule() {
+  return render(
+    <FeedbackProvider feedback={{ error: vi.fn(), success: vi.fn() }}>
+      <PlanSchedule
+        areas={areas}
+        currentDate={now}
+        tasks={tasks}
+        threads={threads}
+      />
+    </FeedbackProvider>,
+  );
+}
+
+/** True when `first` sits before `second` in document order. */
+function precedes(first: Element, second: Element) {
+  return Boolean(
+    first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING,
+  );
+}
+
+const weekdayRails = () => screen.getAllByText(WEEKDAY);
+
+describe("PlanSchedule", () => {
+  it("prints the near horizon day by day, today first and empty days kept", () => {
+    renderSchedule();
+
+    const rails = weekdayRails();
+    expect(rails.map((rail) => rail.textContent)).toEqual(NEAR_WEEKDAYS);
+
+    // Today leads the list: Thursday 6 August, the day `now` falls on.
+    expect(within(rails[0].parentElement!).getByText("6")).toBeVisible();
+
+    // A day nobody planned into keeps its rail rather than folding away.
+    expect(within(rails[1].parentElement!).getByText("7")).toBeVisible();
+
+    // Dated work reads down the page in date order.
+    expect(
+      precedes(
+        screen.getByText("Renew passport"),
+        screen.getByText("Kitchen faucet"),
+      ),
+    ).toBe(true);
+  });
+
+  it("puts an overdue Thread in Waiting, above the calendar", () => {
+    renderSchedule();
+
+    const heading = screen.getByText("Waiting");
+    const overdue = screen.getByText("Dad's cardiologist");
+    const firstMonth = screen.getByText("August 2026");
+
+    expect(precedes(heading, overdue)).toBe(true);
+    expect(precedes(overdue, firstMonth)).toBe(true);
+  });
+
+  it("folds an undated Thread away behind its count", () => {
+    renderSchedule();
+
+    const fold = screen.getByRole("button", { name: /No date/ });
+    expect(fold).toHaveAttribute("aria-expanded", "false");
+    expect(within(fold).getByText("1")).toBeVisible();
+    expect(screen.queryByText("Garage clear-out")).toBeNull();
+  });
+
+  it("opens a Thread in place and sends a Task to the Inbox", async () => {
+    const user = userEvent.setup();
+    renderSchedule();
+
+    await user.click(screen.getByText("Kitchen faucet"));
+
+    const [threadCall] = mocks.navigate.mock.calls.at(-1) as [
+      { search: (previous: object) => object; to: string },
+    ];
+    expect(threadCall.to).toBe(".");
+    expect(threadCall.search({ other: 1 })).toEqual({
+      other: 1,
+      thread: "kitchen-faucet",
+    });
+
+    await user.click(screen.getByText("Renew passport"));
+    expect(mocks.navigate).toHaveBeenLastCalledWith({ to: "/inbox" });
+  });
+
+  it("opens a run of quiet days into the same day rows", async () => {
+    const user = userEvent.setup();
+    renderSchedule();
+
+    // Past the near horizon nothing is planned, so the rest of the reach folds.
+    const gap = screen.getByRole("button", { name: /quiet days/ });
+    expect(within(gap).getByText("14")).toBeVisible();
+    expect(screen.queryByText("September 2026")).toBeNull();
+
+    await user.click(gap);
+
+    expect(gap).toHaveAttribute("aria-expanded", "true");
+    expect(weekdayRails()).toHaveLength(NEAR_WEEKDAYS.length + 14);
+    // The run reaches into September, so it brings the next month band with it.
+    expect(screen.getByText("September 2026")).toBeVisible();
+  });
+
+  it("unfolds the No-date section onto its items", async () => {
+    const user = userEvent.setup();
+    renderSchedule();
+
+    await user.click(screen.getByRole("button", { name: /No date/ }));
+
+    expect(screen.getByText("Garage clear-out")).toBeVisible();
+  });
+
+  it("wires both writes to the app's own mutations", () => {
+    renderSchedule();
+
+    expect([...mocks.mutations.keys()]).toEqual(
+      expect.arrayContaining([
+        getFunctionName(api.threads.update),
+        getFunctionName(api.tasks.updateWhen),
+      ]),
+    );
+  });
+});

--- a/apps/web/src/features/dashboard/plan/plan-schedule.tsx
+++ b/apps/web/src/features/dashboard/plan/plan-schedule.tsx
@@ -1,0 +1,973 @@
+import type {
+  DragEndEvent,
+  DragOverEvent,
+  DragStartEvent,
+} from "@dnd-kit/core";
+import type { RefObject } from "react";
+
+import {
+  DndContext,
+  DragOverlay,
+  MouseSensor,
+  pointerWithin,
+  TouchSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { useNavigate } from "@tanstack/react-router";
+import { cn } from "@vita-os/ui/lib/utils";
+import { format } from "date-fns";
+import {
+  Ban,
+  ChevronDown,
+  ChevronUp,
+  CornerDownRight,
+  Inbox,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type {
+  DashboardArea,
+  DashboardInboxTask,
+  DashboardThread,
+} from "@/features/dashboard/components/dashboard-model";
+
+import { AreaIcon } from "@/features/areas/components/area-icon";
+import {
+  conditionIcons,
+  conditionTextClassName,
+} from "@/features/areas/condition-presentation";
+
+import type { PlanItem, PlanItemKind } from "./plan-model";
+
+import { AreaFilterChips } from "./plan-filters";
+import {
+  buildPlanItems,
+  conditionIconTone,
+  conditionRailTone,
+  dayAt,
+  dayKey,
+  waitingLabel,
+} from "./plan-model";
+import {
+  buildSchedule,
+  monthLabel,
+  planScheduleDrop,
+} from "./plan-schedule-model";
+import { usePlanActions } from "./use-plan-actions";
+
+/**
+ * Plan — the phone schedule.
+ *
+ * The canvas's model in the shape every phone already knows: a vertical agenda.
+ * Area collapses from a lane into a chip attribute (condition rail, icon pill,
+ * meta line) and the filter chips do the narrowing lane headers do on desktop —
+ * what changes is the *date furniture*.
+ *
+ * A day is not a banner across the top of its chips: it is a rail down the
+ * left, weekday over day number, drawn identically on every rendered day.
+ * Months announce themselves in a slim band that pins under the app bar. The
+ * near horizon prints every day, empty ones included — an empty Thursday keeps
+ * its whole rail and loses only its chips, so it reads as a place, not an
+ * absence — and only the quiet stretches past that horizon fold into a tappable
+ * "N quiet days".
+ *
+ * The list opens on today and keeps a floating **Today** pill for when you have
+ * wandered off it. A long-press lifts a chip; dropping it on a day writes the
+ * date straight through the app's own mutations, exactly as the canvas does.
+ */
+export function PlanSchedule({
+  areas,
+  currentDate,
+  tasks,
+  threads,
+}: {
+  areas: DashboardArea[];
+  currentDate: number;
+  tasks: DashboardInboxTask[];
+  threads: DashboardThread[];
+}) {
+  const now = currentDate;
+  const navigate = useNavigate();
+  const { planTask, planThread } = usePlanActions();
+
+  const [activeAreas, setActiveAreas] = useState<ReadonlySet<string> | null>(
+    null,
+  );
+  const [drag, setDrag] = useState<ScheduleDrag | null>(null);
+  const [openGaps, setOpenGaps] = useState<ReadonlySet<number>>(
+    () => new Set(),
+  );
+  const [showNoDate, setShowNoDate] = useState(false);
+  const [todayInView, setTodayInView] = useState(true);
+
+  const todayRef = useRef<HTMLDivElement | null>(null);
+  const bandRef = useRef<HTMLDivElement | null>(null);
+
+  /** The same guards as the canvas: 5px for mouse, long-press for touch. */
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 250, tolerance: 8 },
+    }),
+  );
+
+  const areaById = useMemo(
+    () => new Map(areas.map((area) => [area.id, area])),
+    [areas],
+  );
+
+  const items = useMemo(() => buildPlanItems(threads, tasks), [threads, tasks]);
+
+  /** Tasks have no Area, so the Area filter never hides them. */
+  const visible = useMemo(
+    () =>
+      items.filter(
+        (item) =>
+          item.kind === "task" ||
+          activeAreas == null ||
+          (item.areaId != null && activeAreas.has(item.areaId)),
+      ),
+    [items, activeAreas],
+  );
+
+  const schedule = useMemo(() => buildSchedule(visible, now), [visible, now]);
+
+  const areaCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const item of items) {
+      if (item.areaId == null) continue;
+      counts.set(item.areaId, (counts.get(item.areaId) ?? 0) + 1);
+    }
+    return counts;
+  }, [items]);
+
+  /* ------------------------------------------------------------ today -- */
+
+  /**
+   * How much of the top of the viewport is already spoken for. The app bar is
+   * fixed, but the month band under it is type that reflows, so it is measured
+   * rather than assumed.
+   */
+  const topInset = useCallback(
+    () => APP_BAR + (bandRef.current?.offsetHeight ?? 0),
+    [],
+  );
+
+  const scrollToToday = useCallback(
+    (smooth: boolean) => {
+      const node = todayRef.current;
+      if (!node) return;
+      // The list lives in normal page flow, so the window is the scroller.
+      const top =
+        node.getBoundingClientRect().top + window.scrollY - topInset();
+      window.scrollTo({ behavior: smooth ? "smooth" : "auto", top });
+    },
+    [topInset],
+  );
+
+  /** Open on today, the way a calendar app does. */
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => scrollToToday(false));
+    return () => cancelAnimationFrame(frame);
+  }, [scrollToToday]);
+
+  useEffect(() => {
+    const node = todayRef.current;
+    if (!node || typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setTodayInView(entry.isIntersecting),
+      { rootMargin: `-${topInset()}px 0px -25% 0px` },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [topInset]);
+
+  /* ------------------------------------------------------------- open -- */
+
+  function openItem(item: PlanItem) {
+    // Tasks have no rail of their own; the Inbox is where a Task is handled.
+    if (item.kind === "task") {
+      void navigate({ to: "/inbox" });
+      return;
+    }
+    if (item.slug == null) return;
+    void navigate({
+      to: ".",
+      search: (previous) => ({ ...previous, thread: item.slug }),
+    });
+  }
+
+  /* ------------------------------------------------------------- drag -- */
+
+  function handleDragStart(event: DragStartEvent) {
+    const data = event.active.data.current as ScheduleDragData | undefined;
+    if (!data) return;
+    setDrag({ itemId: data.itemId, slotKey: data.slotKey });
+  }
+
+  function handleDragOver(event: DragOverEvent) {
+    const over = event.over?.data.current as ScheduleSlotData | undefined;
+    setDrag((previous) =>
+      previous ? { ...previous, overSlotKey: over?.slotKey } : previous,
+    );
+  }
+
+  /**
+   * The write is decided from the event alone, never from `drag` state: a drop
+   * that lands in the same frame as the last move would otherwise read a stale
+   * hover target and plan the wrong day.
+   */
+  function handleDragEnd(event: DragEndEvent) {
+    setDrag(null);
+
+    const source = event.active.data.current as ScheduleDragData | undefined;
+    const over = event.over?.data.current as ScheduleSlotData | undefined;
+    if (!source || !over) return;
+
+    const plan = planScheduleDrop(source.slotKey, over.slotKey, now);
+    if (!plan?.valid || !plan.reschedule) return;
+
+    const date = plan.clears ? undefined : plan.date;
+    // An item dropped into a folded-away section has to be visible where it
+    // landed, or the drop reads as a deletion.
+    if (plan.clears) setShowNoDate(true);
+
+    if (source.kind === "task") {
+      planTask(source.itemId, date);
+      return;
+    }
+    planThread(source.itemId, { followUp: date });
+  }
+
+  function toggleGap(from: number) {
+    setOpenGaps((previous) => {
+      const next = new Set(previous);
+      if (next.has(from)) next.delete(from);
+      else next.add(from);
+      return next;
+    });
+  }
+
+  const dragging = drag && visible.find((item) => item.id === drag.itemId);
+  const dropPlan =
+    drag?.overSlotKey == null
+      ? null
+      : planScheduleDrop(drag.slotKey, drag.overSlotKey, now);
+
+  const chrome: ScheduleChrome = { areaById, drag, now, onOpen: openItem };
+  const firstBandKey = schedule.rows.find((row) => row.kind === "month")?.key;
+
+  /* ------------------------------------------------------------ render -- */
+
+  return (
+    <section aria-label="Plan" className="flex flex-col gap-2.5">
+      {/* The narrowing that lane headers do on desktop. */}
+      <div className="-mx-1 overflow-x-auto px-1 pb-1 [scrollbar-width:none]">
+        <div className="w-max">
+          <AreaFilterChips
+            active={activeAreas}
+            areas={areas}
+            counts={areaCounts}
+            onChange={setActiveAreas}
+          />
+        </div>
+      </div>
+
+      <DndContext
+        collisionDetection={pointerWithin}
+        sensors={sensors}
+        onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
+        onDragEnd={handleDragEnd}
+        onDragCancel={() => setDrag(null)}
+        accessibility={{
+          screenReaderInstructions: {
+            draggable:
+              "Drag up or down onto a day to reschedule, or onto No date to clear it. Press Enter to open it instead.",
+          },
+        }}
+      >
+        <div className="flex flex-col">
+          {schedule.overdue.length > 0 && (
+            <WaitingSection chrome={chrome} items={schedule.overdue} />
+          )}
+
+          {schedule.rows.map((row) => {
+            if (row.kind === "month") {
+              return (
+                <MonthBand
+                  key={row.key}
+                  bandRef={row.key === firstBandKey ? bandRef : undefined}
+                  label={row.label}
+                />
+              );
+            }
+            if (row.kind === "gap") {
+              return (
+                <GapRow
+                  key={row.key}
+                  chrome={chrome}
+                  from={row.from}
+                  open={openGaps.has(row.from)}
+                  onToggle={() => toggleGap(row.from)}
+                  to={row.to}
+                />
+              );
+            }
+            return (
+              <DayRow
+                key={row.key}
+                chrome={chrome}
+                items={schedule.byDay.get(row.key)}
+                offset={row.offset}
+                rowRef={row.offset === 0 ? todayRef : undefined}
+              />
+            );
+          })}
+
+          <NoDateSection
+            chrome={chrome}
+            items={schedule.none}
+            open={showNoDate}
+            onToggle={() => setShowNoDate((previous) => !previous)}
+          />
+        </div>
+
+        <DragOverlay dropAnimation={null}>
+          {dragging && drag && (
+            <div className="w-[17rem] max-w-[80vw] cursor-grabbing">
+              <ChipSurface
+                areaById={areaById}
+                item={dragging}
+                lifted
+                now={now}
+                slotKey={drag.slotKey}
+              />
+              {dropPlan && (
+                <span
+                  className={cn(
+                    "mt-1.5 ml-1 inline-flex max-w-full items-center gap-1 truncate rounded-full px-2 py-0.5 text-[10px] font-semibold shadow-sm",
+                    dropPlan.valid
+                      ? "bg-foreground text-surface-1"
+                      : cn("bg-surface-2 ring-1 ring-border/50", MUTE_SOFT),
+                  )}
+                >
+                  {dropPlan.valid ? (
+                    <CornerDownRight className="size-2.5 shrink-0" />
+                  ) : (
+                    <Ban className="size-2.5 shrink-0" />
+                  )}
+                  {dropPlan.caption}
+                </span>
+              )}
+            </div>
+          )}
+        </DragOverlay>
+      </DndContext>
+
+      {/* Bottom-right: the mobile tab bar owns the bottom edge and the DEV
+          toolbar owns bottom-centre, so the pill floats clear of both. */}
+      {!todayInView && (
+        <button
+          type="button"
+          onClick={() => scrollToToday(true)}
+          className="fixed right-4 bottom-[calc(5rem+env(safe-area-inset-bottom))] z-30 flex items-center gap-1 rounded-full bg-foreground px-3 py-1.5 font-heading text-[11px] font-semibold tracking-tight text-surface-1 shadow-lg"
+        >
+          <span
+            aria-hidden
+            className="size-1.5 rounded-full bg-brand-gold-strong"
+          />
+          Today
+        </button>
+      )}
+
+      {schedule.total === 0 && (
+        <p
+          className={cn(
+            "mt-3 rounded-2xl border border-dashed p-10 text-center font-heading text-[13px] font-semibold",
+            HAIRLINE,
+          )}
+        >
+          Nothing to plan
+        </p>
+      )}
+    </section>
+  );
+}
+
+/* ------------------------------------------------------------- internals -- */
+
+interface ScheduleDrag {
+  itemId: string;
+  overSlotKey?: string;
+  slotKey: string;
+}
+
+interface ScheduleDragData {
+  itemId: string;
+  kind: PlanItemKind;
+  slotKey: string;
+}
+
+interface ScheduleSlotData {
+  slotKey: string;
+}
+
+/** What every row needs and none of them should have to thread individually. */
+interface ScheduleChrome {
+  areaById: ReadonlyMap<string, DashboardArea>;
+  drag: ScheduleDrag | null;
+  now: number;
+  onOpen: (item: PlanItem) => void;
+}
+
+/** The app bar the month band pins under. */
+const APP_BAR = 48;
+
+/** The date rail. Wide enough for "WED" over a two-digit day in a 24px disc. */
+const RAIL = "w-12 shrink-0";
+
+/**
+ * Every day row clears the rail: 4px lead + 9px weekday + 2px gap + 24px disc
+ * is 39px, rounded to 40. Empty days are the same 40px — the rail sets the
+ * floor, which also makes an empty day a fingertip-sized drop target.
+ */
+const ROW_MIN = "min-h-10";
+
+/* -- The knobs below are the whole visual vocabulary of this surface. -- */
+
+/**
+ * Three fixed muting steps. Every faint tone here picks one of them rather than
+ * inventing an alpha, so "quiet" reads as a ladder, not as noise.
+ */
+const MUTE = "text-muted-foreground";
+const MUTE_SOFT = "text-muted-foreground/70";
+const MUTE_FAINT = "text-muted-foreground/40";
+
+/** One hairline for row separators, gap rows, section borders and rules. */
+const HAIRLINE = "border-border/50";
+const HAIRLINE_BG = "bg-border/50";
+
+/**
+ * Chips are objects, not structure, so their edge sits one step above the
+ * hairline — but it is still a single value shared by both chip kinds.
+ */
+const CHIP_EDGE = "border-border/70";
+
+/** One tracking value for every uppercase micro-label. */
+const CAPS = "font-semibold tracking-[0.1em] uppercase";
+
+/** Gold means "in flight or about to receive" — ghost, armed row, armed section. */
+const ARMED = "bg-brand-gold-strong/15";
+
+/* ------------------------------------------------------------- furniture -- */
+
+/** The one piece of chrome that spans the full width. Pins under the app bar. */
+function MonthBand({
+  bandRef,
+  label,
+}: {
+  bandRef?: RefObject<HTMLDivElement | null>;
+  label: string;
+}) {
+  return (
+    <div
+      ref={bandRef}
+      style={{ top: APP_BAR }}
+      className="sticky z-10 -mx-1 flex items-center gap-2 bg-surface-1/95 px-1 pt-3 pb-1.5 backdrop-blur-sm"
+    >
+      <span className={cn("font-heading text-[11px]", CAPS, MUTE)}>
+        {label}
+      </span>
+      <span aria-hidden className={cn("h-px flex-1", HAIRLINE_BG)} />
+    </div>
+  );
+}
+
+/**
+ * The date marker of the whole surface, and the only one.
+ *
+ * Weekday over day number in a fixed rail, with *identical* layout, type and
+ * x-alignment on every rendered day — occupied, empty, weekend, today. A
+ * quieter day changes only its tone; nothing shifts, nothing shrinks, so a run
+ * of empty Thursdays still scans as the same column of dates.
+ *
+ * Every day number already sits in a 24px disc; today is the one where the disc
+ * is filled. That is the whole today treatment — the phone-calendar idiom, in
+ * the same accent the desktop ruler paints its now-rule with.
+ */
+function DayRail({
+  date,
+  empty,
+  isToday,
+  isWeekend,
+}: {
+  date: Date;
+  empty: boolean;
+  isToday: boolean;
+  isWeekend: boolean;
+}) {
+  /** One step down for a weekend, two for a day with nothing on it. */
+  const dim = isToday ? "none" : empty ? "faint" : isWeekend ? "soft" : "none";
+
+  return (
+    <div className={cn(RAIL, "flex flex-col items-center gap-0.5 pt-1")}>
+      <span
+        className={cn(
+          "text-[9px] leading-none",
+          CAPS,
+          dim === "faint" ? MUTE_FAINT : dim === "soft" ? MUTE_SOFT : MUTE,
+        )}
+      >
+        {format(date, "EEE")}
+      </span>
+      <span
+        className={cn(
+          "flex size-6 items-center justify-center rounded-full text-[13px] leading-none font-semibold tabular-nums",
+          isToday
+            ? "bg-brand-accent-foreground text-surface-1"
+            : dim === "faint"
+              ? MUTE_FAINT
+              : dim === "soft"
+                ? MUTE_SOFT
+                : "text-foreground",
+        )}
+      >
+        {format(date, "d")}
+      </span>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ rows -- */
+
+const NO_ITEMS: PlanItem[] = [];
+
+/**
+ * One calendar day: rail on the left, chips stacked to its right.
+ *
+ * An empty day keeps the row, the rail and the hairline, and loses only the
+ * chips — so the day stays a visible, droppable place roughly a fingertip tall.
+ * Today is the same row, marked: the filled disc in the rail, plus one faint
+ * wash so it can be found while scrolling. Nothing else — no accent rule, no
+ * extra height, no borrowed border colour.
+ */
+function DayRow({
+  chrome,
+  items = NO_ITEMS,
+  offset,
+  rowRef,
+}: {
+  chrome: ScheduleChrome;
+  items?: PlanItem[];
+  offset: number;
+  rowRef?: RefObject<HTMLDivElement | null>;
+}) {
+  const key = dayKey(offset);
+  const date = new Date(dayAt(offset, chrome.now));
+  const isToday = offset === 0;
+  const weekday = date.getDay();
+  const isWeekend = weekday === 0 || weekday === 6;
+  const empty = items.length === 0;
+
+  const { isOver, setNodeRef } = useDroppable({
+    id: `slot::${key}`,
+    data: { slotKey: key } satisfies ScheduleSlotData,
+  });
+  const armed = chrome.drag != null && isOver;
+
+  return (
+    <div
+      ref={(node) => {
+        setNodeRef(node);
+        if (rowRef) rowRef.current = node;
+      }}
+      className={cn(
+        "flex items-stretch rounded-md transition-colors",
+        ROW_MIN,
+        isToday && "bg-brand-accent-foreground/[0.05]",
+        armed && ARMED,
+      )}
+    >
+      <DayRail
+        date={date}
+        empty={empty}
+        isToday={isToday}
+        isWeekend={isWeekend}
+      />
+
+      <div
+        className={cn(
+          "min-w-0 flex-1 border-t pr-0.5 pl-1",
+          armed ? "border-dashed border-brand-gold-strong/70" : HAIRLINE,
+          !empty && "flex flex-col gap-1 py-1.5",
+        )}
+      >
+        {items.map((item) => (
+          <ScheduleChip
+            key={item.id}
+            chrome={chrome}
+            item={item}
+            slotKey={key}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A run of quiet days past the near horizon, as one line. Tapping it opens the
+ * run into the same hairline day rows the near horizon prints, so a far-off
+ * date is reachable without spending a screenful of list on it.
+ */
+function GapRow({
+  chrome,
+  from,
+  onToggle,
+  open,
+  to,
+}: {
+  chrome: ScheduleChrome;
+  from: number;
+  onToggle: () => void;
+  open: boolean;
+  to: number;
+}) {
+  const count = to - from + 1;
+  const offsets: number[] = [];
+  for (let offset = from; offset <= to; offset += 1) offsets.push(offset);
+
+  return (
+    <div className="flex flex-col">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={onToggle}
+        className={cn(
+          "flex items-center border-t border-dashed py-2 text-left",
+          HAIRLINE,
+        )}
+      >
+        <span
+          aria-hidden
+          className={cn(RAIL, "text-center text-[10px]", MUTE_FAINT)}
+        >
+          ···
+        </span>
+        <span
+          className={cn(
+            "flex flex-1 items-center gap-1 pl-1 text-[10px]",
+            MUTE_SOFT,
+          )}
+        >
+          <span className="tabular-nums">{count}</span>
+          {count === 1 ? "quiet day" : "quiet days"}
+          {open ? (
+            <ChevronUp className="size-3" />
+          ) : (
+            <ChevronDown className="size-3" />
+          )}
+        </span>
+      </button>
+
+      {open &&
+        offsets.map((offset) => {
+          const at = dayAt(offset, chrome.now);
+          const crossesMonth = new Date(at).getDate() === 1;
+          return (
+            <div key={dayKey(offset)} className="flex flex-col">
+              {crossesMonth && <MonthBand label={monthLabel(at)} />}
+              <DayRow chrome={chrome} offset={offset} />
+            </div>
+          );
+        })}
+    </div>
+  );
+}
+
+/** Above the months: the debt, not a plan. Never accepts a drop. */
+function WaitingSection({
+  chrome,
+  items,
+}: {
+  chrome: ScheduleChrome;
+  items: PlanItem[];
+}) {
+  const { isOver, setNodeRef } = useDroppable({
+    id: "slot::overdue",
+    data: { slotKey: "overdue" } satisfies ScheduleSlotData,
+  });
+  const rejecting = chrome.drag != null && isOver;
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        "mb-1 rounded-xl bg-condition-attention/[0.07] transition-colors",
+        rejecting && "ring-1 ring-condition-attention/30 ring-inset",
+      )}
+    >
+      <div className="flex items-center gap-2 px-2.5 pt-2 pb-1.5">
+        <span
+          className={cn(
+            "font-heading text-[11px] text-condition-attention",
+            CAPS,
+          )}
+        >
+          Waiting
+        </span>
+        <span aria-hidden className="h-px flex-1 bg-condition-attention/25" />
+        <span className="text-[10px] font-semibold tabular-nums text-condition-attention">
+          {items.length}
+        </span>
+      </div>
+      <div className="flex flex-col gap-1 px-1.5 pb-2">
+        {items.map((item) => (
+          <ScheduleChip
+            key={item.id}
+            chrome={chrome}
+            item={item}
+            slotKey="overdue"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** The bottom of the list, folded away behind its count until asked for. */
+function NoDateSection({
+  chrome,
+  items,
+  onToggle,
+  open,
+}: {
+  chrome: ScheduleChrome;
+  items: PlanItem[];
+  onToggle: () => void;
+  open: boolean;
+}) {
+  const { isOver, setNodeRef } = useDroppable({
+    id: "slot::none",
+    data: { slotKey: "none" } satisfies ScheduleSlotData,
+  });
+  const armed = chrome.drag != null && isOver;
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        "mt-2 rounded-xl border transition-colors",
+        armed ? cn("border-brand-gold-strong/50", ARMED) : HAIRLINE,
+      )}
+    >
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 px-2.5 py-2 text-left"
+      >
+        <span className={cn("font-heading text-[11px]", CAPS, MUTE)}>
+          No date
+        </span>
+        <span
+          className={cn(
+            "rounded-full bg-surface-3 px-1.5 text-[10px] font-semibold tabular-nums",
+            MUTE,
+          )}
+        >
+          {items.length}
+        </span>
+        <span aria-hidden className={cn("h-px flex-1", HAIRLINE_BG)} />
+        {open ? (
+          <ChevronUp className={cn("size-3.5", MUTE_SOFT)} />
+        ) : (
+          <ChevronDown className={cn("size-3.5", MUTE_SOFT)} />
+        )}
+      </button>
+
+      {open && (
+        <div className="flex flex-col gap-1 px-1.5 pb-2">
+          {items.length === 0 ? (
+            <p className={cn("py-1 pl-1 text-[11px]", MUTE_FAINT)}>
+              Everything has a day
+            </p>
+          ) : (
+            items.map((item) => (
+              <ScheduleChip
+                key={item.id}
+                chrome={chrome}
+                item={item}
+                slotKey="none"
+              />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ chip -- */
+
+/**
+ * Presentation only, so the lifted ghost is identical to the row it left.
+ *
+ * The chip *is* the Area label: a condition rail down its left edge and the
+ * Area's icon in a condition-toned pill — a calendar event block that happens
+ * to carry an Area instead of a colour-coded calendar. An inbox Task wears a
+ * dashed pill and the Inbox glyph instead; it has no Area to wear.
+ */
+function ChipSurface({
+  areaById,
+  item,
+  lifted,
+  now,
+  slotKey,
+}: {
+  areaById: ReadonlyMap<string, DashboardArea>;
+  item: PlanItem;
+  lifted?: boolean;
+  now: number;
+  slotKey: string;
+}) {
+  const isTask = item.kind === "task";
+  const area = item.areaId == null ? undefined : areaById.get(item.areaId);
+  const waiting = slotKey === "overdue" && item.date != null;
+  const ConditionIcon = area ? conditionIcons[area.condition] : undefined;
+
+  return (
+    <div
+      className={cn(
+        "relative flex w-full items-start gap-2 overflow-hidden rounded-lg border py-2 pr-2 pl-2.5 text-left",
+        isTask
+          ? cn("border-dashed bg-surface-2/60", CHIP_EDGE)
+          : cn("bg-surface-2", CHIP_EDGE),
+        waiting && "border-condition-attention/30 bg-condition-attention/8",
+        // The lifted ghost wears the same gold the armed row does, so what is in
+        // flight and where it would land read as one gesture.
+        lifted &&
+          "border-transparent bg-surface-2 shadow-lg ring-1 ring-brand-gold-strong/50",
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "absolute inset-y-0 left-0 w-[3px]",
+          waiting
+            ? "bg-condition-attention"
+            : area == null || area.condition === "healthy"
+              ? "bg-border"
+              : conditionRailTone[area.condition],
+        )}
+      />
+
+      <span
+        className={cn(
+          "mt-px flex size-6 shrink-0 items-center justify-center rounded-md",
+          isTask
+            ? cn("border border-dashed bg-surface-2", CHIP_EDGE, MUTE)
+            : conditionIconTone[area?.condition ?? "healthy"],
+        )}
+      >
+        {isTask ? (
+          <Inbox aria-hidden className="size-3" />
+        ) : (
+          <AreaIcon icon={area?.icon} className="size-3.5" />
+        )}
+      </span>
+
+      <span className="min-w-0 flex-1">
+        <span
+          className={cn(
+            "line-clamp-2 text-[13px] leading-snug",
+            isTask ? "font-normal" : "font-medium",
+          )}
+        >
+          {item.title}
+        </span>
+
+        <span
+          className={cn(
+            "mt-0.5 flex min-w-0 items-center gap-1 text-[10px] leading-snug",
+            MUTE_SOFT,
+          )}
+        >
+          {ConditionIcon && area && area.condition !== "healthy" && (
+            <ConditionIcon
+              aria-hidden
+              className={cn("size-2.5", conditionTextClassName[area.condition])}
+            />
+          )}
+          <span className="truncate">{area?.name ?? "Inbox"}</span>
+          {item.nextMove && (
+            <>
+              <span aria-hidden>·</span>
+              <CornerDownRight aria-hidden className="size-2.5 shrink-0" />
+              <span className="truncate">{item.nextMove}</span>
+            </>
+          )}
+        </span>
+      </span>
+
+      {waiting && (
+        <span className="mt-px shrink-0 text-[10px] font-semibold tabular-nums text-condition-attention">
+          {waitingLabel(item.date!, now)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * A chip sitting on its day.
+ *
+ * Tapping opens the Thread rail in place; a Task chip goes to the Inbox, the
+ * only place a Task can be edited. Dragging arms on a touch long-press, so a
+ * tap and a lift never fight each other.
+ */
+function ScheduleChip({
+  chrome,
+  item,
+  slotKey,
+}: {
+  chrome: ScheduleChrome;
+  item: PlanItem;
+  slotKey: string;
+}) {
+  const { attributes, isDragging, listeners, setNodeRef } = useDraggable({
+    id: item.id,
+    data: {
+      itemId: item.id,
+      kind: item.kind,
+      slotKey,
+    } satisfies ScheduleDragData,
+  });
+
+  return (
+    <button
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      type="button"
+      onClick={() => chrome.onOpen(item)}
+      className={cn(
+        // `touch-manipulation`, not `touch-none`: a swipe that starts on a chip
+        // must still scroll the list until the long-press arms the drag.
+        "w-full touch-manipulation rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring/60 active:cursor-grabbing",
+        isDragging && "opacity-30",
+      )}
+    >
+      <ChipSurface
+        areaById={chrome.areaById}
+        item={item}
+        now={chrome.now}
+        slotKey={slotKey}
+      />
+    </button>
+  );
+}

--- a/apps/web/src/hooks/use-mobile.ts
+++ b/apps/web/src/hooks/use-mobile.ts
@@ -1,25 +1,50 @@
 import { useSyncExternalStore } from "react";
 
 const MOBILE_BREAKPOINT = 768;
+/** Tailwind's `sm`: below it a phone screen is the only layout that fits. */
+const COMPACT_BREAKPOINT = 640;
 
-const mql =
-  typeof window !== "undefined"
-    ? window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    : null;
+function watch(breakpoint: number) {
+  const mql =
+    typeof window !== "undefined"
+      ? window.matchMedia(`(max-width: ${breakpoint - 1}px)`)
+      : null;
 
-function subscribe(cb: () => void) {
-  mql?.addEventListener("change", cb);
-  return () => mql?.removeEventListener("change", cb);
+  return {
+    getSnapshot: () => window.innerWidth < breakpoint,
+    subscribe: (cb: () => void) => {
+      mql?.addEventListener("change", cb);
+      return () => mql?.removeEventListener("change", cb);
+    },
+  };
 }
 
-function getSnapshot() {
-  return window.innerWidth < MOBILE_BREAKPOINT;
-}
+const mobile = watch(MOBILE_BREAKPOINT);
+const compact = watch(COMPACT_BREAKPOINT);
 
 function getServerSnapshot() {
   return false;
 }
 
 export function useIsMobile() {
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  return useSyncExternalStore(
+    mobile.subscribe,
+    mobile.getSnapshot,
+    getServerSnapshot,
+  );
+}
+
+/**
+ * Phone-sized viewport.
+ *
+ * Unlike `hidden sm:block`, this switch is a real branch: the compact surface
+ * only mounts when it is on screen, so its scroll and observer effects never
+ * run against a hidden tree.
+ */
+export function useIsCompact() {
+  return useSyncExternalStore(
+    compact.subscribe,
+    compact.getSnapshot,
+    getServerSnapshot,
+  );
 }


### PR DESCRIPTION
Closes #268.

## What

Replaces the interim mobile thread list with **PlanSchedule** — a calendar-schedule vertical agenda for `< sm` viewports. The direction was chosen by prototyping seven layout variants and a three-lens comparative review (touch ergonomics, information density, path to production); the full prototype set and decision log live on branch `worktree-plan-mobile-prototype-268` (see `apps/web/src/features/dashboard/prototype/README.md` there).

## Design (winner: polished "b2" calendar schedule)

- Date-rail day rows (weekday over day number) with one unified rail for occupied and empty days, uniform 40px row minimum
- Today = filled accent disc + faint row wash; sticky month bands; runs of quiet days fold to a tappable "N quiet days" row (today never folds)
- Waiting (overdue) card on top — a droppable that rejects with a blocked caption; No-date section collapsed behind its count at the bottom, auto-expands on drop
- Area filter chips; floating Today pill (IntersectionObserver); mount-scroll to today
- Long-press (250ms) touch drag so swipes still scroll; drag overlay carries an exact-day caption

## Implementation

- **`planDayDrop` seam** extracted from `planDrop` in `plan-model.ts`: both surfaces share the past-blocked / clears / caption rules; the desktop canvas's behavior is unchanged (`plan-model.test.ts` / `plan-canvas.test.tsx` untouched and passing)
- Real writes via `usePlanActions` (`planTask` / `planThread`) with the existing optimistic updates
- **`useIsCompact`** (639px) alongside `useIsMobile`; `DashboardOverview` now uses a JS breakpoint split so the hidden surface no longer mounts its scroll/observer effects
- Interim mobile list (`DashboardThreadList`, `InboxSection`) and its dead model exports removed

## Acceptance criteria (from #268)

- [x] Direction chosen after comparing compact-header fix and transposed/agenda layouts (7 prototyped variants + 3-lens review)
- [x] On a ~390px viewport the majority of width is plannable content (48px rail vs ~178px pinned desktop furniture; ~85% content width)
- [x] Chips reschedule on touch without hijacking scroll (long-press arming, `touch-manipulation`)

## Tests

- `plan-schedule-model.test.ts` — 11 cases: bucketing/ordering, near-horizon empty days, gap folding + today exemption, horizon bounds, month bands, drop rules
- `plan-schedule.test.tsx` — 7 cases: render order, Waiting/No-date behavior, quiet-day expansion, tap-to-open (thread rail / inbox), mutation wiring
- `dashboard-overview.test.tsx` reworked: asserts the canvas/schedule swap at the 640px boundary
- Full suite: 52 files, 266 tests passing; `bun run lint` and `bun run build` clean

Independent code review found the desktop canvas not at risk; both findings (dead exports, missing component test) are addressed in this PR.