### PR TITLE
feat(convex): delete unauthenticated/dead functions and centralize owned-document access (#248, #249)

### DIFF
--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -21,6 +21,7 @@ import type * as lib_condition from "../lib/condition.js";
 import type * as lib_dashboard from "../lib/dashboard.js";
 import type * as lib_helpers from "../lib/helpers.js";
 import type * as lib_inboxProcessing from "../lib/inboxProcessing.js";
+import type * as lib_ownedAccess from "../lib/ownedAccess.js";
 import type * as lib_patch from "../lib/patch.js";
 import type * as lib_slugs from "../lib/slugs.js";
 import type * as lib_threadChanges from "../lib/threadChanges.js";
@@ -49,6 +50,7 @@ declare const fullApi: ApiFromModules<{
   "lib/dashboard": typeof lib_dashboard;
   "lib/helpers": typeof lib_helpers;
   "lib/inboxProcessing": typeof lib_inboxProcessing;
+  "lib/ownedAccess": typeof lib_ownedAccess;
   "lib/patch": typeof lib_patch;
   "lib/slugs": typeof lib_slugs;
   "lib/threadChanges": typeof lib_threadChanges;

--- a/apps/web/convex/activityLogs.ts
+++ b/apps/web/convex/activityLogs.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 
 import { mutation, query } from "./_generated/server";
 import { getAuthUserId, safeGetAuthUserId } from "./lib/helpers";
+import { getOwned, requireOwned } from "./lib/ownedAccess";
 
 export const listByThread = query({
   args: { threadId: v.id("threads") },
@@ -9,8 +10,11 @@ export const listByThread = query({
     const userId = await safeGetAuthUserId(ctx);
     if (!userId) return [];
 
-    const thread = await ctx.db.get(args.threadId);
-    if (!thread || thread.userId !== userId) return [];
+    const thread = await getOwned(ctx, "threads", {
+      userId,
+      id: args.threadId,
+    });
+    if (!thread) return [];
 
     return ctx.db
       .query("activityLogs")
@@ -28,10 +32,7 @@ export const create = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
 
-    const thread = await ctx.db.get(args.threadId);
-    if (!thread || thread.userId !== userId) {
-      throw new Error("Thread not found");
-    }
+    await requireOwned(ctx, "threads", { userId, id: args.threadId });
 
     return ctx.db.insert("activityLogs", {
       userId,

--- a/apps/web/convex/areas.ts
+++ b/apps/web/convex/areas.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { assertAreaCanBeDeleted } from "./lib/areaThreads";
 import { getAuthUserId, getNextOrder, safeGetAuthUserId } from "./lib/helpers";
+import { getOwned, getOwnedBySlug, requireOwned } from "./lib/ownedAccess";
 import { nullsToUndefined } from "./lib/patch";
 import { generateSlug } from "./lib/slugs";
 import { validateAreaName } from "./lib/validation";
@@ -25,9 +26,7 @@ export const get = query({
   handler: async (ctx, args) => {
     const userId = await safeGetAuthUserId(ctx);
     if (!userId) return null;
-    const area = await ctx.db.get(args.id);
-    if (!area || area.userId !== userId) return null;
-    return area;
+    return getOwned(ctx, "areas", { userId, id: args.id });
   },
 });
 
@@ -36,12 +35,7 @@ export const getBySlug = query({
   handler: async (ctx, args) => {
     const userId = await safeGetAuthUserId(ctx);
     if (!userId) return null;
-    return ctx.db
-      .query("areas")
-      .withIndex("by_user_slug", (q) =>
-        q.eq("userId", userId).eq("slug", args.slug),
-      )
-      .unique();
+    return getOwnedBySlug(ctx, "areas", { userId, slug: args.slug });
   },
 });
 
@@ -86,10 +80,7 @@ export const update = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
 
-    const area = await ctx.db.get(args.id);
-    if (!area || area.userId !== userId) {
-      throw new Error("Area not found");
-    }
+    const area = await requireOwned(ctx, "areas", { userId, id: args.id });
 
     const { id, ...rest } = args;
     if (rest.name !== undefined) {
@@ -114,10 +105,7 @@ export const remove = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
 
-    const area = await ctx.db.get(args.id);
-    if (!area || area.userId !== userId) {
-      throw new Error("Area not found");
-    }
+    await requireOwned(ctx, "areas", { userId, id: args.id });
 
     await assertAreaCanBeDeleted(ctx, { userId, areaId: args.id });
 

--- a/apps/web/convex/areas.ts
+++ b/apps/web/convex/areas.ts
@@ -124,20 +124,3 @@ export const remove = mutation({
     await ctx.db.delete(args.id);
   },
 });
-
-export const reorder = mutation({
-  args: {
-    tasks: v.array(v.object({ id: v.id("areas"), order: v.number() })),
-  },
-  handler: async (ctx, args) => {
-    const userId = await getAuthUserId(ctx);
-
-    for (const task of args.tasks) {
-      const area = await ctx.db.get(task.id);
-      if (!area || area.userId !== userId) {
-        throw new Error("Area not found");
-      }
-      await ctx.db.patch(task.id, { order: task.order });
-    }
-  },
-});

--- a/apps/web/convex/auth.ts
+++ b/apps/web/convex/auth.ts
@@ -5,7 +5,6 @@ import { betterAuth } from "better-auth/minimal";
 import type { DataModel } from "./_generated/dataModel";
 
 import { components } from "./_generated/api";
-import { query } from "./_generated/server";
 import authConfig from "./auth.config";
 
 const siteUrl = process.env.SITE_URL ?? "";
@@ -45,10 +44,3 @@ export const createAuth = (ctx: GenericCtx<DataModel>) => {
     plugins: [crossDomain({ siteUrl }), convex({ authConfig })],
   });
 };
-
-export const getCurrentUser = query({
-  args: {},
-  handler: async (ctx) => {
-    return authComponent.getAuthUser(ctx);
-  },
-});

--- a/apps/web/convex/authorization.test.ts
+++ b/apps/web/convex/authorization.test.ts
@@ -1,0 +1,506 @@
+import type { TestConvex, TestConvexForDataModel } from "convex-test";
+import type { DataModelFromSchemaDefinition } from "convex/server";
+
+import betterAuthTest from "@convex-dev/better-auth/test";
+import { convexTest } from "convex-test";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { Id } from "./_generated/dataModel";
+
+import { api, components } from "./_generated/api";
+import schema from "./schema";
+
+/**
+ * Authorization tests for every public Convex function, exercised through
+ * `api.*` exactly as a client would.
+ *
+ * Auth is real, not stubbed: the Better Auth component is registered with
+ * `@convex-dev/better-auth/test` (its documented `register` helper), and
+ * `signIn` seeds a `user` + non-expired `session` through the component's own
+ * `adapter.create` mutation. `authComponent.getAuthUser` then resolves the
+ * identity the same way it does in production — `ctx.auth.getUserIdentity()`,
+ * then a session lookup by `identity.sessionId` and a user lookup by
+ * `identity.subject` against the component's tables.
+ */
+
+const modules = import.meta.glob("./**/*.ts");
+
+type Schema = typeof schema;
+type TestApi = TestConvex<Schema>;
+type SignedIn = TestConvexForDataModel<DataModelFromSchemaDefinition<Schema>>;
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function setupTest(): TestApi {
+  const t = convexTest(schema, modules);
+  betterAuthTest.register(t);
+  return t;
+}
+
+/**
+ * Create a Better Auth user with a live session and return a `t` bound to
+ * that identity.
+ */
+async function signIn(t: TestApi, email: string): Promise<SignedIn> {
+  const now = Date.now();
+
+  const user = await t.run((ctx) =>
+    ctx.runMutation(components.betterAuth.adapter.create, {
+      input: {
+        model: "user",
+        data: {
+          name: email,
+          email,
+          emailVerified: true,
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+    }),
+  );
+
+  const session = await t.run((ctx) =>
+    ctx.runMutation(components.betterAuth.adapter.create, {
+      input: {
+        model: "session",
+        data: {
+          userId: user._id,
+          token: `token-${email}`,
+          expiresAt: now + HOUR_MS,
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+    }),
+  );
+
+  return t.withIdentity({ subject: user._id, sessionId: session._id });
+}
+
+interface Fixture {
+  areaId: Id<"areas">;
+  areaSlug: string;
+  logId: Id<"activityLogs">;
+  taskId: Id<"tasks">;
+  threadId: Id<"threads">;
+  threadSlug: string;
+}
+
+/** One Area, Thread, Task and Activity Log, all created through `api.*`. */
+async function seed(as: SignedIn): Promise<Fixture> {
+  const area = await as.mutation(api.areas.create, {
+    name: "Family Health",
+    condition: "healthy",
+    icon: "HeartPulse",
+  });
+  const thread = await as.mutation(api.threads.create, {
+    title: "Book checkup",
+    areaId: area.id,
+  });
+  await as.mutation(api.threads.update, {
+    id: thread.id,
+    nextMove: "Call the clinic",
+  });
+  const taskId = await as.mutation(api.tasks.create, { text: "Buy vitamins" });
+  const logId = await as.mutation(api.activityLogs.create, {
+    threadId: thread.id,
+    content: "Left a voicemail",
+  });
+
+  return {
+    areaId: area.id,
+    areaSlug: area.slug,
+    threadId: thread.id,
+    threadSlug: thread.slug,
+    taskId,
+    logId,
+  };
+}
+
+describe("owned-document authorization", () => {
+  let t: TestApi;
+  let owner: SignedIn;
+  let intruder: SignedIn;
+  let owned: Fixture;
+
+  beforeEach(async () => {
+    t = setupTest();
+    owner = await signIn(t, "owner@example.com");
+    intruder = await signIn(t, "intruder@example.com");
+    owned = await seed(owner);
+  });
+
+  describe("areas", () => {
+    it("hides another user's Area from every read", async () => {
+      // Assert the owner's side first: an isolation check alone would pass
+      // against a function that returned nothing to anybody.
+      expect(
+        (await owner.query(api.areas.list, {})).map((area) => area._id),
+      ).toEqual([owned.areaId]);
+      expect(await owner.query(api.areas.get, { id: owned.areaId })).toEqual(
+        expect.objectContaining({ _id: owned.areaId }),
+      );
+      expect(
+        await owner.query(api.areas.getBySlug, { slug: owned.areaSlug }),
+      ).toEqual(expect.objectContaining({ _id: owned.areaId }));
+
+      expect(await intruder.query(api.areas.list, {})).toEqual([]);
+      expect(await intruder.query(api.areas.get, { id: owned.areaId })).toBe(
+        null,
+      );
+      expect(
+        await intruder.query(api.areas.getBySlug, { slug: owned.areaSlug }),
+      ).toBe(null);
+    });
+
+    it("refuses another user's Area in every mutation", async () => {
+      await expect(
+        intruder.mutation(api.areas.update, {
+          id: owned.areaId,
+          name: "Stolen",
+        }),
+      ).rejects.toThrow(/Area not found/);
+      await expect(
+        intruder.mutation(api.areas.remove, { id: owned.areaId }),
+      ).rejects.toThrow(/Area not found/);
+
+      expect(await owner.query(api.areas.get, { id: owned.areaId })).toEqual(
+        expect.objectContaining({ name: "Family Health" }),
+      );
+    });
+
+    it("refuses unauthenticated mutations", async () => {
+      await expect(
+        t.mutation(api.areas.create, {
+          name: "Anon",
+          condition: "healthy",
+          icon: "HeartPulse",
+        }),
+      ).rejects.toThrow();
+      await expect(
+        t.mutation(api.areas.update, { id: owned.areaId, name: "Anon" }),
+      ).rejects.toThrow();
+      await expect(
+        t.mutation(api.areas.remove, { id: owned.areaId }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("threads", () => {
+    it("hides another user's Thread from every read", async () => {
+      expect(
+        (await owner.query(api.threads.list, {})).map((thread) => thread._id),
+      ).toEqual([owned.threadId]);
+      expect(
+        await owner.query(api.threads.get, { id: owned.threadId }),
+      ).toEqual(expect.objectContaining({ _id: owned.threadId }));
+      expect(
+        await owner.query(api.threads.getBySlug, { slug: owned.threadSlug }),
+      ).toEqual(expect.objectContaining({ _id: owned.threadId }));
+      expect(
+        (
+          await owner.query(api.threads.listByArea, { areaId: owned.areaId })
+        ).map((thread) => thread._id),
+      ).toEqual([owned.threadId]);
+
+      expect(await intruder.query(api.threads.list, {})).toEqual([]);
+      expect(
+        await intruder.query(api.threads.get, { id: owned.threadId }),
+      ).toBe(null);
+      expect(
+        await intruder.query(api.threads.getBySlug, { slug: owned.threadSlug }),
+      ).toBe(null);
+      expect(
+        await intruder.query(api.threads.listByArea, { areaId: owned.areaId }),
+      ).toEqual([]);
+    });
+
+    it("refuses another user's Thread in every mutation", async () => {
+      await expect(
+        intruder.mutation(api.threads.update, {
+          id: owned.threadId,
+          title: "Stolen",
+        }),
+      ).rejects.toThrow(/Thread not found/);
+      await expect(
+        intruder.mutation(api.threads.remove, { id: owned.threadId }),
+      ).rejects.toThrow(/Thread not found/);
+      await expect(
+        intruder.mutation(api.threads.completeNextMoveMutation, {
+          id: owned.threadId,
+        }),
+      ).rejects.toThrow(/Thread not found/);
+    });
+
+    it("refuses filing a Thread under another user's Area", async () => {
+      await expect(
+        intruder.mutation(api.threads.create, {
+          title: "Squatting",
+          areaId: owned.areaId,
+        }),
+      ).rejects.toThrow(/Area not found/);
+    });
+
+    it("refuses moving one's own Thread into another user's Area", async () => {
+      const theirs = await seed(intruder);
+
+      await expect(
+        intruder.mutation(api.threads.update, {
+          id: theirs.threadId,
+          areaId: owned.areaId,
+        }),
+      ).rejects.toThrow(/Area not found/);
+    });
+
+    it("refuses unauthenticated mutations", async () => {
+      await expect(
+        t.mutation(api.threads.create, {
+          title: "Anon",
+          areaId: owned.areaId,
+        }),
+      ).rejects.toThrow();
+      await expect(
+        t.mutation(api.threads.update, { id: owned.threadId, title: "Anon" }),
+      ).rejects.toThrow();
+      await expect(
+        t.mutation(api.threads.remove, { id: owned.threadId }),
+      ).rejects.toThrow();
+      await expect(
+        t.mutation(api.threads.completeNextMoveMutation, {
+          id: owned.threadId,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("tasks", () => {
+    it("hides another user's Task from every read", async () => {
+      expect(
+        (await owner.query(api.tasks.list, {})).map((task) => task._id),
+      ).toEqual([owned.taskId]);
+      expect(await owner.query(api.tasks.count, {})).toBe(1);
+
+      expect(await intruder.query(api.tasks.list, {})).toEqual([]);
+      expect(await intruder.query(api.tasks.count, {})).toBe(0);
+    });
+
+    it("refuses another user's Task in every mutation", async () => {
+      await expect(
+        intruder.mutation(api.tasks.remove, { id: owned.taskId }),
+      ).rejects.toThrow(/Task not found/);
+      await expect(
+        intruder.mutation(api.tasks.updateText, {
+          id: owned.taskId,
+          text: "Stolen",
+        }),
+      ).rejects.toThrow(/Task not found/);
+      await expect(
+        intruder.mutation(api.tasks.updateWhen, {
+          id: owned.taskId,
+          when: Date.now(),
+        }),
+      ).rejects.toThrow(/Task not found/);
+      await expect(
+        intruder.mutation(api.tasks.markDone, { id: owned.taskId }),
+      ).rejects.toThrow(/Task not found/);
+      await expect(
+        intruder.mutation(api.tasks.markOpen, { id: owned.taskId }),
+      ).rejects.toThrow(/Task not found/);
+      await expect(
+        intruder.mutation(api.tasks.process, {
+          id: owned.taskId,
+          action: { type: "discard" },
+        }),
+      ).rejects.toThrow(/Task not found/);
+
+      expect(await owner.query(api.tasks.count, {})).toBe(1);
+    });
+
+    it("refuses processing one's own Task into another user's Thread", async () => {
+      const theirs = await seed(intruder);
+
+      await expect(
+        intruder.mutation(api.tasks.process, {
+          id: theirs.taskId,
+          action: {
+            type: "add_activity_log_entry",
+            threadId: owned.threadId,
+          },
+        }),
+      ).rejects.toThrow(/Thread not found/);
+      await expect(
+        intruder.mutation(api.tasks.process, {
+          id: theirs.taskId,
+          action: { type: "set_next_move", threadId: owned.threadId },
+        }),
+      ).rejects.toThrow(/Thread not found/);
+      await expect(
+        intruder.mutation(api.tasks.process, {
+          id: theirs.taskId,
+          action: {
+            type: "create_thread",
+            title: "Squatting",
+            areaId: owned.areaId,
+          },
+        }),
+      ).rejects.toThrow(/Area not found/);
+    });
+
+    it("refuses unauthenticated mutations", async () => {
+      await expect(
+        t.mutation(api.tasks.create, { text: "Anon" }),
+      ).rejects.toThrow();
+      await expect(
+        t.mutation(api.tasks.remove, { id: owned.taskId }),
+      ).rejects.toThrow();
+      await expect(
+        t.mutation(api.tasks.updateText, { id: owned.taskId, text: "Anon" }),
+      ).rejects.toThrow();
+      await expect(
+        t.mutation(api.tasks.markDone, { id: owned.taskId }),
+      ).rejects.toThrow();
+      await expect(
+        t.mutation(api.tasks.process, {
+          id: owned.taskId,
+          action: { type: "discard" },
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("activityLogs", () => {
+    it("hides another user's Activity Log from every read", async () => {
+      expect(
+        (
+          await owner.query(api.activityLogs.listByThread, {
+            threadId: owned.threadId,
+          })
+        ).map((log) => log._id),
+      ).toContain(owned.logId);
+
+      expect(
+        await intruder.query(api.activityLogs.listByThread, {
+          threadId: owned.threadId,
+        }),
+      ).toEqual([]);
+    });
+
+    it("refuses writing to another user's Thread", async () => {
+      await expect(
+        intruder.mutation(api.activityLogs.create, {
+          threadId: owned.threadId,
+          content: "Injected",
+        }),
+      ).rejects.toThrow(/Thread not found/);
+
+      const logs = await owner.query(api.activityLogs.listByThread, {
+        threadId: owned.threadId,
+      });
+      expect(logs.map((log) => log._id)).toContain(owned.logId);
+      expect(logs.map((log) => log.content)).not.toContain("Injected");
+    });
+
+    it("refuses unauthenticated mutations", async () => {
+      await expect(
+        t.mutation(api.activityLogs.create, {
+          threadId: owned.threadId,
+          content: "Anon",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("dashboard", () => {
+    it("shows another user nothing of the owner's data", async () => {
+      const mine = await owner.query(api.dashboard.overview, {
+        currentDate: Date.now(),
+        timezoneOffsetMinutes: 0,
+      });
+      expect(mine.areas.map((area) => area.id)).toEqual([owned.areaId]);
+      expect(mine.threads.map((thread) => thread.id)).toEqual([owned.threadId]);
+      expect(mine.inbox.items.map((item) => item.id)).toEqual([owned.taskId]);
+      expect(mine.recentActivity.map((entry) => entry.id)).toContain(
+        owned.logId,
+      );
+
+      const overview = await intruder.query(api.dashboard.overview, {
+        currentDate: Date.now(),
+        timezoneOffsetMinutes: 0,
+      });
+
+      expect(overview).toEqual({
+        areas: [],
+        threads: [],
+        inbox: { items: [], totalOpen: 0 },
+        recentActivity: [],
+      });
+    });
+
+    it("shows an unauthenticated caller nothing", async () => {
+      const overview = await t.query(api.dashboard.overview, {
+        currentDate: Date.now(),
+        timezoneOffsetMinutes: 0,
+      });
+
+      expect(overview.areas).toEqual([]);
+      expect(overview.threads).toEqual([]);
+    });
+  });
+
+  describe("duplicate slugs", () => {
+    it("resolves an Area slug shared by two documents to the oldest", async () => {
+      const ids = await t.run(async (ctx) => {
+        const base = {
+          userId: (await ctx.db.get("areas", owned.areaId))?.userId ?? "",
+          slug: "shared-slug",
+          condition: "healthy" as const,
+          createdAt: 0,
+        };
+        const first = await ctx.db.insert("areas", {
+          ...base,
+          name: "First",
+          order: 10,
+        });
+        const second = await ctx.db.insert("areas", {
+          ...base,
+          name: "Second",
+          order: 11,
+        });
+        return { first, second };
+      });
+
+      const found = await owner.query(api.areas.getBySlug, {
+        slug: "shared-slug",
+      });
+      expect(found?._id).toBe(ids.first);
+    });
+
+    it("resolves a Thread slug shared by two documents to the oldest", async () => {
+      const ids = await t.run(async (ctx) => {
+        const base = {
+          userId: (await ctx.db.get("threads", owned.threadId))?.userId ?? "",
+          slug: "shared-slug",
+          areaId: owned.areaId,
+          state: "open" as const,
+          createdAt: 0,
+        };
+        const first = await ctx.db.insert("threads", {
+          ...base,
+          title: "First",
+          order: 10,
+        });
+        const second = await ctx.db.insert("threads", {
+          ...base,
+          title: "Second",
+          order: 11,
+        });
+        return { first, second };
+      });
+
+      const found = await owner.query(api.threads.getBySlug, {
+        slug: "shared-slug",
+      });
+      expect(found?._id).toBe(ids.first);
+    });
+  });
+});

--- a/apps/web/convex/dashboard.ts
+++ b/apps/web/convex/dashboard.ts
@@ -91,7 +91,6 @@ export const overview = query({
     ]);
 
     return buildDashboardOverview(
-      userId,
       {
         areas,
         threads,

--- a/apps/web/convex/dashboard.ts
+++ b/apps/web/convex/dashboard.ts
@@ -1,8 +1,8 @@
 import { v } from "convex/values";
 
-import { mutation, query } from "./_generated/server";
+import { query } from "./_generated/server";
 import { buildDashboardOverview } from "./lib/dashboard";
-import { getAuthUserId, safeGetAuthUserId } from "./lib/helpers";
+import { safeGetAuthUserId } from "./lib/helpers";
 import { areaIconValidator, conditionValidator } from "./lib/validators";
 
 const dashboardAreaValidator = v.object({
@@ -47,55 +47,6 @@ const dashboardOverviewValidator = v.object({
       createdAt: v.number(),
     }),
   ),
-});
-
-export const attention = query({
-  args: {},
-  handler: async (ctx) => {
-    const userId = await safeGetAuthUserId(ctx);
-    if (!userId) return { tasks: [], byArea: {} as Record<string, number> };
-
-    const threads = await ctx.db
-      .query("threads")
-      .withIndex("by_user_order", (q) => q.eq("userId", userId))
-      .collect();
-    const openThreads = threads.filter((thread) => thread.state === "open");
-
-    const tasks: Array<{
-      threadId: string;
-      threadName: string;
-      threadSlug: string | undefined;
-      areaId: string;
-      reason: "no_next_action";
-    }> = [];
-
-    for (const thread of openThreads) {
-      const hasAction = thread.nextMove != null;
-      if (!hasAction) {
-        tasks.push({
-          threadId: thread._id,
-          threadName: thread.title,
-          threadSlug: thread.slug,
-          areaId: thread.areaId,
-          reason: "no_next_action",
-        });
-      }
-    }
-
-    const byArea: Record<string, number> = {};
-    const seenByArea = new Map<string, Set<string>>();
-    for (const task of tasks) {
-      if (!seenByArea.has(task.areaId)) {
-        seenByArea.set(task.areaId, new Set());
-      }
-      seenByArea.get(task.areaId)?.add(task.threadId);
-    }
-    for (const [areaId, threadSet] of seenByArea) {
-      byArea[areaId] = threadSet.size;
-    }
-
-    return { tasks, byArea };
-  },
 });
 
 export const overview = query({
@@ -150,47 +101,5 @@ export const overview = query({
       args.currentDate,
       args.timezoneOffsetMinutes,
     );
-  },
-});
-
-export const lastReview = query({
-  args: {},
-  handler: async (ctx) => {
-    const userId = await safeGetAuthUserId(ctx);
-    if (!userId) return null;
-
-    const settings = await ctx.db
-      .query("userSettings")
-      .withIndex("by_user", (q) => q.eq("userId", userId))
-      .unique();
-
-    return settings?.lastReviewDate ?? null;
-  },
-});
-
-export const markReviewed = mutation({
-  args: {},
-  handler: async (ctx) => {
-    const userId = await getAuthUserId(ctx);
-
-    const existing = await ctx.db
-      .query("userSettings")
-      .withIndex("by_user", (q) => q.eq("userId", userId))
-      .unique();
-
-    const now = Date.now();
-
-    if (existing) {
-      await ctx.db.patch(existing._id, {
-        lastReviewDate: now,
-      });
-    } else {
-      await ctx.db.insert("userSettings", {
-        userId,
-        lastReviewDate: now,
-      });
-    }
-
-    return now;
   },
 });

--- a/apps/web/convex/lib/areaThreads.test.ts
+++ b/apps/web/convex/lib/areaThreads.test.ts
@@ -2,22 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { Doc, Id } from "../_generated/dataModel";
 
-import { areaBelongsToUser, getAreaDeletionBlocker } from "./areaThreads";
-import { DEFAULT_CONDITION } from "./condition";
-
-function makeArea(overrides: Partial<Doc<"areas">> = {}): Doc<"areas"> {
-  return {
-    _id: "area1" as Id<"areas">,
-    _creationTime: 0,
-    userId: "user1",
-    name: "Family Health",
-    slug: "family-health-00000000",
-    condition: DEFAULT_CONDITION,
-    order: 0,
-    createdAt: 0,
-    ...overrides,
-  };
-}
+import { getAreaDeletionBlocker } from "./areaThreads";
 
 function makeThread(overrides: Partial<Doc<"threads">> = {}): Doc<"threads"> {
   return {
@@ -33,22 +18,6 @@ function makeThread(overrides: Partial<Doc<"threads">> = {}): Doc<"threads"> {
     ...overrides,
   };
 }
-
-describe("areaBelongsToUser", () => {
-  it("accepts an Area owned by the user", () => {
-    expect(areaBelongsToUser(makeArea(), "user1")).toBe(true);
-  });
-
-  it("rejects missing Areas", () => {
-    expect(areaBelongsToUser(null, "user1")).toBe(false);
-  });
-
-  it("rejects Areas owned by another user", () => {
-    expect(areaBelongsToUser(makeArea({ userId: "user2" }), "user1")).toBe(
-      false,
-    );
-  });
-});
 
 describe("getAreaDeletionBlocker", () => {
   it("allows deleting Areas with no Threads", () => {

--- a/apps/web/convex/lib/areaThreads.ts
+++ b/apps/web/convex/lib/areaThreads.ts
@@ -1,15 +1,8 @@
-import type { GenericMutationCtx } from "convex/server";
+import type { GenericMutationCtx, GenericQueryCtx } from "convex/server";
 
 import type { DataModel, Doc, Id } from "../_generated/dataModel";
 
-type MutationCtx = GenericMutationCtx<DataModel>;
-
-export function areaBelongsToUser(
-  area: Doc<"areas"> | null,
-  userId: string,
-): area is Doc<"areas"> {
-  return area !== null && area.userId === userId;
-}
+type ReadCtx = GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>;
 
 export function getAreaDeletionBlocker(
   threads: Array<Doc<"threads">>,
@@ -17,19 +10,14 @@ export function getAreaDeletionBlocker(
   return threads[0] ?? null;
 }
 
-export async function getAreaForUser(
-  ctx: MutationCtx,
-  args: { userId: string; areaId: Id<"areas"> },
-): Promise<Doc<"areas">> {
-  const area = await ctx.db.get(args.areaId);
-  if (!areaBelongsToUser(area, args.userId)) {
-    throw new Error("Area not found");
-  }
-  return area;
-}
-
+/**
+ * Threads filed under an Area, restricted to one owner.
+ *
+ * The `by_area` index is not user-scoped, so unlike a read through
+ * `ownedAccess` this one has to drop foreign Threads itself.
+ */
 export async function listThreadsInAreaForUser(
-  ctx: MutationCtx,
+  ctx: ReadCtx,
   args: { userId: string; areaId: Id<"areas"> },
 ): Promise<Array<Doc<"threads">>> {
   const threads = await ctx.db
@@ -41,7 +29,7 @@ export async function listThreadsInAreaForUser(
 }
 
 export async function assertAreaCanBeDeleted(
-  ctx: MutationCtx,
+  ctx: ReadCtx,
   args: { userId: string; areaId: Id<"areas"> },
 ): Promise<void> {
   const threads = await listThreadsInAreaForUser(ctx, args);

--- a/apps/web/convex/lib/dashboard.test.ts
+++ b/apps/web/convex/lib/dashboard.test.ts
@@ -67,19 +67,11 @@ function activity(
 }
 
 describe("buildDashboardOverview", () => {
-  it("isolates authenticated user data and returns open Threads and Tasks only", () => {
-    const result = buildDashboardOverview("user1", {
-      areas: [area("mine"), area("theirs", { userId: "user2" })],
-      threads: [
-        thread("open"),
-        thread("resolved", { state: "resolved" }),
-        thread("foreign", { userId: "user2" }),
-      ],
-      tasks: [
-        task("open"),
-        task("done", { state: "done" }),
-        task("foreign", { userId: "user2" }),
-      ],
+  it("returns open Threads and Tasks only", () => {
+    const result = buildDashboardOverview({
+      areas: [area("mine")],
+      threads: [thread("open"), thread("resolved", { state: "resolved" })],
+      tasks: [task("open"), task("done", { state: "done" })],
       activityLogs: [],
     });
 
@@ -90,7 +82,7 @@ describe("buildDashboardOverview", () => {
   });
 
   it("includes an Area Icon when one is stored", () => {
-    const result = buildDashboardOverview("user1", {
+    const result = buildDashboardOverview({
       areas: [area("health", { icon: "HeartPulse" })],
       threads: [],
       tasks: [],
@@ -105,7 +97,6 @@ describe("buildDashboardOverview", () => {
   it("returns every Open Task in the shared attention order", () => {
     const currentDate = new Date(2026, 6, 17, 12).getTime();
     const result = buildDashboardOverview(
-      "user1",
       {
         areas: [],
         threads: [],
@@ -141,7 +132,7 @@ describe("buildDashboardOverview", () => {
   });
 
   it("returns the latest entry per distinct open Thread", () => {
-    const result = buildDashboardOverview("user1", {
+    const result = buildDashboardOverview({
       areas: [],
       tasks: [],
       threads: [
@@ -155,7 +146,6 @@ describe("buildDashboardOverview", () => {
         activity("deleted-log", "deleted", 45),
         activity("a-new", "a", 40),
         activity("b-new", "b", 30),
-        activity("foreign", "b", 60, { userId: "user2" }),
       ],
     });
 

--- a/apps/web/convex/lib/dashboard.ts
+++ b/apps/web/convex/lib/dashboard.ts
@@ -44,14 +44,17 @@ export interface DashboardSource {
   threads: Doc<"threads">[];
 }
 
+/**
+ * Shape the Dashboard payload from documents the caller has already read
+ * through user-scoped indexes. This is pure presentation: it does no
+ * ownership filtering, because every input is already the caller's own.
+ */
 export function buildDashboardOverview(
-  userId: string,
   source: DashboardSource,
   currentDate = Date.now(),
   timezoneOffsetMinutes?: number,
 ) {
-  const areas = source.areas
-    .filter((area) => area.userId === userId)
+  const areas = [...source.areas]
     .sort((a, b) => a.order - b.order)
     .map(
       (area): DashboardArea => ({
@@ -65,7 +68,7 @@ export function buildDashboardOverview(
     );
 
   const openThreads = source.threads
-    .filter((thread) => thread.userId === userId && thread.state === "open")
+    .filter((thread) => thread.state === "open")
     .sort((a, b) => a.order - b.order);
   const threads = openThreads.map(
     (thread): DashboardThread => ({
@@ -81,7 +84,7 @@ export function buildDashboardOverview(
   );
 
   const openTasks = source.tasks
-    .filter((task) => task.userId === userId && task.state === "open")
+    .filter((task) => task.state === "open")
     .sort((a, b) =>
       compareTasksByAttention(a, b, currentDate, timezoneOffsetMinutes),
     );
@@ -94,8 +97,7 @@ export function buildDashboardOverview(
   // full-width activity strip at two rows of three.
   const recentActivityCap = 6;
 
-  for (const entry of source.activityLogs
-    .filter((activity) => activity.userId === userId)
+  for (const entry of [...source.activityLogs]
     .sort((a, b) => b.createdAt - a.createdAt)
     .slice(0, 50)) {
     if (!openThreadIds.has(entry.threadId) || seenThreads.has(entry.threadId)) {

--- a/apps/web/convex/lib/inboxProcessing.test.ts
+++ b/apps/web/convex/lib/inboxProcessing.test.ts
@@ -93,7 +93,8 @@ describe("processInboxTask", () => {
     };
     const ctx = {
       db: {
-        get: async (id: string) => (id === areaId ? area : null),
+        get: async (_table: string, id: string) =>
+          id === areaId ? area : null,
         query: () => ({
           withIndex: () => ({
             order: () => ({
@@ -161,7 +162,8 @@ describe("processInboxTask", () => {
     const deleted: string[] = [];
     const ctx = {
       db: {
-        get: async (id: string) => (id === thread._id ? thread : null),
+        get: async (_table: string, id: string) =>
+          id === thread._id ? thread : null,
         insert: async (table: string, value: unknown) => {
           inserted.push({ table, value });
           return "inserted";
@@ -202,7 +204,8 @@ describe("processInboxTask", () => {
     const deleted: string[] = [];
     const ctx = {
       db: {
-        get: async (id: string) => (id === thread._id ? thread : null),
+        get: async (_table: string, id: string) =>
+          id === thread._id ? thread : null,
         insert: async (table: string, value: unknown) => {
           inserted.push({ table, value });
           return "inserted";

--- a/apps/web/convex/lib/inboxProcessing.ts
+++ b/apps/web/convex/lib/inboxProcessing.ts
@@ -2,8 +2,8 @@ import type { GenericMutationCtx } from "convex/server";
 
 import type { DataModel, Doc, Id } from "../_generated/dataModel";
 
-import { getAreaForUser } from "./areaThreads";
 import { getNextOrder } from "./helpers";
+import { requireOwned } from "./ownedAccess";
 import { generateSlug } from "./slugs";
 import { applyThreadPatch } from "./threadChanges";
 
@@ -59,9 +59,9 @@ export async function processInboxTask(
   },
 ): Promise<InboxProcessingResult> {
   if (args.action.type === "create_thread") {
-    await getAreaForUser(ctx, {
+    await requireOwned(ctx, "areas", {
       userId: args.userId,
-      areaId: args.action.areaId,
+      id: args.action.areaId,
     });
 
     const nextOrder = await getNextOrder(ctx, "threads", args.userId);
@@ -93,9 +93,9 @@ export async function processInboxTask(
   }
 
   if (args.action.type === "add_activity_log_entry") {
-    const thread = await getThreadForProcessing(ctx, {
+    const thread = await requireOwned(ctx, "threads", {
       userId: args.userId,
-      threadId: args.action.threadId,
+      id: args.action.threadId,
     });
 
     await copyTaskToActivityLog(ctx, {
@@ -108,9 +108,9 @@ export async function processInboxTask(
   }
 
   if (args.action.type === "set_next_move") {
-    const thread = await getThreadForProcessing(ctx, {
+    const thread = await requireOwned(ctx, "threads", {
       userId: args.userId,
-      threadId: args.action.threadId,
+      id: args.action.threadId,
     });
 
     await applyThreadPatch(ctx, {
@@ -124,17 +124,6 @@ export async function processInboxTask(
 
   await ctx.db.delete(args.task._id);
   return { type: "discarded" };
-}
-
-async function getThreadForProcessing(
-  ctx: MutationCtx,
-  args: { userId: string; threadId: Id<"threads"> },
-): Promise<Doc<"threads">> {
-  const thread = await ctx.db.get(args.threadId);
-  if (!thread || thread.userId !== args.userId) {
-    throw new Error("Thread not found");
-  }
-  return thread;
 }
 
 async function copyTaskToActivityLog(

--- a/apps/web/convex/lib/ownedAccess.ts
+++ b/apps/web/convex/lib/ownedAccess.ts
@@ -1,0 +1,134 @@
+import type { GenericMutationCtx, GenericQueryCtx } from "convex/server";
+
+import type { DataModel, Doc, Id } from "../_generated/dataModel";
+
+/**
+ * The single way Convex functions read a document that belongs to one user.
+ *
+ * Every table in this schema stores its owner in `userId`. Reading such a
+ * document through this module means the ownership check cannot be forgotten:
+ * there is no accessor here that returns a document without comparing its
+ * owner to the caller.
+ */
+
+/** Tables whose documents belong to exactly one user through `userId`. */
+export type OwnedTable = "activityLogs" | "areas" | "tasks" | "threads";
+
+/**
+ * Owned tables that also carry a user-scoped `slug` and a `by_user_slug`
+ * index. Tasks and activity logs have no slug, so they cannot be looked up
+ * by one.
+ */
+export type SluggedTable = "areas" | "threads";
+
+type ReadCtx = GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>;
+
+/**
+ * Mirrors Convex's own guard on `db.get(table, id)`. Wrapping the type
+ * parameter in a conditional makes the `id` argument a non-inference site, so
+ * `Table` is fixed by the `table` argument alone. Without it, passing a Thread
+ * id alongside `"areas"` would compile by widening `Table` to a union.
+ */
+type NonUnion<T> = T extends never ? never : T;
+
+/**
+ * Every owned table has a `userId`, but TypeScript cannot see through a
+ * still-generic table name to prove it, so state it.
+ */
+type OwnedDoc<Table extends OwnedTable> = Doc<Table> & { userId: string };
+
+/** Fails to compile when its argument is `false`. */
+type AssertTrue<Assertion extends true> = Assertion;
+
+/**
+ * Compile-time proof of what `OwnedDoc` above asserts. Adding a table without
+ * a `userId` field to `OwnedTable` breaks this line rather than leaving the
+ * cast to fail silently at runtime.
+ */
+export type EveryOwnedDocHasUserId = AssertTrue<
+  Doc<OwnedTable> extends { userId: string } ? true : false
+>;
+
+/** Names used in the "<label> not found" errors thrown by `requireOwned`. */
+const DOCUMENT_LABELS: Record<OwnedTable, string> = {
+  activityLogs: "Activity log",
+  areas: "Area",
+  tasks: "Task",
+  threads: "Thread",
+};
+
+/**
+ * Read an owned document, or `null` when it is missing or owned by someone
+ * else. Queries use this so a foreign id is indistinguishable from a
+ * nonexistent one.
+ */
+export async function getOwned<Table extends OwnedTable>(
+  ctx: ReadCtx,
+  table: Table,
+  args: { userId: string; id: Id<NonUnion<Table>> },
+): Promise<Doc<Table> | null> {
+  const doc = (await ctx.db.get(table, args.id)) as OwnedDoc<Table> | null;
+  if (!doc || doc.userId !== args.userId) return null;
+  return doc;
+}
+
+/**
+ * Read an owned document, or throw `"<Label> not found"`. Mutations use this
+ * so a foreign id fails exactly like a missing one, leaking nothing about
+ * another user's data.
+ */
+export async function requireOwned<Table extends OwnedTable>(
+  ctx: ReadCtx,
+  table: Table,
+  args: { userId: string; id: Id<NonUnion<Table>> },
+): Promise<Doc<Table>> {
+  const doc = await getOwned(ctx, table, args);
+  if (!doc) {
+    throw new Error(`${DOCUMENT_LABELS[table]} not found`);
+  }
+  return doc;
+}
+
+/**
+ * Read an owned document by its user-scoped slug, or `null` when the user has
+ * no document with that slug.
+ *
+ * Slugs are generated, not enforced unique, so a user can end up with two
+ * documents sharing one. This resolves to the oldest match — `by_user_slug`
+ * orders equal keys by creation time — rather than failing the whole request
+ * the way a uniqueness assertion would.
+ */
+export async function getOwnedBySlug<Table extends SluggedTable>(
+  ctx: ReadCtx,
+  table: Table,
+  args: { userId: string; slug: string },
+): Promise<Doc<Table> | null> {
+  // Convex types an index range against one named table, so the two slugged
+  // tables are spelled out. The `assertNever` arm makes a third member of
+  // `SluggedTable` a compile error instead of a silent fall-through.
+  let match: Doc<"areas"> | Doc<"threads"> | null;
+  if (table === "areas") {
+    match = await ctx.db
+      .query("areas")
+      .withIndex("by_user_slug", (q) =>
+        q.eq("userId", args.userId).eq("slug", args.slug),
+      )
+      .first();
+  } else if (table === "threads") {
+    match = await ctx.db
+      .query("threads")
+      .withIndex("by_user_slug", (q) =>
+        q.eq("userId", args.userId).eq("slug", args.slug),
+      )
+      .first();
+  } else {
+    assertNever(table);
+  }
+
+  // Narrowing `table` does not narrow `Table`, hence the cast on the way out.
+  return match as Doc<Table> | null;
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled slugged table: ${String(value)}`);
+}

--- a/apps/web/convex/lib/threadChanges.ts
+++ b/apps/web/convex/lib/threadChanges.ts
@@ -6,6 +6,7 @@ import {
   type AutoActivityLogEntry,
   buildAreaMoveLogEntry,
 } from "./activityLog";
+import { getOwned } from "./ownedAccess";
 
 type MutationCtx = GenericMutationCtx<DataModel>;
 
@@ -177,8 +178,14 @@ export async function applyThreadPatch(
     writePatch.areaId !== undefined &&
     writePatch.areaId !== args.thread.areaId
   ) {
-    const fromArea = await ctx.db.get(args.thread.areaId);
-    const toArea = await ctx.db.get(writePatch.areaId);
+    const fromArea = await getOwned(ctx, "areas", {
+      userId: args.userId,
+      id: args.thread.areaId,
+    });
+    const toArea = await getOwned(ctx, "areas", {
+      userId: args.userId,
+      id: writePatch.areaId,
+    });
     if (fromArea && toArea) {
       areaMoveNames = {
         fromAreaName: fromArea.name,

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -52,11 +52,6 @@ export default defineSchema({
     .index("by_user_created", ["userId", "createdAt"])
     .index("by_user_inbox", ["userId", "state", "createdAt"]),
 
-  userSettings: defineTable({
-    userId: v.string(),
-    lastReviewDate: v.optional(v.number()),
-  }).index("by_user", ["userId"]),
-
   activityLogs: defineTable({
     userId: v.string(),
     threadId: v.id("threads"),

--- a/apps/web/convex/tasks.ts
+++ b/apps/web/convex/tasks.ts
@@ -4,6 +4,7 @@ import { mutation, query } from "./_generated/server";
 import { isOpenTask } from "./lib/attentionOrdering";
 import { getAuthUserId, safeGetAuthUserId } from "./lib/helpers";
 import { processInboxTask } from "./lib/inboxProcessing";
+import { requireOwned } from "./lib/ownedAccess";
 
 export const list = query({
   args: {},
@@ -59,10 +60,7 @@ export const remove = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
 
-    const task = await ctx.db.get(args.id);
-    if (!task || task.userId !== userId) {
-      throw new Error("Task not found");
-    }
+    await requireOwned(ctx, "tasks", { userId, id: args.id });
 
     await ctx.db.delete(args.id);
   },
@@ -73,10 +71,7 @@ export const updateText = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
 
-    const task = await ctx.db.get(args.id);
-    if (!task || task.userId !== userId) {
-      throw new Error("Task not found");
-    }
+    await requireOwned(ctx, "tasks", { userId, id: args.id });
 
     await ctx.db.patch(args.id, { text: args.text });
   },
@@ -87,10 +82,7 @@ export const updateWhen = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
 
-    const task = await ctx.db.get(args.id);
-    if (!task || task.userId !== userId) {
-      throw new Error("Task not found");
-    }
+    await requireOwned(ctx, "tasks", { userId, id: args.id });
 
     await ctx.db.patch(args.id, { when: args.when });
   },
@@ -101,10 +93,7 @@ export const markDone = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
 
-    const task = await ctx.db.get(args.id);
-    if (!task || task.userId !== userId) {
-      throw new Error("Task not found");
-    }
+    await requireOwned(ctx, "tasks", { userId, id: args.id });
 
     await ctx.db.patch(args.id, {
       state: "done",
@@ -118,10 +107,7 @@ export const markOpen = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
 
-    const task = await ctx.db.get(args.id);
-    if (!task || task.userId !== userId) {
-      throw new Error("Task not found");
-    }
+    await requireOwned(ctx, "tasks", { userId, id: args.id });
 
     await ctx.db.patch(args.id, {
       state: "open",
@@ -156,10 +142,7 @@ export const process = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
 
-    const task = await ctx.db.get(args.id);
-    if (!task || task.userId !== userId) {
-      throw new Error("Task not found");
-    }
+    const task = await requireOwned(ctx, "tasks", { userId, id: args.id });
 
     return processInboxTask(ctx, { userId, task, action: args.action });
   },

--- a/apps/web/convex/threads.ts
+++ b/apps/web/convex/threads.ts
@@ -1,8 +1,9 @@
 import { v } from "convex/values";
 
 import { mutation, query } from "./_generated/server";
-import { getAreaForUser } from "./lib/areaThreads";
+import { listThreadsInAreaForUser } from "./lib/areaThreads";
 import { getAuthUserId, getNextOrder, safeGetAuthUserId } from "./lib/helpers";
+import { getOwned, getOwnedBySlug, requireOwned } from "./lib/ownedAccess";
 import { nullsToUndefined } from "./lib/patch";
 import { generateSlug } from "./lib/slugs";
 import {
@@ -29,9 +30,7 @@ export const get = query({
   handler: async (ctx, args) => {
     const userId = await safeGetAuthUserId(ctx);
     if (!userId) return null;
-    const thread = await ctx.db.get(args.id);
-    if (!thread || thread.userId !== userId) return null;
-    return thread;
+    return getOwned(ctx, "threads", { userId, id: args.id });
   },
 });
 
@@ -40,14 +39,7 @@ export const getBySlug = query({
   handler: async (ctx, args) => {
     const userId = await safeGetAuthUserId(ctx);
     if (!userId) return null;
-    const thread = await ctx.db
-      .query("threads")
-      .withIndex("by_user_slug", (q) =>
-        q.eq("userId", userId).eq("slug", args.slug),
-      )
-      .unique();
-    if (!thread || thread.userId !== userId) return null;
-    return thread;
+    return getOwnedBySlug(ctx, "threads", { userId, slug: args.slug });
   },
 });
 
@@ -56,13 +48,14 @@ export const listByArea = query({
   handler: async (ctx, args) => {
     const userId = await safeGetAuthUserId(ctx);
     if (!userId) return [];
-    const threads = await ctx.db
-      .query("threads")
-      .withIndex("by_area", (q) => q.eq("areaId", args.areaId))
-      .collect();
-    return threads.filter(
-      (thread) => thread.userId === userId && thread.state === "open",
-    );
+    const area = await getOwned(ctx, "areas", { userId, id: args.areaId });
+    if (!area) return [];
+
+    const threads = await listThreadsInAreaForUser(ctx, {
+      userId,
+      areaId: area._id,
+    });
+    return threads.filter((thread) => thread.state === "open");
   },
 });
 
@@ -74,7 +67,7 @@ export const create = mutation({
   },
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
-    await getAreaForUser(ctx, { userId, areaId: args.areaId });
+    await requireOwned(ctx, "areas", { userId, id: args.areaId });
 
     const nextOrder = await getNextOrder(ctx, "threads", userId);
     const slug = generateSlug(args.title);
@@ -109,13 +102,10 @@ export const update = mutation({
     const userId = await getAuthUserId(ctx);
     const { id, resolutionNote, ...rest } = args;
 
-    const thread = await ctx.db.get(id);
-    if (!thread || thread.userId !== userId) {
-      throw new Error("Thread not found");
-    }
+    const thread = await requireOwned(ctx, "threads", { userId, id });
 
     if (rest.areaId !== undefined) {
-      await getAreaForUser(ctx, { userId, areaId: rest.areaId });
+      await requireOwned(ctx, "areas", { userId, id: rest.areaId });
     }
 
     let newSlug: string | undefined;
@@ -144,10 +134,10 @@ export const remove = mutation({
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
 
-    const thread = await ctx.db.get(args.id);
-    if (!thread || thread.userId !== userId) {
-      throw new Error("Thread not found");
-    }
+    const thread = await requireOwned(ctx, "threads", {
+      userId,
+      id: args.id,
+    });
 
     await ctx.db.delete(thread._id);
   },
@@ -157,10 +147,10 @@ export const completeNextMoveMutation = mutation({
   args: { id: v.id("threads") },
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
-    const thread = await ctx.db.get(args.id);
-    if (!thread || thread.userId !== userId) {
-      throw new Error("Thread not found");
-    }
+    const thread = await requireOwned(ctx, "threads", {
+      userId,
+      id: args.id,
+    });
 
     await completeNextMove(ctx, { userId, thread });
   },

--- a/apps/web/convex/threads.ts
+++ b/apps/web/convex/threads.ts
@@ -165,19 +165,3 @@ export const completeNextMoveMutation = mutation({
     await completeNextMove(ctx, { userId, thread });
   },
 });
-
-export const backfillSlugs = mutation({
-  args: {},
-  handler: async (ctx) => {
-    const threads = await ctx.db.query("threads").collect();
-    let count = 0;
-    for (const thread of threads) {
-      if (!thread.slug) {
-        const slug = generateSlug(thread.title);
-        await ctx.db.patch(thread._id, { slug });
-        count++;
-      }
-    }
-    return { backfilled: count };
-  },
-});

--- a/apps/web/convex/tsconfig.json
+++ b/apps/web/convex/tsconfig.json
@@ -9,7 +9,9 @@
     "strict": true,
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
-    "types": ["node"],
+    /* "vite/client" types `import.meta.glob`, which the convex-test suite
+     * uses to hand Convex function modules to `convexTest`. */
+    "types": ["node", "vite/client"],
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "tailwind-merge": "catalog:"
   },
   "devDependencies": {
+    "@edge-runtime/vm": "5.0.0",
     "@rolldown/plugin-babel": "0.2.3",
     "@tailwindcss/vite": "4.3.0",
     "@tanstack/react-router": "1.170.18",
@@ -49,6 +50,7 @@
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "6.0.2",
     "babel-plugin-react-compiler": "^1.0.0",
+    "convex-test": "0.0.54",
     "jsdom": "29.1.1",
     "tailwindcss": "catalog:",
     "typescript": "catalog:",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -25,11 +25,36 @@ export default defineConfig({
     },
   },
   test: {
-    globals: true,
-    environment: "jsdom",
-    setupFiles: ["./src/test/setup.ts"],
-    css: true,
     passWithNoTests: true,
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "web",
+          include: ["src/**/*.test.{ts,tsx}"],
+          globals: true,
+          environment: "jsdom",
+          setupFiles: ["./src/test/setup.ts"],
+          css: true,
+        },
+      },
+      {
+        // Convex functions run in the Convex runtime, which convex-test
+        // approximates with the edge runtime rather than jsdom.
+        extends: true,
+        test: {
+          name: "convex",
+          include: ["convex/**/*.test.ts"],
+          globals: true,
+          environment: "edge-runtime",
+          server: {
+            // Both ship raw TypeScript that Vite has to transform, and
+            // `@convex-dev/better-auth/test` needs `import.meta.glob`.
+            deps: { inline: ["convex-test", "@convex-dev/better-auth"] },
+          },
+        },
+      },
+    ],
   },
   preview: {
     port: 5173,

--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
         "tailwind-merge": "catalog:",
       },
       "devDependencies": {
+        "@edge-runtime/vm": "5.0.0",
         "@rolldown/plugin-babel": "0.2.3",
         "@tailwindcss/vite": "4.3.0",
         "@tanstack/react-router": "1.170.18",
@@ -65,6 +66,7 @@
         "@types/react-dom": "catalog:",
         "@vitejs/plugin-react": "6.0.2",
         "babel-plugin-react-compiler": "^1.0.0",
+        "convex-test": "0.0.54",
         "jsdom": "29.1.1",
         "tailwindcss": "catalog:",
         "typescript": "catalog:",
@@ -236,6 +238,10 @@
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.65.1", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.4", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-mOr9TV+DFQR0PqNAWdonSS8YWM77Y2HIVCokFs4U5GnKFNViCsMFsSzDGz1aiflI0Iu55lhZd9CgLWCkVtoVYg=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.6", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g=="],
+
+    "@edge-runtime/primitives": ["@edge-runtime/primitives@6.0.0", "", {}, "sha512-FqoxaBT+prPBHBwE1WXS1ocnu/VLTQyZ6NMUBAdbP7N2hsFTTxMC/jMu2D/8GAlMQfxeuppcPuCUk/HO3fpIvA=="],
+
+    "@edge-runtime/vm": ["@edge-runtime/vm@5.0.0", "", { "dependencies": { "@edge-runtime/primitives": "6.0.0" } }, "sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -898,6 +904,8 @@
     "convex": ["convex@1.42.3", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.21.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-7Tz/lH6UlZdiqzLPF/zrlH6Rlo/DOp836dL+GZkUMEQ2jaGGNnBIiIDcOOiEqtfSehuQ65r/rdNMnb4LupowaA=="],
 
     "convex-helpers": ["convex-helpers@0.1.120", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "convex": "^1.32.0", "hono": "^4.0.5", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "typescript": "^5.5 || ^6.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@standard-schema/spec", "hono", "react", "typescript", "zod"], "bin": { "convex-helpers": "bin.cjs" } }, "sha512-FPqtmN/10uoxmmhVq0ViNi08AnmHKT/eU1R8+ohmPZoHfg8noZEZCltApY/ASDdhq92o0kLZETggzBvMfHJDLQ=="],
+
+    "convex-test": ["convex-test@0.0.54", "", { "peerDependencies": { "convex": "^1.32.0" } }, "sha512-C0v2SQcuxrELAJRNzE6fQ686XDPor7UFoC22jcoJXeCRqhLo8ZIMZ4jyUHoo1UdAL2enCb0AbiprCVpLDN8u9Q=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 


### PR DESCRIPTION
Implements the first two sub-issues of the codebase-health remediation (#246), in dependency order on one branch.

Closes #248
Closes #249

## #248 — Delete unauthenticated/dead public Convex functions

- Removes `threads.backfillSlugs` — the repo's **only unauthenticated public function**, able to read and patch every user's Threads.
- Removes dead functions with zero client call sites: `dashboard.attention`, `dashboard.lastReview`, `dashboard.markReviewed`, `areas.reorder`, `auth.getCurrentUser`.
- Removes the `userSettings` table and its `by_user` index — `lastReview`/`markReviewed` were its only readers/writers. Orphaned rows persist unvalidated on the deployment, which Convex allows.
- `auth.getCurrentUser` was verified unused not just by grep: the installed `@convex-dev/better-auth@0.12.5` package source contains no reference to it; auth flows through `authComponent` directly and `useConvexAuth()` on the client.

## #249 — Owned-document access module + first authorization test suite

- New `convex/lib/ownedAccess.ts`: `getOwned` (get-or-null), `requireOwned` (get-or-throw, preserving the exact pre-existing "Area/Thread/Task not found" messages), and `getOwnedBySlug`, parameterized over the owned tables (`SluggedTable` narrows the slug op to areas/threads). Type-level guards: a `NonUnion` id/table agreement check mirroring Convex's own `db.get`, an exhaustive `assertNever` in the slug branch, and a compile-time assertion that every owned table's doc carries `userId`.
- All 18 inline `doc.userId !== userId` guards migrated; the only remaining `userId` comparisons are inside the module and the load-bearing filter over the non-user-scoped `by_area` index. `getAreaForUser`, `areaBelongsToUser`, and `getThreadForProcessing` are replaced by the module.
- Duplicate slugs no longer crash lookups: both `getBySlug` queries move from `.unique()` (throws on duplicates) to `.first()` on `by_user_slug` (oldest match wins, deterministically).
- Four redundant `userId ===` re-filters deleted from `lib/dashboard.ts` (their inputs were already fetched via user-scoped indexes); `buildDashboardOverview` no longer takes `userId`.
- **Net-new convex-test harness**: `convex-test@0.0.54` + `@edge-runtime/vm` under a vitest `projects` split (jsdom for `src`, edge-runtime for `convex`); `bun run test:run` from the repo root runs both. `convex-test` is pinned exact — 0.0.55 requires convex ^1.43 and breaks component calls against the repo's 1.42.3.
- Authorization suite (`convex/authorization.test.ts`) exercises the **real public functions with the real better-auth component** (registered via `@convex-dev/better-auth/test`, sessions seeded through the component's own adapter — no stubbed auth): per table, owners see their data, cross-user reads return nothing, cross-user mutations throw, unauthenticated mutations throw; plus cross-object cases (foreign Area/Thread targets) and duplicate-slug tolerance.

## Review

Implemented and independently reviewed by separate agents. The review confirmed no ownership check was lost in the migration, null-vs-throw semantics and error strings are byte-identical per function, and the test auth path resolves sessions exactly as production does. Review follow-ups applied: owner-side positive assertions added to the isolation tests, plus the type-level hardening listed above.

## Deployment status

`convex dev` was run from this branch against the dev deployment, so the function/schema deletions are already live there (`threads:backfillSlugs` is no longer callable) and the regenerated `_generated/api.d.ts` is committed. If a separate production deployment exists, deploy promptly after merging so the deletions land there too.

## Verification

From the repo root: `bun run lint`, `bun run build`, `bun run test:run` — all green (56 test files / 314+ tests, including the new convex-test project).
