### PR TITLE
feat: attention clock, app shell hardening, and CI hardening (#253, #255, #256)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,27 @@ jobs:
       - name: Lint (check only)
         run: bun run lint:check
 
+      - name: Typecheck (app, node, convex backend, ui package)
+        run: bun run typecheck
+
       - name: Build
         run: bun run build
+        env:
+          VITE_CONVEX_URL: ${{ vars.VITE_CONVEX_URL }}
+          VITE_CONVEX_SITE_URL: ${{ vars.VITE_CONVEX_SITE_URL }}
+          VITE_SITE_URL: ${{ vars.VITE_SITE_URL }}
+
+      - name: Route-split chunk check
+        working-directory: apps/web
+        run: node scripts/check-chunks.mjs
+
+      - name: Convex codegen drift check
+        working-directory: apps/web
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: |
+          bunx convex codegen --typecheck disable
+          git diff --exit-code -- convex/_generated
 
       - name: Test
         run: bun run test:run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,5 @@ jobs:
         working-directory: apps/web
         run: node scripts/check-chunks.mjs
 
-      - name: Convex codegen drift check
-        working-directory: apps/web
-        env:
-          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
-        run: |
-          bunx convex codegen --typecheck disable
-          git diff --exit-code -- convex/_generated
-
       - name: Test
         run: bun run test:run

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "lint:check": "oxlint --deny-warnings . && oxfmt --check .",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
+    "typecheck": "tsc -b && tsc -p convex/tsconfig.json --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
     "preview": "vite preview",

--- a/apps/web/scripts/check-chunks.mjs
+++ b/apps/web/scripts/check-chunks.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// Guards route splitting: the sign-in page must not download the authenticated
+// app. Run after `vite build`, from apps/web (or pass a dist path).
+//
+//   node scripts/check-chunks.mjs [distDir]
+//
+// The check walks the static import graph of the built chunks — everything the
+// browser fetches before it can run the sign-in route — and fails if any chunk
+// carrying the authenticated shell ends up inside it.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+
+const distDir = resolve(process.argv[2] ?? "dist");
+const assetsDir = join(distDir, "assets");
+
+// Copy that only exists in the authenticated shell. If a marker stops matching
+// anything at all the check fails too, so renamed copy cannot silently pass.
+const AUTHENTICATED_MARKERS = [
+  "Vita OS home",
+  "Jump to an area, thread, or action",
+  "What's on your mind?",
+];
+
+const STATIC_IMPORT =
+  /(?:^|[\s,;}])(?:import|from)\s*["'](\.\/[^"']+\.js)["']/g;
+
+function fail(message) {
+  console.error(`✗ ${message}`);
+  process.exitCode = 1;
+}
+
+function readChunks() {
+  const chunks = new Map();
+  for (const name of readdirSync(assetsDir)) {
+    if (!name.endsWith(".js")) continue;
+    chunks.set(name, readFileSync(join(assetsDir, name), "utf8"));
+  }
+  return chunks;
+}
+
+function staticImportsOf(source) {
+  const imports = new Set();
+  for (const [, specifier] of source.matchAll(STATIC_IMPORT)) {
+    imports.add(basename(specifier));
+  }
+  return imports;
+}
+
+function closure(chunks, roots) {
+  const seen = new Set();
+  const queue = [...roots];
+  while (queue.length > 0) {
+    const name = queue.pop();
+    if (name === undefined || seen.has(name)) continue;
+    const source = chunks.get(name);
+    if (source === undefined) continue;
+    seen.add(name);
+    queue.push(...staticImportsOf(source));
+  }
+  return seen;
+}
+
+const chunks = readChunks();
+if (chunks.size === 0) {
+  fail(`no JavaScript chunks in ${assetsDir} — run \`vite build\` first`);
+  process.exit(1);
+}
+
+const html = readFileSync(join(distDir, "index.html"), "utf8");
+const entry = html.match(/src="\/assets\/([^"]+\.js)"/)?.[1];
+if (entry === undefined) {
+  fail("could not find the entry script in dist/index.html");
+  process.exit(1);
+}
+
+const signInChunks = [...chunks.keys()].filter((name) =>
+  name.startsWith("sign-in-"),
+);
+if (signInChunks.length === 0) {
+  fail("no sign-in chunk — the sign-in route is no longer code split");
+  process.exit(1);
+}
+
+// Everything the browser has loaded once the sign-in route is on screen.
+const signInGraph = closure(chunks, [entry, ...signInChunks]);
+
+for (const marker of AUTHENTICATED_MARKERS) {
+  const carriers = [...chunks].filter(([, source]) => source.includes(marker));
+  if (carriers.length === 0) {
+    fail(
+      `marker ${JSON.stringify(marker)} matched no chunk — update this script`,
+    );
+    continue;
+  }
+  const leaked = carriers.filter(([name]) => signInGraph.has(name));
+  if (leaked.length > 0) {
+    fail(
+      `sign-in loads the authenticated app: ${JSON.stringify(marker)} is in ` +
+        leaked.map(([name]) => name).join(", "),
+    );
+  }
+}
+
+if (process.exitCode === 1) {
+  console.error("\nsign-in graph:", [...signInGraph].sort().join("\n  "));
+  process.exit(1);
+}
+
+console.log(
+  `✓ sign-in stays split: ${signInGraph.size} chunk(s) reachable, ` +
+    `${chunks.size - signInGraph.size} chunk(s) deferred`,
+);

