### PR TITLE
feat(optimistic): shared store combinators, derived Open Task count, optimistic reopen

### DIFF
--- a/apps/web/src/features/areas/optimistic.ts
+++ b/apps/web/src/features/areas/optimistic.ts
@@ -4,7 +4,12 @@ import type { OptimisticLocalStore } from "convex/browser";
 import { api } from "@convex/_generated/api";
 import { nullsToUndefined } from "@convex/lib/patch";
 
-import { nextOrder, patchById, removeById } from "@/features/shared/optimistic";
+import {
+  nextOrder,
+  patchById,
+  patchQuery,
+  removeById,
+} from "@/features/shared/optimistic";
 
 type Area = Doc<"areas">;
 
@@ -44,15 +49,12 @@ export function optimisticallyCreateArea(
   localStore: OptimisticLocalStore,
   args: CreateAreaArgs,
 ): void {
-  const current = localStore.getQuery(api.areas.list, {});
-  if (current === undefined) return;
-
-  localStore.setQuery(api.areas.list, {}, [
-    ...current,
+  patchQuery(localStore, api.areas.list, {}, (areas) => [
+    ...areas,
     buildOptimisticArea(args, {
       id: crypto.randomUUID() as Id<"areas">,
       now: Date.now(),
-      order: nextOrder(current),
+      order: nextOrder(areas),
     }),
   ]);
 }
@@ -65,29 +67,19 @@ export function optimisticallyUpdateArea(
   const { id, ...updates } = args;
   const patch = nullsToUndefined(updates);
 
-  const current = localStore.getQuery(api.areas.list, {});
-  if (current !== undefined) {
-    localStore.setQuery(api.areas.list, {}, patchById(current, id, patch));
-  }
-
-  const single = localStore.getQuery(api.areas.get, { id });
-  if (single !== undefined && single !== null) {
-    localStore.setQuery(api.areas.get, { id }, { ...single, ...patch });
-  }
-
-  const bySlug = localStore.getQuery(api.areas.getBySlug, {
-    slug: options.areaSlug,
-  });
-  if (bySlug !== undefined && bySlug !== null) {
-    localStore.setQuery(
-      api.areas.getBySlug,
-      { slug: options.areaSlug },
-      {
-        ...bySlug,
-        ...patch,
-      },
-    );
-  }
+  patchQuery(localStore, api.areas.list, {}, (areas) =>
+    patchById(areas, id, patch),
+  );
+  patchQuery(localStore, api.areas.get, { id }, (area) => ({
+    ...area,
+    ...patch,
+  }));
+  patchQuery(
+    localStore,
+    api.areas.getBySlug,
+    { slug: options.areaSlug },
+    (area) => ({ ...area, ...patch }),
+  );
 }
 
 export function optimisticallyRemoveArea(
@@ -95,10 +87,9 @@ export function optimisticallyRemoveArea(
   args: { id: Id<"areas"> },
   options: { areaSlug: string },
 ): void {
-  const current = localStore.getQuery(api.areas.list, {});
-  if (current !== undefined) {
-    localStore.setQuery(api.areas.list, {}, removeById(current, args.id));
-  }
+  patchQuery(localStore, api.areas.list, {}, (areas) =>
+    removeById(areas, args.id),
+  );
   localStore.setQuery(api.areas.get, { id: args.id }, null);
   localStore.setQuery(api.areas.getBySlug, { slug: options.areaSlug }, null);
 }

--- a/apps/web/src/features/shared/optimistic.test.ts
+++ b/apps/web/src/features/shared/optimistic.test.ts
@@ -1,6 +1,17 @@
+import type { Doc, Id } from "@convex/_generated/dataModel";
+
+import { api } from "@convex/_generated/api";
 import { describe, expect, it } from "vitest";
 
-import { nextOrder, patchById, removeById } from "./optimistic";
+import { createLocalStore } from "@/test/optimistic-local-store";
+
+import {
+  nextOrder,
+  patchAllQueries,
+  patchById,
+  patchQuery,
+  removeById,
+} from "./optimistic";
 
 type TestRecord = {
   _id: string;
@@ -13,6 +24,20 @@ function makeRecord(overrides: Partial<TestRecord> = {}): TestRecord {
     _id: "record1",
     name: "Family Health",
     order: 0,
+    ...overrides,
+  };
+}
+
+function makeThread(overrides: Partial<Doc<"threads">> = {}): Doc<"threads"> {
+  return {
+    _id: "thread1" as Id<"threads">,
+    _creationTime: 0,
+    userId: "user1",
+    title: "Book checkup",
+    areaId: "area1" as Id<"areas">,
+    order: 0,
+    state: "open",
+    createdAt: 0,
     ...overrides,
   };
 }
@@ -41,5 +66,122 @@ describe("optimistic update helpers", () => {
 
   it("starts order at zero for an empty list", () => {
     expect(nextOrder([])).toBe(0);
+  });
+});
+
+describe("patchQuery", () => {
+  it("writes the patched value back to the query it read", () => {
+    const { store, get } = createLocalStore();
+    const thread = makeThread();
+    store.setQuery(api.threads.list, {}, [thread]);
+
+    patchQuery(store, api.threads.list, {}, (threads) =>
+      threads.map((current) => ({ ...current, title: "Book labs" })),
+    );
+
+    expect(get(api.threads.list, {})).toEqual([
+      { ...thread, title: "Book labs" },
+    ]);
+  });
+
+  it("leaves a query the client hasn't loaded alone", () => {
+    const { store, get } = createLocalStore();
+    let patched = false;
+
+    patchQuery(store, api.threads.list, {}, (threads) => {
+      patched = true;
+      return threads;
+    });
+
+    expect(patched).toBe(false);
+    expect(get(api.threads.list, {})).toBeUndefined();
+  });
+
+  it("leaves a missing document alone", () => {
+    const { store, get } = createLocalStore();
+    store.setQuery(api.threads.get, { id: "thread1" as Id<"threads"> }, null);
+
+    patchQuery(store, api.threads.get, { id: "thread1" as Id<"threads"> }, () =>
+      makeThread(),
+    );
+
+    expect(get(api.threads.get, { id: "thread1" })).toBeNull();
+  });
+
+  it("patches only the argument set it was given", () => {
+    const { store, get } = createLocalStore();
+    const area1 = "area1" as Id<"areas">;
+    const area2 = "area2" as Id<"areas">;
+    store.setQuery(api.threads.listByArea, { areaId: area1 }, []);
+    store.setQuery(api.threads.listByArea, { areaId: area2 }, []);
+
+    patchQuery(store, api.threads.listByArea, { areaId: area1 }, (threads) => [
+      ...threads,
+      makeThread({ areaId: area1 }),
+    ]);
+
+    expect(get(api.threads.listByArea, { areaId: area1 })).toHaveLength(1);
+    expect(get(api.threads.listByArea, { areaId: area2 })).toEqual([]);
+  });
+});
+
+describe("patchAllQueries", () => {
+  it("patches every cached argument set and passes each its arguments", () => {
+    const { store, get } = createLocalStore();
+    const area1 = "area1" as Id<"areas">;
+    const area2 = "area2" as Id<"areas">;
+    store.setQuery(api.threads.listByArea, { areaId: area1 }, [
+      makeThread({ _id: "thread1" as Id<"threads">, areaId: area1 }),
+    ]);
+    store.setQuery(api.threads.listByArea, { areaId: area2 }, [
+      makeThread({ _id: "thread2" as Id<"threads">, areaId: area2 }),
+    ]);
+
+    patchAllQueries(store, api.threads.listByArea, (threads, args) =>
+      threads.map((thread) => ({ ...thread, title: args.areaId })),
+    );
+
+    expect(get(api.threads.listByArea, { areaId: area1 })).toEqual([
+      makeThread({
+        _id: "thread1" as Id<"threads">,
+        areaId: area1,
+        title: area1,
+      }),
+    ]);
+    expect(get(api.threads.listByArea, { areaId: area2 })).toEqual([
+      makeThread({
+        _id: "thread2" as Id<"threads">,
+        areaId: area2,
+        title: area2,
+      }),
+    ]);
+  });
+
+  it("skips argument sets the client is still loading", () => {
+    const { store, get } = createLocalStore();
+    const area1 = "area1" as Id<"areas">;
+    const area2 = "area2" as Id<"areas">;
+    store.setQuery(api.threads.listByArea, { areaId: area1 }, []);
+    store.setQuery(api.threads.listByArea, { areaId: area2 }, undefined);
+
+    patchAllQueries(store, api.threads.listByArea, (threads) => [
+      ...threads,
+      makeThread(),
+    ]);
+
+    expect(get(api.threads.listByArea, { areaId: area1 })).toHaveLength(1);
+    expect(get(api.threads.listByArea, { areaId: area2 })).toBeUndefined();
+  });
+
+  it("does nothing when no argument set is cached", () => {
+    const { store } = createLocalStore();
+    let patched = false;
+
+    patchAllQueries(store, api.threads.listByArea, (threads) => {
+      patched = true;
+      return threads;
+    });
+
+    expect(patched).toBe(false);
   });
 });

--- a/apps/web/src/features/shared/optimistic.ts
+++ b/apps/web/src/features/shared/optimistic.ts
@@ -1,3 +1,47 @@
+import type { OptimisticLocalStore } from "convex/browser";
+import type {
+  FunctionArgs,
+  FunctionReference,
+  FunctionReturnType,
+} from "convex/server";
+
+type QueryValue<Query extends FunctionReference<"query">> = NonNullable<
+  FunctionReturnType<Query>
+>;
+
+/**
+ * Rewrite one cached query result. A query the client has no answer for yet —
+ * never loaded, or loaded as a missing document — is left alone: there is
+ * nothing to patch, and the server sends the real value soon enough.
+ */
+export function patchQuery<Query extends FunctionReference<"query">>(
+  localStore: OptimisticLocalStore,
+  query: Query,
+  args: FunctionArgs<Query>,
+  patch: (value: QueryValue<Query>) => FunctionReturnType<Query>,
+): void {
+  const value = localStore.getQuery(query, args);
+  if (value === undefined || value === null) return;
+
+  localStore.setQuery(query, args, patch(value));
+}
+
+/** `patchQuery` over every argument set the client holds for a query. */
+export function patchAllQueries<Query extends FunctionReference<"query">>(
+  localStore: OptimisticLocalStore,
+  query: Query,
+  patch: (
+    value: QueryValue<Query>,
+    args: FunctionArgs<Query>,
+  ) => FunctionReturnType<Query>,
+): void {
+  for (const { args, value } of localStore.getAllQueries(query)) {
+    if (value === undefined || value === null) continue;
+
+    localStore.setQuery(query, args, patch(value, args));
+  }
+}
+
 export function patchById<T extends { _id: string }>(
   tasks: T[],
   id: string,

--- a/apps/web/src/features/shared/optimistic.ts
+++ b/apps/web/src/features/shared/optimistic.ts
@@ -10,9 +10,14 @@ type QueryValue<Query extends FunctionReference<"query">> = NonNullable<
 >;
 
 /**
- * Rewrite one cached query result. A query the client has no answer for yet —
- * never loaded, or loaded as a missing document — is left alone: there is
- * nothing to patch, and the server sends the real value soon enough.
+ * Rewrite one cached query result. A query the client has no answer for is
+ * left alone: `undefined` covers one never loaded, one still in flight, and
+ * one whose last result was an error, and `null` covers a document that isn't
+ * there. In each case there is nothing to patch and the server settles it.
+ *
+ * `patch` must be total. Convex replays optimistic updates from its server
+ * ingest loop, which doesn't guard them, so a throw from here propagates out
+ * and stops every query update until the page is reloaded.
  */
 export function patchQuery<Query extends FunctionReference<"query">>(
   localStore: OptimisticLocalStore,

--- a/apps/web/src/features/tasks/inbox.ts
+++ b/apps/web/src/features/tasks/inbox.ts
@@ -45,6 +45,24 @@ export function removeTaskFromInbox<T extends Task>(
   return removeById(tasks, id);
 }
 
+/**
+ * Puts a Task back into the open Inbox list, at the position the server would
+ * give it: `tasks.list` reads the `by_user_inbox` index in descending order,
+ * so newest `createdAt` first, ties broken by `_creationTime`.
+ */
+export function insertTaskIntoInbox<T extends Task>(tasks: T[], task: T): T[] {
+  const index = tasks.findIndex((existing) => sortsBefore(task, existing));
+  if (index === -1) return [...tasks, task];
+
+  return [...tasks.slice(0, index), task, ...tasks.slice(index)];
+}
+
+function sortsBefore(task: Task, other: Task): boolean {
+  return task.createdAt === other.createdAt
+    ? task._creationTime > other._creationTime
+    : task.createdAt > other.createdAt;
+}
+
 export function updateTaskWhenInInbox<T extends Task>(
   tasks: T[],
   id: Id<"tasks">,

--- a/apps/web/src/features/tasks/optimistic.test.ts
+++ b/apps/web/src/features/tasks/optimistic.test.ts
@@ -7,6 +7,7 @@ import { createLocalStore } from "@/test/optimistic-local-store";
 
 import {
   isUnprocessedTask,
+  optimisticallyAddToOpenTasks,
   optimisticallyRemoveFromOpenTasks,
   optimisticallyReopenTask,
   patchOpenTasks,
@@ -125,6 +126,40 @@ describe("patchOpenTasks", () => {
   });
 });
 
+describe("optimisticallyAddToOpenTasks", () => {
+  it("adds the Task to tasks.list and derives tasks.count", () => {
+    const { store, get } = createLocalStore();
+    const existing = makeTask({ _id: "existing" as Id<"tasks">, createdAt: 1 });
+    store.setQuery(api.tasks.list, {}, [existing]);
+    store.setQuery(api.tasks.count, {}, 1);
+
+    const created = makeTask({ _id: "created" as Id<"tasks">, createdAt: 2 });
+    optimisticallyAddToOpenTasks(store, created);
+
+    expect(get(api.tasks.list, {})).toEqual([created, existing]);
+    expect(get(api.tasks.count, {})).toBe(2);
+  });
+
+  it("steps tasks.count up when only the count is cached", () => {
+    const { store, get } = createLocalStore();
+    store.setQuery(api.tasks.count, {}, 3);
+
+    optimisticallyAddToOpenTasks(store, makeTask());
+
+    expect(get(api.tasks.list, {})).toBeUndefined();
+    expect(get(api.tasks.count, {})).toBe(4);
+  });
+
+  it("is a no-op when neither cache has been populated yet", () => {
+    const { store, get } = createLocalStore();
+
+    optimisticallyAddToOpenTasks(store, makeTask());
+
+    expect(get(api.tasks.list, {})).toBeUndefined();
+    expect(get(api.tasks.count, {})).toBeUndefined();
+  });
+});
+
 describe("optimisticallyRemoveFromOpenTasks", () => {
   it("removes the Task from tasks.list and derives tasks.count", () => {
     const { store, get } = createLocalStore();
@@ -139,15 +174,28 @@ describe("optimisticallyRemoveFromOpenTasks", () => {
     expect(get(api.tasks.count, {})).toBe(1);
   });
 
-  it("never drops tasks.count below zero", () => {
+  it("re-derives a stale tasks.count instead of stepping it down", () => {
     const { store, get } = createLocalStore();
     const completing = makeTask({ _id: "completing" as Id<"tasks"> });
-    store.setQuery(api.tasks.list, {}, [completing]);
-    store.setQuery(api.tasks.count, {}, 0);
+    store.setQuery(api.tasks.list, {}, [
+      completing,
+      makeTask({ _id: "second" as Id<"tasks"> }),
+      makeTask({ _id: "third" as Id<"tasks"> }),
+    ]);
+    store.setQuery(api.tasks.count, {}, 5);
 
     optimisticallyRemoveFromOpenTasks(store, { id: completing._id });
 
-    expect(get(api.tasks.count, {})).toBe(0);
+    expect(get(api.tasks.count, {})).toBe(2);
+  });
+
+  it("leaves tasks.count alone when only the count is cached", () => {
+    const { store, get } = createLocalStore();
+    store.setQuery(api.tasks.count, {}, 3);
+
+    optimisticallyRemoveFromOpenTasks(store, { id: "task1" as Id<"tasks"> });
+
+    expect(get(api.tasks.count, {})).toBe(3);
   });
 
   it("leaves tasks.list alone when the Task isn't in the cached open list", () => {
@@ -269,10 +317,10 @@ describe("optimisticallyReopenTask", () => {
 
     optimisticallyRemoveFromOpenTasks(store, { id: first._id });
     optimisticallyRemoveFromOpenTasks(store, { id: second._id });
-    patchOpenTasks(store, (tasks) => [
+    optimisticallyAddToOpenTasks(
+      store,
       makeTask({ _id: "third" as Id<"tasks">, createdAt: 300 }),
-      ...tasks,
-    ]);
+    );
     optimisticallyReopenTask(store, { ...first, state: "done" });
 
     const list = get(api.tasks.list, {}) as Array<Doc<"tasks">>;

--- a/apps/web/src/features/tasks/optimistic.test.ts
+++ b/apps/web/src/features/tasks/optimistic.test.ts
@@ -1,13 +1,15 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
-import type { OptimisticLocalStore } from "convex/browser";
 
 import { api } from "@convex/_generated/api";
-import { getFunctionName } from "convex/server";
 import { describe, expect, it } from "vitest";
+
+import { createLocalStore } from "@/test/optimistic-local-store";
 
 import {
   isUnprocessedTask,
   optimisticallyRemoveFromOpenTasks,
+  optimisticallyReopenTask,
+  patchOpenTasks,
   removeTaskFromInbox,
   updateTaskTextInInbox,
   updateTaskWhenInInbox,
@@ -22,41 +24,6 @@ function makeTask(overrides: Partial<Doc<"tasks">> = {}): Doc<"tasks"> {
     state: "open",
     createdAt: 0,
     ...overrides,
-  };
-}
-
-function createLocalStore() {
-  const entries: Array<{
-    query: unknown;
-    args: unknown;
-    value: unknown;
-  }> = [];
-
-  const queryKey = (query: unknown) => getFunctionName(query as never);
-  const findEntry = (query: unknown, args: unknown) =>
-    entries.find(
-      (entry) =>
-        entry.query === queryKey(query) &&
-        JSON.stringify(entry.args) === JSON.stringify(args),
-    );
-
-  return {
-    store: {
-      getQuery(query: unknown, args: unknown) {
-        return findEntry(query, args)?.value;
-      },
-      setQuery(query: unknown, args: unknown, value: unknown) {
-        const entry = findEntry(query, args);
-        if (entry) {
-          entry.value = value;
-        } else {
-          entries.push({ query: queryKey(query), args, value });
-        }
-      },
-    } as OptimisticLocalStore,
-    get(query: unknown, args: unknown) {
-      return findEntry(query, args)?.value;
-    },
   };
 }
 
@@ -103,8 +70,63 @@ describe("Task optimistic updates", () => {
   });
 });
 
+describe("patchOpenTasks", () => {
+  it("derives tasks.count from the patched list", () => {
+    const { store, get } = createLocalStore();
+    const existing = makeTask({ _id: "existing" as Id<"tasks"> });
+    store.setQuery(api.tasks.list, {}, [existing]);
+    store.setQuery(api.tasks.count, {}, 1);
+
+    const created = makeTask({ _id: "created" as Id<"tasks">, createdAt: 10 });
+    patchOpenTasks(store, (tasks) => [created, ...tasks]);
+
+    expect(get(api.tasks.list, {})).toEqual([created, existing]);
+    expect(get(api.tasks.count, {})).toBe(2);
+  });
+
+  it("re-derives a stale tasks.count rather than stepping it", () => {
+    const { store, get } = createLocalStore();
+    store.setQuery(api.tasks.list, {}, [makeTask()]);
+    store.setQuery(api.tasks.count, {}, 7);
+
+    patchOpenTasks(store, (tasks) => tasks);
+
+    expect(get(api.tasks.count, {})).toBe(1);
+  });
+
+  it("leaves tasks.count alone when tasks.list isn't cached", () => {
+    const { store, get } = createLocalStore();
+    store.setQuery(api.tasks.count, {}, 3);
+
+    patchOpenTasks(store, (tasks) => [...tasks, makeTask()]);
+
+    expect(get(api.tasks.list, {})).toBeUndefined();
+    expect(get(api.tasks.count, {})).toBe(3);
+  });
+
+  it("patches tasks.list when tasks.count isn't cached", () => {
+    const { store, get } = createLocalStore();
+    const removing = makeTask({ _id: "removing" as Id<"tasks"> });
+    store.setQuery(api.tasks.list, {}, [removing]);
+
+    patchOpenTasks(store, (tasks) => removeTaskFromInbox(tasks, removing._id));
+
+    expect(get(api.tasks.list, {})).toEqual([]);
+    expect(get(api.tasks.count, {})).toBeUndefined();
+  });
+
+  it("is a no-op when neither cache has been populated yet", () => {
+    const { store, get } = createLocalStore();
+
+    patchOpenTasks(store, (tasks) => [...tasks, makeTask()]);
+
+    expect(get(api.tasks.list, {})).toBeUndefined();
+    expect(get(api.tasks.count, {})).toBeUndefined();
+  });
+});
+
 describe("optimisticallyRemoveFromOpenTasks", () => {
-  it("removes the Task from tasks.list and decrements tasks.count", () => {
+  it("removes the Task from tasks.list and derives tasks.count", () => {
     const { store, get } = createLocalStore();
     const completing = makeTask({ _id: "completing" as Id<"tasks"> });
     const keeping = makeTask({ _id: "keeping" as Id<"tasks"> });
@@ -128,21 +150,18 @@ describe("optimisticallyRemoveFromOpenTasks", () => {
     expect(get(api.tasks.count, {})).toBe(0);
   });
 
-  it("leaves tasks.count untouched when the Task isn't in the cached open list", () => {
+  it("leaves tasks.list alone when the Task isn't in the cached open list", () => {
     const { store, get } = createLocalStore();
-    store.setQuery(api.tasks.list, {}, [
-      makeTask({ _id: "other" as Id<"tasks"> }),
-    ]);
-    store.setQuery(api.tasks.count, {}, 3);
+    const other = makeTask({ _id: "other" as Id<"tasks"> });
+    store.setQuery(api.tasks.list, {}, [other]);
+    store.setQuery(api.tasks.count, {}, 1);
 
     optimisticallyRemoveFromOpenTasks(store, {
       id: "already-done" as Id<"tasks">,
     });
 
-    expect(get(api.tasks.list, {})).toEqual([
-      makeTask({ _id: "other" as Id<"tasks"> }),
-    ]);
-    expect(get(api.tasks.count, {})).toBe(3);
+    expect(get(api.tasks.list, {})).toEqual([other]);
+    expect(get(api.tasks.count, {})).toBe(1);
   });
 
   it("is a no-op when neither cache has been populated yet", () => {
@@ -155,5 +174,109 @@ describe("optimisticallyRemoveFromOpenTasks", () => {
     ).not.toThrow();
     expect(get(api.tasks.list, {})).toBeUndefined();
     expect(get(api.tasks.count, {})).toBeUndefined();
+  });
+});
+
+describe("optimisticallyReopenTask", () => {
+  it("reopens the Task into tasks.list in server order and derives the count", () => {
+    const { store, get } = createLocalStore();
+    const newer = makeTask({ _id: "newer" as Id<"tasks">, createdAt: 300 });
+    const older = makeTask({ _id: "older" as Id<"tasks">, createdAt: 100 });
+    store.setQuery(api.tasks.list, {}, [newer, older]);
+    store.setQuery(api.tasks.count, {}, 2);
+
+    const reopening = makeTask({
+      _id: "reopening" as Id<"tasks">,
+      state: "done",
+      completedAt: 500,
+      createdAt: 200,
+    });
+    optimisticallyReopenTask(store, reopening);
+
+    expect(get(api.tasks.list, {})).toEqual([
+      newer,
+      { ...reopening, state: "open", completedAt: undefined },
+      older,
+    ]);
+    expect(get(api.tasks.count, {})).toBe(3);
+  });
+
+  it("puts the oldest Task last and the newest first", () => {
+    const { store, get } = createLocalStore();
+    const middle = makeTask({ _id: "middle" as Id<"tasks">, createdAt: 200 });
+    store.setQuery(api.tasks.list, {}, [middle]);
+
+    optimisticallyReopenTask(
+      store,
+      makeTask({ _id: "oldest" as Id<"tasks">, createdAt: 100 }),
+    );
+    optimisticallyReopenTask(
+      store,
+      makeTask({ _id: "newest" as Id<"tasks">, createdAt: 300 }),
+    );
+
+    expect(
+      (get(api.tasks.list, {}) as Array<Doc<"tasks">>).map((task) => task._id),
+    ).toEqual(["newest", "middle", "oldest"]);
+  });
+
+  it("breaks createdAt ties on creation time", () => {
+    const { store, get } = createLocalStore();
+    const first = makeTask({
+      _id: "first" as Id<"tasks">,
+      createdAt: 100,
+      _creationTime: 1,
+    });
+    const third = makeTask({
+      _id: "third" as Id<"tasks">,
+      createdAt: 100,
+      _creationTime: 3,
+    });
+    store.setQuery(api.tasks.list, {}, [third, first]);
+
+    optimisticallyReopenTask(
+      store,
+      makeTask({
+        _id: "second" as Id<"tasks">,
+        createdAt: 100,
+        _creationTime: 2,
+      }),
+    );
+
+    expect(
+      (get(api.tasks.list, {}) as Array<Doc<"tasks">>).map((task) => task._id),
+    ).toEqual(["third", "second", "first"]);
+  });
+
+  it("leaves the caches alone when the Task is already open", () => {
+    const { store, get } = createLocalStore();
+    const task = makeTask();
+    store.setQuery(api.tasks.list, {}, [task]);
+    store.setQuery(api.tasks.count, {}, 1);
+
+    optimisticallyReopenTask(store, task);
+
+    expect(get(api.tasks.list, {})).toEqual([task]);
+    expect(get(api.tasks.count, {})).toBe(1);
+  });
+
+  it("keeps tasks.count in step through a run of Inbox actions", () => {
+    const { store, get } = createLocalStore();
+    const first = makeTask({ _id: "first" as Id<"tasks">, createdAt: 100 });
+    const second = makeTask({ _id: "second" as Id<"tasks">, createdAt: 200 });
+    store.setQuery(api.tasks.list, {}, [second, first]);
+    store.setQuery(api.tasks.count, {}, 2);
+
+    optimisticallyRemoveFromOpenTasks(store, { id: first._id });
+    optimisticallyRemoveFromOpenTasks(store, { id: second._id });
+    patchOpenTasks(store, (tasks) => [
+      makeTask({ _id: "third" as Id<"tasks">, createdAt: 300 }),
+      ...tasks,
+    ]);
+    optimisticallyReopenTask(store, { ...first, state: "done" });
+
+    const list = get(api.tasks.list, {}) as Array<Doc<"tasks">>;
+    expect(list.map((task) => task._id)).toEqual(["third", "first"]);
+    expect(get(api.tasks.count, {})).toBe(list.length);
   });
 });

--- a/apps/web/src/features/tasks/optimistic.ts
+++ b/apps/web/src/features/tasks/optimistic.ts
@@ -2,10 +2,12 @@ import type { Doc, Id } from "@convex/_generated/dataModel";
 import type { OptimisticLocalStore } from "convex/browser";
 
 import { api } from "@convex/_generated/api";
-import { isOpenTask } from "@convex/lib/attentionOrdering";
 
-import { patchById } from "@/features/shared/optimistic";
-import { removeTaskFromInbox } from "@/features/tasks/inbox";
+import { patchById, patchQuery } from "@/features/shared/optimistic";
+import {
+  insertTaskIntoInbox,
+  removeTaskFromInbox,
+} from "@/features/tasks/inbox";
 
 export {
   isUnprocessedTask,
@@ -24,30 +26,54 @@ export function updateTaskTextInInbox<T extends Task>(
 }
 
 /**
+ * Every optimistic change to the Open Tasks goes through here. `tasks.count`
+ * is the length of `tasks.list` on the server — the same index read two ways —
+ * so the count is derived from the patched list rather than counted up and
+ * down on its own. With no cached list there is nothing to derive from, and
+ * the count is left for the server to reconcile.
+ */
+export function patchOpenTasks(
+  localStore: OptimisticLocalStore,
+  patch: (tasks: Task[]) => Task[],
+): void {
+  const current = localStore.getQuery(api.tasks.list, {});
+  if (current === undefined) return;
+
+  const next = patch(current);
+  localStore.setQuery(api.tasks.list, {}, next);
+  patchQuery(localStore, api.tasks.count, {}, () => next.length);
+}
+
+/**
  * Shared cache update for taking a Task out of the open Inbox — completing
  * it and discarding it both do this the same way. `tasks.list` is Open Tasks
  * only, so either action removes the Task from that cache outright rather
- * than patching it in place. `tasks.count` (the Open Task count) drops by
- * one, but only once the Task has been read back from the still-populated
- * list — which is why that lookup happens before the list is patched below.
+ * than patching it in place.
  */
 export function optimisticallyRemoveFromOpenTasks(
   localStore: OptimisticLocalStore,
   args: { id: Id<"tasks"> },
 ): void {
-  const current = localStore.getQuery(api.tasks.list, {});
-  const task = current?.find((task) => task._id === args.id);
+  patchOpenTasks(localStore, (tasks) => removeTaskFromInbox(tasks, args.id));
+}
 
-  const count = localStore.getQuery(api.tasks.count, {});
-  if (count !== undefined && task !== undefined && isOpenTask(task)) {
-    localStore.setQuery(api.tasks.count, {}, Math.max(0, count - 1));
-  }
-
-  if (current !== undefined) {
-    localStore.setQuery(
-      api.tasks.list,
-      {},
-      removeTaskFromInbox(current, args.id),
-    );
-  }
+/**
+ * Reopening a Task moves it off the `tasks.listDone` page and back onto
+ * `tasks.list`, which is why the caller passes the whole document: a Done
+ * Task was never in the open list to reconstruct it from. The Done row itself
+ * waits for server reactivity — the paginated Done cache is left alone.
+ */
+export function optimisticallyReopenTask(
+  localStore: OptimisticLocalStore,
+  task: Task,
+): void {
+  patchOpenTasks(localStore, (tasks) =>
+    tasks.some((existing) => existing._id === task._id)
+      ? tasks
+      : insertTaskIntoInbox(tasks, {
+          ...task,
+          state: "open",
+          completedAt: undefined,
+        }),
+  );
 }

--- a/apps/web/src/features/tasks/optimistic.ts
+++ b/apps/web/src/features/tasks/optimistic.ts
@@ -26,11 +26,12 @@ export function updateTaskTextInInbox<T extends Task>(
 }
 
 /**
- * Every optimistic change to the Open Tasks goes through here. `tasks.count`
- * is the length of `tasks.list` on the server — the same index read two ways —
- * so the count is derived from the patched list rather than counted up and
- * down on its own. With no cached list there is nothing to derive from, and
- * the count is left for the server to reconcile.
+ * Membership changes to the Open Tasks go through here. `tasks.count` is the
+ * length of `tasks.list` on the server — the same index read two ways — so the
+ * count is derived from the patched list rather than counted up and down on
+ * its own. With no cached list there is nothing to derive from, and the count
+ * is left for the server to reconcile, except where the delta is knowable on
+ * its own (see `optimisticallyAddToOpenTasks`).
  */
 export function patchOpenTasks(
   localStore: OptimisticLocalStore,
@@ -42,6 +43,26 @@ export function patchOpenTasks(
   const next = patch(current);
   localStore.setQuery(api.tasks.list, {}, next);
   patchQuery(localStore, api.tasks.count, {}, () => next.length);
+}
+
+/**
+ * Creating a Task is the one membership change whose delta holds without the
+ * list: it adds exactly one Open Task. That matters because `tasks.count`
+ * feeds the app-wide Inbox badge while `tasks.list` is only loaded by the
+ * Inbox screen, so a Task created from anywhere else would otherwise leave the
+ * badge frozen until the round-trip lands. Removals get no such fallback —
+ * whether the Task was in the Open Tasks at all can't be known without them.
+ */
+export function optimisticallyAddToOpenTasks(
+  localStore: OptimisticLocalStore,
+  task: Task,
+): void {
+  if (localStore.getQuery(api.tasks.list, {}) === undefined) {
+    patchQuery(localStore, api.tasks.count, {}, (count) => count + 1);
+    return;
+  }
+
+  patchOpenTasks(localStore, (tasks) => [task, ...tasks]);
 }
 
 /**
@@ -60,8 +81,10 @@ export function optimisticallyRemoveFromOpenTasks(
 /**
  * Reopening a Task moves it off the `tasks.listDone` page and back onto
  * `tasks.list`, which is why the caller passes the whole document: a Done
- * Task was never in the open list to reconstruct it from. The Done row itself
- * waits for server reactivity — the paginated Done cache is left alone.
+ * Task was never in the open list to reconstruct it from. The paginated Done
+ * cache is deliberately left alone, so for one round-trip the Task renders in
+ * both places: back in the open list, and still under Completed until the
+ * server drops it from that page.
  */
 export function optimisticallyReopenTask(
   localStore: OptimisticLocalStore,

--- a/apps/web/src/features/tasks/task-row/use-task-row-actions.ts
+++ b/apps/web/src/features/tasks/task-row/use-task-row-actions.ts
@@ -22,7 +22,7 @@ export function useTaskRowActions(task: Doc<"tasks">) {
     useGuardedAsyncAction(
       async (intent: "complete" | "reopen") => {
         if (intent === "reopen") {
-          await uncompleteTask(task._id);
+          await uncompleteTask(task);
         } else {
           await completeTask(task._id);
         }

--- a/apps/web/src/features/tasks/use-create-task.ts
+++ b/apps/web/src/features/tasks/use-create-task.ts
@@ -3,7 +3,7 @@ import type { Id } from "@convex/_generated/dataModel";
 import { api } from "@convex/_generated/api";
 import { useMutation } from "convex/react";
 
-import { patchOpenTasks } from "./optimistic";
+import { optimisticallyAddToOpenTasks } from "./optimistic";
 
 export type CreateTaskValue = {
   text: string;
@@ -13,18 +13,17 @@ export type CreateTaskValue = {
 export function useCreateTask() {
   const createTask = useMutation(api.tasks.create).withOptimisticUpdate(
     (localStore, args) => {
-      patchOpenTasks(localStore, (tasks) => [
-        {
-          _id: crypto.randomUUID() as Id<"tasks">,
-          _creationTime: Date.now(),
-          userId: "",
-          text: args.text,
-          when: args.when,
-          state: "open",
-          createdAt: Date.now(),
-        },
-        ...tasks,
-      ]);
+      const now = Date.now();
+
+      optimisticallyAddToOpenTasks(localStore, {
+        _id: crypto.randomUUID() as Id<"tasks">,
+        _creationTime: now,
+        userId: "",
+        text: args.text,
+        when: args.when,
+        state: "open",
+        createdAt: now,
+      });
     },
   );
 

--- a/apps/web/src/features/tasks/use-create-task.ts
+++ b/apps/web/src/features/tasks/use-create-task.ts
@@ -3,6 +3,8 @@ import type { Id } from "@convex/_generated/dataModel";
 import { api } from "@convex/_generated/api";
 import { useMutation } from "convex/react";
 
+import { patchOpenTasks } from "./optimistic";
+
 export type CreateTaskValue = {
   text: string;
   when?: number;
@@ -11,26 +13,18 @@ export type CreateTaskValue = {
 export function useCreateTask() {
   const createTask = useMutation(api.tasks.create).withOptimisticUpdate(
     (localStore, args) => {
-      const current = localStore.getQuery(api.tasks.list, {});
-      if (current !== undefined) {
-        localStore.setQuery(api.tasks.list, {}, [
-          {
-            _id: crypto.randomUUID() as Id<"tasks">,
-            _creationTime: Date.now(),
-            userId: "",
-            text: args.text,
-            when: args.when,
-            state: "open",
-            createdAt: Date.now(),
-          },
-          ...current,
-        ]);
-      }
-
-      const count = localStore.getQuery(api.tasks.count, {});
-      if (count !== undefined) {
-        localStore.setQuery(api.tasks.count, {}, count + 1);
-      }
+      patchOpenTasks(localStore, (tasks) => [
+        {
+          _id: crypto.randomUUID() as Id<"tasks">,
+          _creationTime: Date.now(),
+          userId: "",
+          text: args.text,
+          when: args.when,
+          state: "open",
+          createdAt: Date.now(),
+        },
+        ...tasks,
+      ]);
     },
   );
 

--- a/apps/web/src/features/tasks/use-uncomplete-task.ts
+++ b/apps/web/src/features/tasks/use-uncomplete-task.ts
@@ -1,18 +1,15 @@
-import type { Id } from "@convex/_generated/dataModel";
+import type { Doc } from "@convex/_generated/dataModel";
 
 import { api } from "@convex/_generated/api";
 import { useMutation } from "convex/react";
 
-/**
- * Reopening a Task moves it from the `tasks.listDone` page back onto
- * `tasks.list`. Neither cache can be patched optimistically here: the Done
- * Task was never in `tasks.list` (Open Tasks only) to begin with, and
- * reconstructing its full doc to insert one would need a hook signature
- * change that's out of scope for now (see #254). Server reactivity moves
- * the Task between the two caches once the mutation lands.
- */
+import { optimisticallyReopenTask } from "./optimistic";
+
 export function useUncompleteTask() {
   const uncompleteTask = useMutation(api.tasks.markOpen);
 
-  return (id: Id<"tasks">) => uncompleteTask({ id });
+  return (task: Doc<"tasks">) =>
+    uncompleteTask.withOptimisticUpdate((localStore) =>
+      optimisticallyReopenTask(localStore, task),
+    )({ id: task._id });
 }

--- a/apps/web/src/features/tasks/use-update-task-text.ts
+++ b/apps/web/src/features/tasks/use-update-task-text.ts
@@ -3,19 +3,16 @@ import type { Id } from "@convex/_generated/dataModel";
 import { api } from "@convex/_generated/api";
 import { useMutation } from "convex/react";
 
+import { patchQuery } from "@/features/shared/optimistic";
+
 import { updateTaskTextInInbox } from "./optimistic";
 
 export function useUpdateTaskText() {
   const updateTaskText = useMutation(api.tasks.updateText).withOptimisticUpdate(
     (localStore, args) => {
-      const current = localStore.getQuery(api.tasks.list, {});
-      if (current !== undefined) {
-        localStore.setQuery(
-          api.tasks.list,
-          {},
-          updateTaskTextInInbox(current, args.id, args.text),
-        );
-      }
+      patchQuery(localStore, api.tasks.list, {}, (tasks) =>
+        updateTaskTextInInbox(tasks, args.id, args.text),
+      );
     },
   );
 

--- a/apps/web/src/features/tasks/use-update-task-when.ts
+++ b/apps/web/src/features/tasks/use-update-task-when.ts
@@ -3,19 +3,16 @@ import type { Id } from "@convex/_generated/dataModel";
 import { api } from "@convex/_generated/api";
 import { useMutation } from "convex/react";
 
+import { patchQuery } from "@/features/shared/optimistic";
+
 import { updateTaskWhenInInbox } from "./optimistic";
 
 export function useUpdateTaskWhen() {
   const updateTaskWhen = useMutation(api.tasks.updateWhen).withOptimisticUpdate(
     (localStore, args) => {
-      const current = localStore.getQuery(api.tasks.list, {});
-      if (current !== undefined) {
-        localStore.setQuery(
-          api.tasks.list,
-          {},
-          updateTaskWhenInInbox(current, args.id, args.when),
-        );
-      }
+      patchQuery(localStore, api.tasks.list, {}, (tasks) =>
+        updateTaskWhenInInbox(tasks, args.id, args.when),
+      );
     },
   );
 

--- a/apps/web/src/features/threads/optimistic.test.ts
+++ b/apps/web/src/features/threads/optimistic.test.ts
@@ -92,4 +92,67 @@ describe("Thread optimistic updates", () => {
       followUp: undefined,
     });
   });
+
+  it("moves a Thread between the two Area lists it belongs to", () => {
+    const area1 = "area1" as Id<"areas">;
+    const area2 = "area2" as Id<"areas">;
+    const thread = makeThread({ slug: "book-checkup", areaId: area1 });
+    const other = makeThread({
+      _id: "thread2" as Id<"threads">,
+      areaId: area2,
+    });
+    const localStore = createLocalStore();
+
+    localStore.set(api.threads.list, {}, [thread]);
+    localStore.set(api.threads.listByArea, { areaId: area1 }, [thread]);
+    localStore.set(api.threads.listByArea, { areaId: area2 }, [other]);
+    localStore.set(api.threads.getBySlug, { slug: "book-checkup" }, thread);
+
+    optimisticallyUpdateThread(
+      localStore.store,
+      { id: thread._id, areaId: area2 },
+      { threadSlug: "book-checkup" },
+    );
+
+    const moved = { ...thread, areaId: area2 };
+    expect(localStore.get(api.threads.listByArea, { areaId: area1 })).toEqual(
+      [],
+    );
+    expect(localStore.get(api.threads.listByArea, { areaId: area2 })).toEqual([
+      other,
+      moved,
+    ]);
+    expect(localStore.get(api.threads.list, {})).toEqual([moved]);
+    expect(
+      localStore.get(api.threads.getBySlug, { slug: "book-checkup" }),
+    ).toEqual(moved);
+  });
+
+  it("resolves a Thread out of its Area list without landing it in another", () => {
+    const area1 = "area1" as Id<"areas">;
+    const area2 = "area2" as Id<"areas">;
+    const thread = makeThread({ slug: "book-checkup", areaId: area1 });
+    const other = makeThread({
+      _id: "thread2" as Id<"threads">,
+      areaId: area2,
+    });
+    const localStore = createLocalStore();
+
+    localStore.set(api.threads.listByArea, { areaId: area1 }, [thread]);
+    localStore.set(api.threads.listByArea, { areaId: area2 }, [other]);
+    localStore.set(api.threads.getBySlug, { slug: "book-checkup" }, thread);
+
+    optimisticallyUpdateThread(
+      localStore.store,
+      { id: thread._id, state: "resolved" },
+      { threadSlug: "book-checkup" },
+    );
+
+    expect(localStore.get(api.threads.listByArea, { areaId: area1 })).toEqual(
+      [],
+    );
+    expect(localStore.get(api.threads.listByArea, { areaId: area2 })).toEqual([
+      other,
+    ]);
+  });
 });

--- a/apps/web/src/features/threads/optimistic.test.ts
+++ b/apps/web/src/features/threads/optimistic.test.ts
@@ -1,9 +1,9 @@
 import type { Doc, Id } from "@convex/_generated/dataModel";
-import type { OptimisticLocalStore } from "convex/browser";
 
 import { api } from "@convex/_generated/api";
-import { getFunctionName } from "convex/server";
 import { describe, expect, it } from "vitest";
+
+import { createLocalStore } from "@/test/optimistic-local-store";
 
 import {
   buildOptimisticThread,
@@ -22,44 +22,6 @@ function makeThread(overrides: Partial<Doc<"threads">> = {}): Doc<"threads"> {
     state: "open",
     createdAt: 0,
     ...overrides,
-  };
-}
-
-function createLocalStore() {
-  const entries: Array<{
-    query: unknown;
-    args: unknown;
-    value: unknown;
-  }> = [];
-
-  const queryKey = (query: unknown) => getFunctionName(query as never);
-  const findEntry = (query: unknown, args: unknown) =>
-    entries.find(
-      (entry) =>
-        entry.query === queryKey(query) &&
-        JSON.stringify(entry.args) === JSON.stringify(args),
-    );
-
-  return {
-    store: {
-      getQuery(query: unknown, args: unknown) {
-        return findEntry(query, args)?.value;
-      },
-      setQuery(query: unknown, args: unknown, value: unknown) {
-        const entry = findEntry(query, args);
-        if (entry) {
-          entry.value = value;
-        } else {
-          entries.push({ query: queryKey(query), args, value });
-        }
-      },
-    } as OptimisticLocalStore,
-    set(query: unknown, args: unknown, value: unknown) {
-      entries.push({ query: queryKey(query), args, value });
-    },
-    get(query: unknown, args: unknown) {
-      return findEntry(query, args)?.value;
-    },
   };
 }
 

--- a/apps/web/src/features/threads/optimistic.ts
+++ b/apps/web/src/features/threads/optimistic.ts
@@ -4,7 +4,12 @@ import type { OptimisticLocalStore } from "convex/browser";
 import { api } from "@convex/_generated/api";
 import { nullsToUndefined } from "@convex/lib/patch";
 
-import { nextOrder, patchById, removeById } from "@/features/shared/optimistic";
+import {
+  nextOrder,
+  patchById,
+  patchQuery,
+  removeById,
+} from "@/features/shared/optimistic";
 
 type Thread = Doc<"threads">;
 
@@ -52,15 +57,12 @@ export function optimisticallyCreateThreadInList(
   localStore: OptimisticLocalStore,
   args: CreateThreadArgs,
 ): void {
-  const current = localStore.getQuery(api.threads.list, {});
-  if (current === undefined) return;
-
-  localStore.setQuery(api.threads.list, {}, [
-    ...current,
+  patchQuery(localStore, api.threads.list, {}, (threads) => [
+    ...threads,
     buildOptimisticThread(args, {
       id: crypto.randomUUID() as Id<"threads">,
       now: Date.now(),
-      order: nextOrder(current),
+      order: nextOrder(threads),
     }),
   ]);
 }
@@ -70,19 +72,19 @@ export function optimisticallyCreateThreadInArea(
   args: CreateThreadArgs,
   options: { areaId: Id<"areas"> },
 ): void {
-  const current = localStore.getQuery(api.threads.listByArea, {
-    areaId: options.areaId,
-  });
-  if (current === undefined) return;
-
-  localStore.setQuery(api.threads.listByArea, { areaId: options.areaId }, [
-    ...current,
-    buildOptimisticThread(args, {
-      id: crypto.randomUUID() as Id<"threads">,
-      now: Date.now(),
-      order: nextOrder(current),
-    }),
-  ]);
+  patchQuery(
+    localStore,
+    api.threads.listByArea,
+    { areaId: options.areaId },
+    (threads) => [
+      ...threads,
+      buildOptimisticThread(args, {
+        id: crypto.randomUUID() as Id<"threads">,
+        now: Date.now(),
+        order: nextOrder(threads),
+      }),
+    ],
+  );
 }
 
 export function optimisticallyUpdateThread(
@@ -97,32 +99,27 @@ export function optimisticallyUpdateThread(
       ? { ...patch, nextMove: undefined, followUp: undefined }
       : patch;
 
-  const current = localStore.getQuery(api.threads.list, {});
-  if (current !== undefined) {
-    localStore.setQuery(
-      api.threads.list,
-      {},
-      threadPatch.state === "resolved"
-        ? removeById(current, id)
-        : patchById(current, id, threadPatch),
-    );
-  }
-
-  const single = localStore.getQuery(api.threads.get, { id });
-  if (single !== undefined && single !== null) {
-    localStore.setQuery(api.threads.get, { id }, { ...single, ...threadPatch });
-  }
-
   const bySlug = localStore.getQuery(api.threads.getBySlug, {
     slug: options.threadSlug,
   });
-  if (bySlug !== undefined && bySlug !== null) {
-    localStore.setQuery(
-      api.threads.getBySlug,
-      { slug: options.threadSlug },
-      { ...bySlug, ...threadPatch },
-    );
-  }
+
+  patchQuery(localStore, api.threads.list, {}, (threads) =>
+    threadPatch.state === "resolved"
+      ? removeById(threads, id)
+      : patchById(threads, id, threadPatch),
+  );
+
+  patchQuery(localStore, api.threads.get, { id }, (thread) => ({
+    ...thread,
+    ...threadPatch,
+  }));
+
+  patchQuery(
+    localStore,
+    api.threads.getBySlug,
+    { slug: options.threadSlug },
+    (thread) => ({ ...thread, ...threadPatch }),
+  );
 
   if (
     (threadPatch.areaId !== undefined || threadPatch.state === "resolved") &&
@@ -134,31 +131,23 @@ export function optimisticallyUpdateThread(
       previousAreaId !== threadPatch.areaId ||
       threadPatch.state === "resolved"
     ) {
-      const previousAreaThreads = localStore.getQuery(api.threads.listByArea, {
-        areaId: previousAreaId,
-      });
-      if (previousAreaThreads !== undefined) {
-        localStore.setQuery(
-          api.threads.listByArea,
-          { areaId: previousAreaId },
-          removeById(previousAreaThreads, id),
-        );
-      }
+      patchQuery(
+        localStore,
+        api.threads.listByArea,
+        { areaId: previousAreaId },
+        (threads) => removeById(threads, id),
+      );
 
       if (
         threadPatch.areaId !== undefined &&
         threadPatch.state !== "resolved"
       ) {
-        const nextAreaThreads = localStore.getQuery(api.threads.listByArea, {
-          areaId: threadPatch.areaId,
-        });
-        if (nextAreaThreads !== undefined) {
-          localStore.setQuery(
-            api.threads.listByArea,
-            { areaId: threadPatch.areaId },
-            [...nextAreaThreads, { ...bySlug, ...threadPatch }],
-          );
-        }
+        patchQuery(
+          localStore,
+          api.threads.listByArea,
+          { areaId: threadPatch.areaId },
+          (threads) => [...threads, { ...bySlug, ...threadPatch }],
+        );
       }
     }
   }
@@ -169,22 +158,17 @@ export function optimisticallyRemoveThread(
   args: { id: Id<"threads"> },
   options: { threadSlug?: string; areaId?: Id<"areas"> } = {},
 ): void {
-  const current = localStore.getQuery(api.threads.list, {});
-  if (current !== undefined) {
-    localStore.setQuery(api.threads.list, {}, removeById(current, args.id));
-  }
+  patchQuery(localStore, api.threads.list, {}, (threads) =>
+    removeById(threads, args.id),
+  );
 
   if (options.areaId !== undefined) {
-    const areaThreads = localStore.getQuery(api.threads.listByArea, {
-      areaId: options.areaId,
-    });
-    if (areaThreads !== undefined) {
-      localStore.setQuery(
-        api.threads.listByArea,
-        { areaId: options.areaId },
-        removeById(areaThreads, args.id),
-      );
-    }
+    patchQuery(
+      localStore,
+      api.threads.listByArea,
+      { areaId: options.areaId },
+      (threads) => removeById(threads, args.id),
+    );
   }
 
   localStore.setQuery(api.threads.get, { id: args.id }, null);
@@ -202,34 +186,18 @@ export function optimisticallyCompleteNextMove(
   args: { id: Id<"threads"> },
   options: { threadSlug: string },
 ): void {
-  const current = localStore.getQuery(api.threads.list, {});
-  if (current !== undefined) {
-    localStore.setQuery(
-      api.threads.list,
-      {},
-      current.map((thread) =>
-        thread._id === args.id ? completeNextMove(thread) : thread,
-      ),
-    );
-  }
+  patchQuery(localStore, api.threads.list, {}, (threads) =>
+    threads.map((thread) =>
+      thread._id === args.id ? completeNextMove(thread) : thread,
+    ),
+  );
 
-  const single = localStore.getQuery(api.threads.get, { id: args.id });
-  if (single !== undefined && single !== null) {
-    localStore.setQuery(
-      api.threads.get,
-      { id: args.id },
-      completeNextMove(single),
-    );
-  }
+  patchQuery(localStore, api.threads.get, { id: args.id }, completeNextMove);
 
-  const bySlug = localStore.getQuery(api.threads.getBySlug, {
-    slug: options.threadSlug,
-  });
-  if (bySlug !== undefined && bySlug !== null) {
-    localStore.setQuery(
-      api.threads.getBySlug,
-      { slug: options.threadSlug },
-      completeNextMove(bySlug),
-    );
-  }
+  patchQuery(
+    localStore,
+    api.threads.getBySlug,
+    { slug: options.threadSlug },
+    completeNextMove,
+  );
 }

--- a/apps/web/src/test/optimistic-local-store.ts
+++ b/apps/web/src/test/optimistic-local-store.ts
@@ -1,0 +1,51 @@
+import type { OptimisticLocalStore } from "convex/browser";
+
+import { getFunctionName } from "convex/server";
+
+/**
+ * A stand-in for the Convex client's optimistic query cache, so the update
+ * functions can be exercised as plain functions. Entries are keyed the way the
+ * client keys them: query name plus arguments.
+ */
+export function createLocalStore() {
+  const entries: Array<{
+    query: string;
+    args: unknown;
+    value: unknown;
+  }> = [];
+
+  const queryKey = (query: unknown) => getFunctionName(query as never);
+  const findEntry = (query: unknown, args: unknown) =>
+    entries.find(
+      (entry) =>
+        entry.query === queryKey(query) &&
+        JSON.stringify(entry.args) === JSON.stringify(args),
+    );
+
+  const set = (query: unknown, args: unknown, value: unknown) => {
+    const entry = findEntry(query, args);
+    if (entry) {
+      entry.value = value;
+    } else {
+      entries.push({ query: queryKey(query), args, value });
+    }
+  };
+
+  return {
+    store: {
+      getQuery(query: unknown, args: unknown) {
+        return findEntry(query, args)?.value;
+      },
+      getAllQueries(query: unknown) {
+        return entries
+          .filter((entry) => entry.query === queryKey(query))
+          .map((entry) => ({ args: entry.args, value: entry.value }));
+      },
+      setQuery: set,
+    } as OptimisticLocalStore,
+    set,
+    get(query: unknown, args: unknown) {
+      return findEntry(query, args)?.value;
+    },
+  };
+}


### PR DESCRIPTION
Part of #254 (first half — the frontend-only Task/store work; the Plan/Thread half lands with #251's query split, stacked on this branch). Scope per the [validation comment](https://github.com/rigomart/vita-os/issues/254#issuecomment-5260444997).

## What changed

### Shared combinators (`features/shared/optimistic.ts`)
- `patchQuery(localStore, query, args, patch)` — encapsulates read/guard/write: no-ops when the cached value is `undefined` (never loaded, in-flight, or last-result-was-an-error) or `null` (missing document), otherwise writes `patch(value)`.
- `patchAllQueries(localStore, query, patch)` — patches every cached argument set, passing each arg set to the callback. Unit-tested here; its production caller arrives with the #251 split (the current `plan/optimistic.ts` hand-rolled loop is deleted there, so it was deliberately not migrated).
- The three array helpers are unchanged.

### Open Task count derived from the list (`features/tasks/`)
- `patchOpenTasks` is the single door for membership changes: patch `tasks.list`, then set `tasks.count` to the patched list's length. All independent `+1`/`-1`/`Math.max(0, …)` arithmetic is gone. Since #273, `tasks.count === tasks.list.length` is an exact server identity.
- One deliberate asymmetry, caught in review: **creation** keeps an optimistic count bump even when the list is uncached (`optimisticallyAddToOpenTasks` falls back to `count + 1`), because creating adds exactly one Open Task regardless of the list, and `tasks.count` feeds the app-wide Inbox badge while `tasks.list` is only loaded by the Inbox screen — without the fallback, the global new-task shortcut left the badge frozen. **Removals** get no fallback: whether the Task was in the open set at all can't be known without the list.

### `useUncompleteTask` optimistic update restored
- PR #273 removed it and deferred here. The hook now takes the Done Task's document (`(task: Doc<"tasks">) => …`) and optimistically reinserts it as open, positioned to match the server's `by_user_inbox` order (`createdAt` desc, ties by `_creationTime` desc). The paginated Done cache is deliberately left alone, so the Task renders in both sections for one round-trip until the server drops it from the Done page.

### Migrations
- All hand-rolled read/guard/write sites in `features/tasks/*`, `features/areas/optimistic.ts`, and `features/threads/optimistic.ts` now go through `patchQuery`. Semantics-preserving: every migrated site previously carried the identical guard (the tombstone `setQuery(..., null)` writes were correctly left alone — that's the one place `null` is a value, not a skip).
- Not migrated on purpose: `features/dashboard/plan/optimistic.ts` and `use-plan-actions.ts` — both are rewritten/deleted by the #251 PR stacked on this one.

### Test infrastructure
- Shared fake `OptimisticLocalStore` (`src/test/optimistic-local-store.ts`) with a working `getAllQueries`, replacing two verbatim-duplicated fakes.
- New coverage: list/count consistency across complete, reopen, create, remove, and rapid sequences; all missing-cache cases; the cross-Area move branch of `optimisticallyUpdateThread` (mutation-tested — reading `getBySlug` after the patches instead of before fails the suite); combinator behavior including patch-all-argument-sets.

## Review notes

Two independent review passes (correctness + silent-failure) ran against the diff. Fixed from review: the create-path badge regression above, the missing cross-Area test, and one vacuous count assertion. Known transient accepted: the Plan canvas renders from `dashboard.overview.inbox`, a third Open-Tasks cache nothing here patches — creating a Task can briefly show the badge ahead of the canvas. The durable fix is #251's deletion of `dashboard.overview` (next PR); patching it here would be dead code within the stack.

## Verification

`bun run lint`, `bun run build`, `bun run test:run` — 56 files / 353 tests passing.