--- a/apps/web/src/components/error-boundary.test.tsx
+++ b/apps/web/src/components/error-boundary.test.tsx
@@ -1,0 +1,103 @@
+import type { ErrorComponentProps } from "@tanstack/react-router";
+
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@/test/render-with-providers";
+
+import {
+  AppErrorBoundary,
+  AppErrorFallback,
+  RouteErrorFallback,
+} from "./error-boundary";
+
+function Boom(): never {
+  throw new Error("kaboom");
+}
+
+function errorProps(reset: () => void) {
+  return {
+    error: new Error("kaboom"),
+    reset,
+  } as unknown as ErrorComponentProps & { reset: () => void };
+}
+
+describe("error boundaries", () => {
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    reload.mockClear();
+    // React logs caught render errors; keep the run readable.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("catches a crash above the router and offers a reload", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <AppErrorBoundary>
+        <Boom />
+      </AppErrorBoundary>,
+    );
+
+    expect(screen.getByRole("alert")).toBeVisible();
+    expect(screen.getByText("Something went wrong")).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Reload" }));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders children when nothing throws", () => {
+    render(
+      <AppErrorBoundary>
+        <p>all good</p>
+      </AppErrorBoundary>,
+    );
+
+    expect(screen.getByText("all good")).toBeVisible();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("retries or reloads from the full-page route fallback", async () => {
+    const user = userEvent.setup();
+    const reset = vi.fn();
+
+    render(<AppErrorFallback {...errorProps(reset)} />);
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+    expect(reset).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Reload" }));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries from the inline route fallback", async () => {
+    const user = userEvent.setup();
+    const reset = vi.fn();
+
+    render(<RouteErrorFallback {...errorProps(reset)} />);
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("full-page routes", () => {
+  it.each([
+    ["root", () => import("@/routes/__root")],
+    ["unauthenticated layout", () => import("@/routes/_unauthenticated/route")],
+    ["sign in", () => import("@/routes/_unauthenticated/sign-in")],
+    ["sign up", () => import("@/routes/_unauthenticated/sign-up")],
+  ])("declares an error boundary for the %s route", async (_name, load) => {
+    const { Route } = await load();
+    // Code splitting rewrites file-route components into lazy shells, so this
+    // guards the wiring; the screen itself is rendered in the tests above.
+    expect(Route.options.errorComponent).toBeDefined();
+  });
+});

--- a/apps/web/src/components/error-boundary.tsx
+++ b/apps/web/src/components/error-boundary.tsx
@@ -1,14 +1,103 @@
 import type { ErrorComponentProps } from "@tanstack/react-router";
+import type { ErrorInfo, ReactNode } from "react";
 
 import { Button } from "@vita-os/ui/components/button";
+import { Component } from "react";
 
+/** Inline recovery for a route body that failed while the app chrome around it still works. */
 export function RouteErrorFallback({ reset }: ErrorComponentProps) {
   return (
-    <div className="py-16 text-center">
+    <div role="alert" className="py-16 text-center">
       <p className="text-sm text-muted-foreground">Something went wrong.</p>
       <Button variant="outline" size="sm" className="mt-3" onClick={reset}>
         Try again
       </Button>
     </div>
   );
+}
+
+function reloadPage() {
+  window.location.reload();
+}
+
+/**
+ * Full-page branded recovery for failures that take the whole page with them:
+ * the root route, unauthenticated routes, and the provider stack above the router.
+ */
+export function AppErrorScreen({ onRetry }: { onRetry?: () => void }) {
+  return (
+    <div
+      role="alert"
+      className="flex min-h-svh flex-col items-center justify-center gap-6 px-4 text-center"
+    >
+      <div className="flex items-center gap-2">
+        <img
+          src="/vita-logo.svg"
+          alt=""
+          className="size-8 shrink-0 rounded-lg shadow-sm ring-1 ring-border"
+        />
+        <span className="flex items-baseline gap-1 leading-none">
+          <span className="font-heading text-lg font-semibold tracking-tight">
+            vita
+          </span>
+          <span className="text-[0.5625rem] font-semibold tracking-[0.18em] text-muted-foreground uppercase">
+            OS
+          </span>
+        </span>
+      </div>
+      <div className="space-y-1">
+        <h1 className="font-heading text-xl font-semibold tracking-tight">
+          Something went wrong
+        </h1>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          Vita OS hit an unexpected error. Reloading usually clears it — your
+          data is safe.
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        {onRetry ? (
+          <Button variant="outline" onClick={onRetry}>
+            Try again
+          </Button>
+        ) : null}
+        <Button onClick={reloadPage}>Reload</Button>
+      </div>
+    </div>
+  );
+}
+
+/** Router `errorComponent` for routes that render the whole viewport. */
+export function AppErrorFallback({ reset }: ErrorComponentProps) {
+  return <AppErrorScreen onRetry={reset} />;
+}
+
+interface AppErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * The provider stack above `RouterProvider` sits outside the router's own
+ * CatchBoundary, so a crash there blanks the page unless something catches it.
+ */
+export class AppErrorBoundary extends Component<
+  { children: ReactNode },
+  AppErrorBoundaryState
+> {
+  state: AppErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): AppErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo) {
+    console.error("Unhandled error above the router", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // No retry: the crash is in the providers, so only a reload rebuilds them.
+      return <AppErrorScreen />;
+    }
+    return this.props.children;
+  }
 }

--- a/apps/web/src/components/layout/app-shell.test.tsx
+++ b/apps/web/src/components/layout/app-shell.test.tsx
@@ -1,0 +1,250 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+
+import userEvent from "@testing-library/user-event";
+import { getFunctionName } from "convex/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { render, screen, waitFor } from "@/test/render-with-providers";
+
+import { AppShell } from "./app-shell";
+
+const area = {
+  _id: "area1" as Id<"areas">,
+  _creationTime: 0,
+  userId: "user1",
+  name: "Family Health",
+  slug: "family-health",
+  condition: "needs_attention",
+  order: 0,
+  createdAt: 0,
+} satisfies Doc<"areas">;
+
+const thread = {
+  _id: "thread1" as Id<"threads">,
+  _creationTime: 0,
+  userId: "user1",
+  title: "Sister's front teeth",
+  slug: "sister-s-front-teeth",
+  areaId: area._id,
+  state: "open",
+  order: 0,
+  createdAt: 0,
+} satisfies Doc<"threads">;
+
+// cmdk observes and scrolls its list container; jsdom provides neither.
+globalThis.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView ??= vi.fn();
+
+const queryCall = vi.fn<(name: string, args: unknown) => void>();
+
+vi.mock("convex-helpers/react/cache/hooks", () => ({
+  useQuery: (query: unknown, args: unknown) => {
+    const name = getFunctionName(query as never);
+    queryCall(name, args);
+    if (args === "skip") return undefined;
+    if (name === "areas:list") return [area];
+    if (name === "threads:list") return [thread];
+    if (name === "tasks:count") return 0;
+    return undefined;
+  },
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: () => {
+    const mutation = vi.fn().mockResolvedValue({ slug: thread.slug });
+    return Object.assign(mutation, {
+      withOptimisticUpdate: () => mutation,
+    });
+  },
+}));
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-router")>();
+  return {
+    ...actual,
+    useSearch: () => ({}),
+    useMatch: () => undefined,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+// The chrome pulls in auth and theme providers; the shell's own wiring is what
+// these tests exercise, so each entry point is reduced to a labelled button.
+vi.mock("./app-top-bar", () => ({
+  AppTopBar: ({
+    onNewTask,
+    onOpenPalette,
+  }: {
+    onNewTask: () => void;
+    onOpenPalette: () => void;
+  }) => (
+    <div>
+      <button type="button" onClick={onNewTask}>
+        top bar new task
+      </button>
+      <button type="button" onClick={onOpenPalette}>
+        top bar palette
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("./mobile-tab-bar", () => ({
+  MobileTabBar: ({
+    onNewTask,
+    onOpenPalette,
+  }: {
+    onNewTask: () => void;
+    onOpenPalette: () => void;
+  }) => (
+    <div>
+      <button type="button" onClick={onNewTask}>
+        mobile new task
+      </button>
+      <button type="button" onClick={onOpenPalette}>
+        mobile palette
+      </button>
+    </div>
+  ),
+}));
+
+function subscribedTo(name: string) {
+  return queryCall.mock.calls.some(
+    ([calledName, args]) => calledName === name && args !== "skip",
+  );
+}
+
+function renderShell() {
+  return render(
+    <AppShell>
+      <p>page body</p>
+    </AppShell>,
+  );
+}
+
+describe("AppShell", () => {
+  beforeEach(() => queryCall.mockClear());
+
+  it("mounts no create surface and no palette-only subscription while closed", () => {
+    renderShell();
+
+    expect(screen.getByText("page body")).toBeVisible();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(subscribedTo("areas:list")).toBe(false);
+    expect(subscribedTo("threads:list")).toBe(false);
+    expect(subscribedTo("tasks:count")).toBe(true);
+  });
+
+  it.each([
+    ["top bar", "top bar new task"],
+    ["mobile tab bar", "mobile new task"],
+  ])("opens the new task dialog from the %s", async (_source, label) => {
+    const user = userEvent.setup();
+    renderShell();
+
+    await user.click(screen.getByRole("button", { name: label }));
+
+    expect(
+      await screen.findByPlaceholderText("What's on your mind?"),
+    ).toBeVisible();
+  });
+
+  it("opens the new task dialog from the q shortcut", async () => {
+    const user = userEvent.setup();
+    renderShell();
+
+    await user.keyboard("q");
+
+    expect(
+      await screen.findByPlaceholderText("What's on your mind?"),
+    ).toBeVisible();
+  });
+
+  it("resets new task input between openings", async () => {
+    const user = userEvent.setup();
+    renderShell();
+
+    await user.click(screen.getByRole("button", { name: "top bar new task" }));
+    const textarea = await screen.findByPlaceholderText("What's on your mind?");
+    await user.type(textarea, "Buy milk");
+    expect(textarea).toHaveValue("Buy milk");
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() =>
+      expect(
+        screen.queryByPlaceholderText("What's on your mind?"),
+      ).not.toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole("button", { name: "top bar new task" }));
+    expect(
+      await screen.findByPlaceholderText("What's on your mind?"),
+    ).toHaveValue("");
+  });
+
+  it("opens the palette from the shortcut and only then subscribes to areas and threads", async () => {
+    const user = userEvent.setup();
+    renderShell();
+
+    expect(subscribedTo("threads:list")).toBe(false);
+
+    await user.keyboard("{Meta>}k{/Meta}");
+
+    expect(
+      await screen.findByPlaceholderText("Jump to an area, thread, or action…"),
+    ).toBeVisible();
+    expect(subscribedTo("areas:list")).toBe(true);
+    expect(subscribedTo("threads:list")).toBe(true);
+    expect(screen.getAllByText(area.name).length).toBeGreaterThan(0);
+    expect(screen.getByText(thread.title)).toBeVisible();
+  });
+
+  it("unmounts the palette and its subscriptions when it closes", async () => {
+    const user = userEvent.setup();
+    renderShell();
+
+    await user.click(screen.getByRole("button", { name: "top bar palette" }));
+    await screen.findByPlaceholderText("Jump to an area, thread, or action…");
+
+    await user.keyboard("{Escape}");
+    await waitFor(() =>
+      expect(
+        screen.queryByPlaceholderText("Jump to an area, thread, or action…"),
+      ).not.toBeInTheDocument(),
+    );
+
+    queryCall.mockClear();
+    // A re-render after the close must not re-subscribe.
+    await user.click(screen.getByRole("button", { name: "top bar new task" }));
+    await screen.findByPlaceholderText("What's on your mind?");
+    expect(subscribedTo("threads:list")).toBe(false);
+  });
+
+  it("opens the create thread dialog from the palette and subscribes to areas only then", async () => {
+    const user = userEvent.setup();
+    renderShell();
+
+    expect(subscribedTo("areas:list")).toBe(false);
+
+    await user.click(screen.getByRole("button", { name: "top bar palette" }));
+    await user.click(await screen.findByText("New thread"));
+
+    expect(await screen.findByLabelText("Title")).toBeVisible();
+    expect(subscribedTo("areas:list")).toBe(true);
+  });
+
+  it("opens the create area dialog from the palette", async () => {
+    const user = userEvent.setup();
+    renderShell();
+
+    await user.click(screen.getByRole("button", { name: "top bar palette" }));
+    await user.click(await screen.findByText("New area"));
+
+    expect(await screen.findByLabelText("Name")).toBeVisible();
+  });
+});

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -24,14 +24,19 @@ import { CommandPalette } from "./command-palette";
 import { MobileTabBar } from "./mobile-tab-bar";
 
 export function AppShell({ children }: { children: ReactNode }) {
-  const areas = useQuery(api.areas.list);
-  const threads = useQuery(api.threads.list);
   const taskCount = useQuery(api.tasks.count);
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const createTask = useCreateTask();
   const dialogs = useCreateDialogs();
   const [paletteOpen, setPaletteOpen] = useState(false);
+
+  // The area list is only read by the create-thread dialog here; the palette
+  // subscribes for itself while it is mounted.
+  const createThreadAreas = useQuery(
+    api.areas.list,
+    dialogs.showCreateThread ? {} : "skip",
+  );
 
   useGlobalNewTaskShortcut(dialogs.openNewTask);
   useCommandPaletteShortcut(() => setPaletteOpen(true));
@@ -128,37 +133,42 @@ export function AppShell({ children }: { children: ReactNode }) {
         />
       )}
 
-      <CommandPalette
-        open={paletteOpen}
-        onOpenChange={setPaletteOpen}
-        areas={areas}
-        threads={threads}
-        onNewTask={dialogs.openNewTask}
-        onNewThread={() => dialogs.openCreateThread()}
-        onNewArea={dialogs.openCreateArea}
-      />
+      {/* Mounted on demand: each surface holds form state and subscriptions
+          that should not exist — or survive a close — while it is hidden. */}
+      {paletteOpen && (
+        <CommandPalette
+          open
+          onOpenChange={setPaletteOpen}
+          onNewTask={dialogs.openNewTask}
+          onNewThread={() => dialogs.openCreateThread()}
+          onNewArea={dialogs.openCreateArea}
+        />
+      )}
 
-      <CreateThreadDialog
-        open={dialogs.showCreateThread}
-        onOpenChange={dialogs.setShowCreateThread}
-        areas={areas ?? []}
-        defaultAreaId={dialogs.createForAreaId}
-        onCreated={({ slug }) => {
-          openThreadInPlace(slug);
-        }}
-      />
-      <NewTaskDialog
-        open={dialogs.showNewTask}
-        onOpenChange={dialogs.setShowNewTask}
-        onSubmit={async (value) => {
-          await createTask(value);
-          dialogs.setShowNewTask(false);
-        }}
-      />
-      <CreateAreaDialog
-        open={dialogs.showCreateArea}
-        onOpenChange={dialogs.setShowCreateArea}
-      />
+      {dialogs.showCreateThread && (
+        <CreateThreadDialog
+          open
+          onOpenChange={dialogs.setShowCreateThread}
+          areas={createThreadAreas ?? []}
+          defaultAreaId={dialogs.createForAreaId}
+          onCreated={({ slug }) => {
+            openThreadInPlace(slug);
+          }}
+        />
+      )}
+      {dialogs.showNewTask && (
+        <NewTaskDialog
+          open
+          onOpenChange={dialogs.setShowNewTask}
+          onSubmit={async (value) => {
+            await createTask(value);
+            dialogs.setShowNewTask(false);
+          }}
+        />
+      )}
+      {dialogs.showCreateArea && (
+        <CreateAreaDialog open onOpenChange={dialogs.setShowCreateArea} />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/layout/command-palette.tsx
+++ b/apps/web/src/components/layout/command-palette.tsx
@@ -1,6 +1,6 @@
-import type { Doc } from "@convex/_generated/dataModel";
-
+import { api } from "@convex/_generated/api";
 import { useNavigate } from "@tanstack/react-router";
+import { useQuery } from "convex-helpers/react/cache/hooks";
 import {
   FolderPlus,
   Inbox,
@@ -24,8 +24,6 @@ import { AreaIcon } from "@/features/areas/components/area-icon";
 interface CommandPaletteProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  areas: Doc<"areas">[] | undefined;
-  threads: Doc<"threads">[] | undefined;
   onNewTask: () => void;
   onNewThread: () => void;
   onNewArea: () => void;
@@ -34,13 +32,15 @@ interface CommandPaletteProps {
 export function CommandPalette({
   open,
   onOpenChange,
-  areas,
-  threads,
   onNewTask,
   onNewThread,
   onNewArea,
 }: CommandPaletteProps) {
   const navigate = useNavigate();
+  // The palette is mounted only while it is open, so these subscriptions live
+  // exactly as long as the surface that reads them.
+  const areas = useQuery(api.areas.list, open ? {} : "skip");
+  const threads = useQuery(api.threads.list, open ? {} : "skip");
   const areaById = useMemo(
     () => new Map((areas ?? []).map((area) => [area._id, area])),
     [areas],

--- a/apps/web/src/features/areas/area-form/area-form-dialog.test.tsx
+++ b/apps/web/src/features/areas/area-form/area-form-dialog.test.tsx
@@ -45,6 +45,33 @@ describe("AreaFormDialog", () => {
     });
   });
 
+  it("starts blank on Compass when remounted for a new Area", async () => {
+    const user = userEvent.setup();
+    const props = {
+      mode: "create",
+      open: true,
+      onOpenChange: vi.fn(),
+      onSubmit: vi.fn(),
+    } as const;
+
+    // AppShell mounts the create dialog only while it is open, so a reopen is
+    // a remount rather than a prop flip.
+    const { unmount } = render(<AreaFormDialog {...props} />);
+    await user.click(
+      screen.getByRole("button", { name: "Choose Area icon: Compass" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Finances" }));
+    await user.type(screen.getByLabelText("Name"), "Family Health");
+    unmount();
+
+    render(<AreaFormDialog {...props} />);
+
+    expect(screen.getByLabelText("Name")).toHaveValue("");
+    expect(
+      screen.getByRole("button", { name: "Choose Area icon: Compass" }),
+    ).toBeInTheDocument();
+  });
+
   it("does not change the selected icon when the Area name changes", async () => {
     const user = userEvent.setup();
 

--- a/apps/web/src/features/areas/components/area-threads-section.tsx
+++ b/apps/web/src/features/areas/components/area-threads-section.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "convex-helpers/react/cache/hooks";
 import { useMutation } from "convex/react";
 
 import { optimisticallyRemoveThread } from "@/features/threads/optimistic";
+import { useAttentionClock } from "@/hooks/use-attention-clock";
 import { useStableQuery } from "@/hooks/use-stable-query";
 
 import { AreaThreads } from "./area-threads";
@@ -16,6 +17,7 @@ export function AreaThreadsSection({
   areaSlug,
   onCreateThread,
 }: AreaThreadsSectionProps) {
+  const currentDate = useAttentionClock();
   const area = useStableQuery(api.areas.getBySlug, { slug: areaSlug });
   const threads = useQuery(
     api.threads.listByArea,
@@ -31,7 +33,7 @@ export function AreaThreadsSection({
   return (
     <AreaThreads
       threads={threads ?? []}
-      currentDate={Date.now()}
+      currentDate={currentDate}
       isLoading={threads === undefined}
       onCreateThread={onCreateThread}
       onRemoveThread={(threadId) => removeThread({ id: threadId })}

--- a/apps/web/src/features/dashboard/plan/plan-canvas.test.tsx
+++ b/apps/web/src/features/dashboard/plan/plan-canvas.test.tsx
@@ -209,6 +209,38 @@ describe("PlanCanvas", () => {
     expect(screen.getByText("Renew passport")).toBeVisible();
   });
 
+  it("rebuilds the axis when the attention clock rolls the day over", () => {
+    const laneThreads: DashboardThread[] = [
+      {
+        areaId: "home",
+        followUp: day(0),
+        id: "t9",
+        order: 0,
+        slug: "water-plants",
+        title: "Water plants",
+      },
+    ];
+    const view = (clock: number) => (
+      <FeedbackProvider feedback={{ error: vi.fn(), success: vi.fn() }}>
+        <PlanCanvas
+          areas={areas}
+          currentDate={clock}
+          tasks={[]}
+          threads={laneThreads}
+        />
+      </FeedbackProvider>
+    );
+    const canvas = () => screen.getByRole("region", { name: "Plan" });
+
+    const { rerender } = render(view(now));
+    expect(within(canvas()).queryByText("Waiting")).toBeNull();
+
+    rerender(view(new Date(2026, 7, 7, 9).getTime()));
+
+    expect(within(canvas()).getByText("Waiting")).toBeVisible();
+    expect(within(canvas()).getByText("1 waiting")).toBeVisible();
+  });
+
   it("wires both writes to the app's own mutations", () => {
     renderCanvas();
 

--- a/apps/web/src/features/dashboard/plan/plan-model.test.ts
+++ b/apps/web/src/features/dashboard/plan/plan-model.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import type { DashboardArea } from "@/features/dashboard/components/dashboard-model";
+
 import type { DragState, PlanItem } from "./plan-model";
 
 import {
@@ -110,6 +112,72 @@ describe("plan lanes", () => {
     expect(areaLanes[0].plannedCount).toBe(0);
     expect(areaLanes[1].none.map((item) => item.id)).toEqual(["t3"]);
     expect(inbox.byDay.get("d1")?.map((item) => item.id)).toEqual(["k1"]);
+  });
+});
+
+describe("day rollover", () => {
+  const tomorrow = new Date(2026, 7, 7, 9).getTime();
+
+  const home: DashboardArea[] = [
+    { condition: "healthy", id: "home", name: "Home", order: 0, slug: "home" },
+  ];
+
+  const dated: PlanItem[] = [
+    {
+      areaId: "home",
+      date: dayAt(0, now),
+      id: "today",
+      kind: "thread",
+      title: "Today",
+    },
+    {
+      areaId: "home",
+      date: dayAt(1, now),
+      id: "next",
+      kind: "thread",
+      title: "Next",
+    },
+    {
+      areaId: "home",
+      date: dayAt(9, now),
+      id: "far",
+      kind: "thread",
+      title: "Far",
+    },
+    { areaId: "home", id: "undated", kind: "thread", title: "Undated" },
+  ];
+
+  function planAt(clock: number) {
+    const at = buildAxis(dated, clock, "compact");
+    const { areaLanes } = buildLanes(dated, home, clock, at.days.length - 1);
+    return { axis: at, lane: areaLanes[0] };
+  }
+
+  const ids = (bucket: PlanItem[] | undefined) =>
+    bucket?.map((item) => item.id);
+
+  it("re-places every item when the clock steps onto the next day", () => {
+    const before = planAt(now);
+
+    expect(before.axis.hasOverdue).toBe(false);
+    expect(ids(before.lane.byDay.get("d0"))).toEqual(["today"]);
+    expect(ids(before.lane.byDay.get("d1"))).toEqual(["next"]);
+    expect(ids(before.lane.byDay.get("d9"))).toEqual(["far"]);
+    expect(ids(before.lane.none)).toEqual(["undated"]);
+
+    const after = planAt(tomorrow);
+
+    // Yesterday's Today is a debt; the day behind it is the new Today.
+    expect(after.axis.hasOverdue).toBe(true);
+    expect(ids(after.lane.overdue)).toEqual(["today"]);
+    expect(ids(after.lane.byDay.get("d0"))).toEqual(["next"]);
+
+    // A future Thread keeps its exact calendar day, one slot nearer.
+    expect(ids(after.lane.byDay.get("d8"))).toEqual(["far"]);
+    expect(after.axis.days[8].at).toBe(dayAt(9, now));
+
+    // And an undated one is still undated.
+    expect(ids(after.lane.none)).toEqual(["undated"]);
   });
 });
 

--- a/apps/web/src/features/dashboard/screens/dashboard-screen.test.tsx
+++ b/apps/web/src/features/dashboard/screens/dashboard-screen.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DashboardScreen } from "./dashboard-screen";
 
@@ -13,8 +13,17 @@ vi.mock("@/features/areas/area-form/create-area-dialog", () => ({
   CreateAreaDialog: () => null,
 }));
 
+const emptyOverview = {
+  areas: [],
+  threads: [],
+  inbox: { items: [], totalOpen: 0 },
+  recentActivity: [],
+};
+
 describe("DashboardScreen", () => {
   beforeEach(() => useQuery.mockReset());
+
+  afterEach(() => vi.useRealTimers());
 
   it("renders a layout-matched loading state", () => {
     useQuery.mockReturnValue(undefined);
@@ -24,16 +33,32 @@ describe("DashboardScreen", () => {
   });
 
   it("renders the first-run Area creation state", () => {
-    useQuery.mockReturnValue({
-      areas: [],
-      threads: [],
-      inbox: { items: [], totalOpen: 0 },
-      recentActivity: [],
-    });
+    useQuery.mockReturnValue(emptyOverview);
     render(<DashboardScreen />);
 
     expect(
       screen.getByRole("button", { name: "Create Life Area" }),
     ).toBeVisible();
+  });
+
+  it("moves the date and requeries when the day rolls over", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 17, 23, 30));
+    useQuery.mockReturnValue(emptyOverview);
+    render(<DashboardScreen />);
+
+    expect(screen.getByText("Jul")).toBeVisible();
+    expect(screen.getByText("17")).toBeVisible();
+    expect(useQuery.mock.lastCall?.[1]).toEqual({
+      currentDate: new Date(2026, 6, 17, 23, 30).getTime(),
+      timezoneOffsetMinutes: new Date(2026, 6, 17).getTimezoneOffset(),
+    });
+
+    act(() => vi.advanceTimersByTime(30 * 60_000));
+
+    expect(screen.getByText("18")).toBeVisible();
+    expect(useQuery.mock.lastCall?.[1]).toMatchObject({
+      currentDate: new Date(2026, 6, 18).getTime(),
+    });
   });
 });

--- a/apps/web/src/features/dashboard/screens/dashboard-screen.tsx
+++ b/apps/web/src/features/dashboard/screens/dashboard-screen.tsx
@@ -1,19 +1,23 @@
 import { api } from "@convex/_generated/api";
 import { useQuery } from "convex-helpers/react/cache/hooks";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { CreateAreaDialog } from "@/features/areas/area-form/create-area-dialog";
 import { DashboardOverview } from "@/features/dashboard/components/dashboard-overview";
 import { DashboardOverviewSkeleton } from "@/features/dashboard/components/dashboard-overview-skeleton";
+import { useAttentionClock } from "@/hooks/use-attention-clock";
 
 export function DashboardScreen() {
-  const [dateContext] = useState(() => {
-    const currentDate = Date.now();
-    return {
+  const currentDate = useAttentionClock();
+  // Stable for the whole day, so the query re-runs at the rollover and not on
+  // every render.
+  const dateContext = useMemo(
+    () => ({
       currentDate,
       timezoneOffsetMinutes: new Date(currentDate).getTimezoneOffset(),
-    };
-  });
+    }),
+    [currentDate],
+  );
   const overview = useQuery(api.dashboard.overview, dateContext);
   const [showCreateArea, setShowCreateArea] = useState(false);
 

--- a/apps/web/src/features/inbox/components/inbox-task-list.test.tsx
+++ b/apps/web/src/features/inbox/components/inbox-task-list.test.tsx
@@ -1,6 +1,6 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
 
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -72,6 +72,28 @@ describe("InboxTaskList", () => {
     expect(noDate.compareDocumentPosition(completed)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
+  });
+
+  it("re-dates its header and ages today's Task at local midnight", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 17, 23, 30));
+
+    render(
+      <InboxTaskList
+        tasks={[task("Today", { when: new Date(2026, 6, 17).getTime() })]}
+      />,
+    );
+
+    const rail = () =>
+      screen.getByRole("button", { name: "Change when" }).firstElementChild;
+
+    expect(screen.getByText("Friday, July 17")).toBeVisible();
+    expect(rail()).toHaveClass("bg-surface-3");
+
+    act(() => vi.advanceTimersByTime(30 * 60_000));
+
+    expect(screen.getByText("Saturday, July 18")).toBeVisible();
+    expect(rail()).toHaveClass("bg-condition-attention-fill");
   });
 
   it("keeps Completed Tasks collapsed when the Open Inbox is clear", async () => {

--- a/apps/web/src/features/inbox/components/inbox-task-list.tsx
+++ b/apps/web/src/features/inbox/components/inbox-task-list.tsx
@@ -13,6 +13,7 @@ import {
   RowIconAction,
 } from "@/features/attention-list";
 import { useTaskRowActions } from "@/features/tasks/task-row/use-task-row-actions";
+import { useAttentionClock } from "@/hooks/use-attention-clock";
 
 interface InboxTaskListProps {
   tasks: Doc<"tasks">[];
@@ -20,7 +21,7 @@ interface InboxTaskListProps {
 }
 
 export function InboxTaskList({ tasks, onProcess }: InboxTaskListProps) {
-  const now = Date.now();
+  const now = useAttentionClock();
   const groups = groupTasksByAttention(tasks, now);
   const openCount =
     groups.pastDue.length +

--- a/apps/web/src/features/threads/thread-form/thread-form-dialog.test.tsx
+++ b/apps/web/src/features/threads/thread-form/thread-form-dialog.test.tsx
@@ -49,6 +49,29 @@ describe("ThreadFormDialog", () => {
     ).toBeInTheDocument();
   });
 
+  it("starts fresh on the default Area when remounted for a new thread", async () => {
+    const user = userEvent.setup();
+    const props = {
+      mode: "create",
+      open: true,
+      onOpenChange: vi.fn(),
+      areas,
+      defaultAreaId: areas[0]._id,
+      onSubmit: vi.fn(),
+    } as const;
+
+    // AppShell mounts the create dialog only while it is open, so a reopen is
+    // a remount rather than a prop flip.
+    const { unmount } = render(<ThreadFormDialog {...props} />);
+    await user.type(screen.getByLabelText("Title"), "Draft title");
+    unmount();
+
+    render(<ThreadFormDialog {...props} />);
+
+    expect(screen.getByLabelText("Title")).toHaveValue("");
+    expect(screen.getByRole("button", { name: /Health/ })).toBeInTheDocument();
+  });
+
   it("prevents duplicate thread creates while saving", async () => {
     const user = userEvent.setup();
     const pendingCreate = deferred();

--- a/apps/web/src/hooks/use-attention-clock.test.ts
+++ b/apps/web/src/hooks/use-attention-clock.test.ts
@@ -1,0 +1,153 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { nextLocalMidnight, useAttentionClock } from "./use-attention-clock";
+
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+
+const noon = new Date(2026, 6, 17, 12, 30).getTime();
+const nextMidnight = new Date(2026, 6, 18).getTime();
+
+describe("useAttentionClock", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(noon);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("holds one timestamp still for the whole local day", () => {
+    const { result, unmount } = renderHook(() => useAttentionClock());
+    expect(result.current).toBe(noon);
+
+    act(() => vi.advanceTimersByTime(11 * HOUR));
+    expect(result.current).toBe(noon);
+
+    unmount();
+  });
+
+  it("steps to the new day at local midnight, without remounting", () => {
+    const { result, unmount } = renderHook(() => useAttentionClock());
+
+    act(() => vi.advanceTimersByTime(nextMidnight - noon - 1));
+    expect(result.current).toBe(noon);
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current).toBe(nextMidnight);
+
+    unmount();
+  });
+
+  it("reschedules itself for every following midnight", () => {
+    const { result, unmount } = renderHook(() => useAttentionClock());
+
+    act(() => vi.advanceTimersByTime(nextMidnight - noon));
+    act(() => vi.advanceTimersByTime(DAY));
+    expect(result.current).toBe(new Date(2026, 6, 19).getTime());
+
+    act(() => vi.advanceTimersByTime(DAY));
+    expect(result.current).toBe(new Date(2026, 6, 20).getTime());
+
+    unmount();
+  });
+
+  it("hands every consumer the same instant from a single timer", () => {
+    const first = renderHook(() => useAttentionClock());
+    const second = renderHook(() => useAttentionClock());
+
+    expect(second.result.current).toBe(first.result.current);
+    expect(vi.getTimerCount()).toBe(1);
+
+    act(() => vi.advanceTimersByTime(nextMidnight - noon));
+    expect(first.result.current).toBe(nextMidnight);
+    expect(second.result.current).toBe(nextMidnight);
+
+    first.unmount();
+    second.unmount();
+  });
+
+  it("clears the rollover timer once the last consumer unmounts", () => {
+    const first = renderHook(() => useAttentionClock());
+    const second = renderHook(() => useAttentionClock());
+
+    first.unmount();
+    expect(vi.getTimerCount()).toBe(1);
+
+    second.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("picks the clock back up on the day it is remounted", () => {
+    const first = renderHook(() => useAttentionClock());
+    first.unmount();
+
+    vi.setSystemTime(noon + 3 * DAY);
+    const second = renderHook(() => useAttentionClock());
+    expect(second.result.current).toBe(noon + 3 * DAY);
+
+    second.unmount();
+  });
+});
+
+describe("nextLocalMidnight", () => {
+  it("targets the start of the next local calendar day", () => {
+    const cases = [
+      new Date(2026, 6, 17, 0, 0, 0, 0),
+      new Date(2026, 6, 17, 12, 30),
+      new Date(2026, 6, 17, 23, 59, 59, 999),
+      new Date(2026, 11, 31, 18, 0),
+    ];
+
+    for (const at of cases) {
+      const next = new Date(nextLocalMidnight(at.getTime()));
+
+      expect(next.getHours()).toBe(0);
+      expect(next.getMinutes()).toBe(0);
+      expect(next.getSeconds()).toBe(0);
+      expect(next.getMilliseconds()).toBe(0);
+      expect(next.getTime()).toBeGreaterThan(at.getTime());
+      expect(next.getTime() - at.getTime()).toBeLessThanOrEqual(DAY);
+      expect(next.toDateString()).toBe(
+        new Date(
+          at.getFullYear(),
+          at.getMonth(),
+          at.getDate() + 1,
+        ).toDateString(),
+      );
+    }
+  });
+
+  it("crosses local midnight, not UTC midnight", () => {
+    const tz = process.env.TZ;
+    // UTC+9: 23:30 local on the 17th is still 14:30 UTC on the same UTC day,
+    // so a UTC-based clock would roll over nine hours late.
+    process.env.TZ = "Asia/Tokyo";
+
+    const late = new Date(2026, 6, 17, 23, 30).getTime();
+    const next = nextLocalMidnight(late);
+
+    expect(next - late).toBe(30 * 60_000);
+    expect(new Date(next).getHours()).toBe(0);
+    expect(new Date(next).getUTCHours()).toBe(15);
+
+    process.env.TZ = tz;
+  });
+
+  it("crosses local midnight west of UTC too", () => {
+    const tz = process.env.TZ;
+    // UTC-10: 00:30 local on the 17th is already 10:30 UTC, so a UTC-based
+    // clock would have rolled over half an hour ago.
+    process.env.TZ = "Pacific/Honolulu";
+
+    const early = new Date(2026, 6, 17, 0, 30).getTime();
+    const next = nextLocalMidnight(early);
+
+    expect(next - early).toBe(DAY - 30 * 60_000);
+    expect(new Date(next).getHours()).toBe(0);
+
+    process.env.TZ = tz;
+  });
+});

--- a/apps/web/src/hooks/use-attention-clock.ts
+++ b/apps/web/src/hooks/use-attention-clock.ts
@@ -1,0 +1,70 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * The attention clock — one "now" for every surface that reads a date.
+ *
+ * Inbox ordering, Thread attention grouping, the Dashboard date and the Plan
+ * axis all classify by *day*, so they read a single timestamp that holds still
+ * for the whole local day and steps forward once, at local midnight. Nothing
+ * has to remount for the day to turn over, and no surface drifts onto its own
+ * idea of today by reading the wall clock as it renders.
+ *
+ * The clock is a module-level store rather than per-component state so that
+ * every consumer sees the same instant and the app arms one timer, not one per
+ * mounted list.
+ */
+
+/** The midnight that opens the local calendar day after `at`. */
+export function nextLocalMidnight(at: number): number {
+  const date = new Date(at);
+  return new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate() + 1,
+  ).getTime();
+}
+
+let now = Date.now();
+let rollover: ReturnType<typeof setTimeout> | undefined;
+const listeners = new Set<() => void>();
+
+function scheduleRollover() {
+  const midnight = nextLocalMidnight(now);
+
+  rollover = setTimeout(
+    () => {
+      // A timer is allowed to fire a hair early; never land back on the day we
+      // just left.
+      now = Math.max(Date.now(), midnight);
+      scheduleRollover();
+      for (const listener of listeners) listener();
+    },
+    Math.max(midnight - Date.now(), 0),
+  );
+}
+
+function subscribe(listener: () => void): () => void {
+  // With nobody watching, the clock stops. Re-read it before arming the timer
+  // again; React compares the snapshot after subscribing, so a day that passed
+  // while the app was unmounted still lands.
+  if (listeners.size === 0) {
+    now = Date.now();
+    scheduleRollover();
+  }
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size > 0) return;
+    clearTimeout(rollover);
+    rollover = undefined;
+  };
+}
+
+function snapshot(): number {
+  return now;
+}
+
+export function useAttentionClock(): number {
+  return useSyncExternalStore(subscribe, snapshot, snapshot);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -10,6 +10,10 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import {
+  AppErrorBoundary,
+  RouteErrorFallback,
+} from "./components/error-boundary";
+import {
   initializeTheme,
   ThemeProvider,
   useTheme,
@@ -28,7 +32,12 @@ const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL, {
   expectAuth: true,
 });
 
-const router = createRouter({ routeTree });
+// Every match gets a branded boundary; routes that own the whole viewport
+// override this with the full-page `AppErrorFallback`.
+const router = createRouter({
+  routeTree,
+  defaultErrorComponent: RouteErrorFallback,
+});
 
 declare module "@tanstack/react-router" {
   interface Register {
@@ -41,21 +50,23 @@ if (!root) throw new Error("Root element not found");
 
 createRoot(root).render(
   <StrictMode>
-    <ThemeProvider>
-      <ConvexBetterAuthProvider
-        client={convex}
-        // The component's AuthClient union reduces useSession data to `never`
-        // under TypeScript 7, despite this matching its documented plugin setup.
-        authClient={authClient as unknown as AuthClient}
-      >
-        <ConvexQueryCacheProvider expiration={300_000}>
-          <FeedbackProvider>
-            <RouterProvider router={router} />
-            <ThemeAwareToaster />
-          </FeedbackProvider>
-        </ConvexQueryCacheProvider>
-      </ConvexBetterAuthProvider>
-    </ThemeProvider>
+    <AppErrorBoundary>
+      <ThemeProvider>
+        <ConvexBetterAuthProvider
+          client={convex}
+          // The component's AuthClient union reduces useSession data to `never`
+          // under TypeScript 7, despite this matching its documented plugin setup.
+          authClient={authClient as unknown as AuthClient}
+        >
+          <ConvexQueryCacheProvider expiration={300_000}>
+            <FeedbackProvider>
+              <RouterProvider router={router} />
+              <ThemeAwareToaster />
+            </FeedbackProvider>
+          </ConvexQueryCacheProvider>
+        </ConvexBetterAuthProvider>
+      </ThemeProvider>
+    </AppErrorBoundary>
   </StrictMode>,
 );
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,6 +1,8 @@
 import { createRootRoute, HeadContent, Outlet } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 
+import { AppErrorFallback } from "@/components/error-boundary";
+
 export const Route = createRootRoute({
   head: () => ({
     meta: [
@@ -11,6 +13,7 @@ export const Route = createRootRoute({
       },
     ],
   }),
+  errorComponent: AppErrorFallback,
   component: RootLayout,
 });
 

--- a/apps/web/src/routes/_unauthenticated/route.tsx
+++ b/apps/web/src/routes/_unauthenticated/route.tsx
@@ -2,8 +2,10 @@ import { createFileRoute, Navigate, Outlet } from "@tanstack/react-router";
 import { useConvexAuth } from "convex/react";
 
 import { AuthVerifyingLoader } from "@/components/auth/auth-verifying-loader";
+import { AppErrorFallback } from "@/components/error-boundary";
 
 export const Route = createFileRoute("/_unauthenticated")({
+  errorComponent: AppErrorFallback,
   component: UnauthenticatedLayout,
 });
 

--- a/apps/web/src/routes/_unauthenticated/sign-in.tsx
+++ b/apps/web/src/routes/_unauthenticated/sign-in.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { AppErrorFallback } from "@/components/error-boundary";
 import { SignInScreen } from "@/features/auth/screens/sign-in-screen";
 
 export const Route = createFileRoute("/_unauthenticated/sign-in")({
@@ -17,6 +18,7 @@ export const Route = createFileRoute("/_unauthenticated/sign-in")({
       },
     ],
   }),
+  errorComponent: AppErrorFallback,
   component: SignInRoute,
 });
 

--- a/apps/web/src/routes/_unauthenticated/sign-up.tsx
+++ b/apps/web/src/routes/_unauthenticated/sign-up.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { AppErrorFallback } from "@/components/error-boundary";
 import { SignUpScreen } from "@/features/auth/screens/sign-up-screen";
 
 export const Route = createFileRoute("/_unauthenticated/sign-up")({
@@ -17,6 +18,7 @@ export const Route = createFileRoute("/_unauthenticated/sign-up")({
       },
     ],
   }),
+  errorComponent: AppErrorFallback,
   component: SignUpRoute,
 });
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "format:check": "oxfmt --check .",
     "test": "turbo run test",
     "test:run": "turbo run test:run",
+    "typecheck": "turbo run typecheck",
     "convex": "turbo run convex --filter=@vita-os/web"
   },
   "workspaces": [

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -8,6 +8,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "paths": {
       "@vita-os/ui/*": ["./src/*"]
     }

--- a/turbo.json
+++ b/turbo.json
@@ -1,9 +1,14 @@
 {
   "$schema": "https://turborepo.dev/schema.json",
+  "globalDependencies": ["bun.lock", "oxlint.config.ts", "oxfmt.config.ts"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "env": ["VITE_CONVEX_URL", "VITE_CONVEX_SITE_URL", "VITE_SITE_URL"],
       "outputs": ["dist/**"]
+    },
+    "typecheck": {
+      "dependsOn": ["^typecheck"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
Implements three independent sub-issues of #246 (codebase health remediation), developed in parallel in one worktree with disjoint file ownership. One commit per issue.

Closes #253. Closes #255. Closes #256.

## #253 — Attention clock and Plan day-axis rollover
- New `useAttentionClock()` hook: a module-level store (`useSyncExternalStore`) providing one day-stable "now" shared by every consumer, with a single timer that rolls over at local midnight (DST-safe, resyncs on resubscribe, cleans up with the last consumer).
- Rewired the mount-frozen snapshot in `DashboardScreen` (memoized query args, so `dashboard.overview` re-runs only at rollover) and the per-render `Date.now()` reads in the Inbox list and Area threads section.
- Plan's pure model is untouched; new tests prove the axis/lanes recompute on rollover (former Today → overdue, new Today, exact days keep their place, no-date stays no-date). Clock tests cover day stability, rollover scheduling across consecutive midnights, timer cleanup, and non-UTC timezones.

## #255 — Error boundaries and on-demand app shell surfaces
- `AppErrorBoundary` wraps the provider stack above `RouterProvider`; `__root`, the unauthenticated routes, and the router's `defaultErrorComponent` all render a branded recovery screen with working reload/retry actions.
- The command palette and the Create Area / Create Thread / New Task dialogs mount only while open — fresh form state on reopen from every entry point (palette, top bar, mobile nav, shortcuts).
- Palette-only `areas.list`/`threads.list` subscriptions are gone while closed; the palette self-subscribes when mounted, and AppShell keeps a `"skip"`-gated `areas.list` for the create-thread dialog.
- Known trade-off: conditional mounting drops the ~100 ms close animation on these surfaces; restoring it needs `onOpenChangeComplete` plumbing in `packages/ui` (follow-up).

## #256 — Build and CI hardening
- `turbo.json`: `globalDependencies` (lockfile + lint configs) and `env: [VITE_CONVEX_URL, VITE_CONVEX_SITE_URL, VITE_SITE_URL]` on build — verified hit → miss → hit when switching the Convex URL, with the URL provably baked into different bundles.
- New `typecheck` task wired root → turbo → CI, covering apps/web (including the previously unreferenced `convex/tsconfig.json`) and packages/ui, whose orphaned typecheck script hid a real TS5097 error (fixed).
- CI adds: typecheck step and a chunk-graph guard (`apps/web/scripts/check-chunks.mjs`) that fails if the sign-in route's static import closure can reach the authenticated shell (currently: 6 chunks reachable, 26 deferred).
- The codegen-drift check from the issue was implemented and then dropped by decision: it needs a `CONVEX_DEPLOY_KEY` secret in CI to bundle component types, and CI has no deployment credentials. Staleness in `_generated/` surfaces at the next local `convex dev` or deploy instead.

## Maintainer action (optional)
- Set `VITE_CONVEX_URL` / `VITE_CONVEX_SITE_URL` / `VITE_SITE_URL` repo variables if the CI build should bake real deployment URLs; the build succeeds without them since the env guard throws at browser runtime, not build time.

## Verification
`bun run lint`, `bun run typecheck`, `bun run build`, `bun run test:run` all pass from the repo root — 55 test files, 298 tests (+26 new). Chunk guard passes on the production build.